### PR TITLE
delete error-causing space in bibtex .bib template

### DIFF
--- a/src/templates/common/encoding/article_bibtex.bib
+++ b/src/templates/common/encoding/article_bibtex.bib
@@ -1,6 +1,6 @@
 {% load settings %}
 {% load encoding %}
-{% if article.journal.is_conference %}@conference{% else %}@article{% endif %}{% templatetag openbrace %}{{ article.journal.code }} {{ article.id }},
+{% if article.journal.is_conference %}@conference{% else %}@article{% endif %}{% templatetag openbrace %}{{ article.journal.code }}{{ article.id }},
 	author = {{ article.author_list|latex_conform }},
 	title = {{ article.title|escape|latex_conform }},
 	volume = {{ article.issue.volume|latex_conform }},


### PR DESCRIPTION
Currently Janeway is producing bibtex .bib files that cannot be parsed by BibTeX or BibTeX database apps like BibDesk and Zotero. They are failing because the current template contains a space in what becomes the citekey. In BibTeX a citekey cannot spaces. So, when this outputs "journalID articleID" as the citekey, the parser treats "journalID" as the citekey and then breaks because it doesn't know what to do with "articleID" after the space. Removing this space should generate parsable citekeys.

Current example output: `@article{journalcode 4321, author = {Rosalind Franklin},` …

Proposed output: `@article{journalcode4321, author = {Rosalind Franklin},` …

Pull request deletes the space.