### PR TITLE
Get Lando environment working again

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,21 +1,18 @@
 ---
 name: janeway
-
 # CAREFUL with this env file, Docker env files don't support interpolation!
 env_file:
   - dockerfiles/lando_defaults.env
   - dockerfiles/lando_local.env
-
 services:
   appserver:
-    type: python:3.6
-    command: python /app/src/manage.py runserver 0.0.0.0:8000 -v 3
+    type: python:3.8
+    command: python3 /app/src/manage.py runserver 0.0.0.0:8000 -v 3
     build_as_root:
-      - grep '^deb ' /etc/apt/sources.list | perl -pe 's/deb /deb-src /' >> /etc/apt/sources.list
-      - apt-get update -qq && apt-get install -y python3-lxml pylint libxml2-dev libxslt1-dev python3-dev zlib1g-dev lib32z1-dev libffi-dev libssl-dev libjpeg-dev && apt-get build-dep -y lxml
+      - /app/dockerfiles/bin/fix-debian-sources.sh ; apt-get update -qq ; apt-get install -y libxml2-dev libxslt1-dev zlib1g-dev libffi-dev libssl-dev libjpeg-dev ; apt-get build-dep -y lxml ; [ -e /usr/local/bin/pip3 ] || apt-get install -y python3-pip
     build:
-      - cd /app && pip install --upgrade pip && pip install Cython && pip install psycopg2-binary~=2.8.0 && pip install -r requirements.txt &&  pip install -r dev-requirements.txt
-    scanner: true
+      - cd /app && python3 -m pip install --upgrade pip && pip3 install Cython && pip3 install -r requirements.txt && pip3 install -r dev-requirements.txt
+    scanner: false
     overrides:
       ports:
         - '8000:8000'
@@ -25,13 +22,12 @@ services:
     moreHttpPorts:
       - '8000'
   db:
-    type: postgres:10
+    type: postgres:14
     portforward: true
     creds:
       user: postgres
       password: 
       database: janeway
-
 tooling:
   python:
     service: appserver
@@ -39,7 +35,7 @@ tooling:
     dir: /app/src
   pip:
     service: appserver
-    description: run pip commands to manage Python package installation in this environment
+    description: run pip3 commands to manage Python package installation in this environment
     cmd: pip
     dir: /app/src
   manage:
@@ -49,7 +45,7 @@ tooling:
   restart-runserver:
     service: appserver
     description: Quickly restarts the Django runserver process, follows logs, and enables interactive debugging
-    cmd: killall python || python /app/src/manage.py runserver 0.0.0.0:8000 -v 3
+    cmd: killall python3 || python3 /app/src/manage.py runserver 0.0.0.0:8000 -v 3
     dir: /app/src
     user: root
   psql:

--- a/src/core/example_settings_for_lando.py
+++ b/src/core/example_settings_for_lando.py
@@ -1,0 +1,75 @@
+
+# SECURITY WARNING: keep the secret key used in production secret!
+# You should change this key before you go live!
+SECRET_KEY = 'uxprsdhk^gzd-r=_287byolxn)$k6tsd8_cepl^s^tms2w1qrv'
+
+# This is the default redirect if no other sites are found.
+DEFAULT_HOST = 'https://www.example.org'
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+LOGIN_REDIRECT_URL = '/user/profile/'
+
+INTERNAL_IPS = [
+    '127.0.0.1',
+    '192.168.65.2',
+    '192.168.65.1',
+]
+
+#%%% print (5+7)
+
+# CATCHA_TYPE should be either 'simple_math' or 'recaptcha' to enable captcha
+#fields, otherwise disabled
+CAPTCHA_TYPE = 'recaptcha'
+
+# If using recaptcha complete the following
+RECAPTCHA_PRIVATE_KEY = ''
+RECAPTCHA_PUBLIC_KEY = ''
+
+# If using hcaptcha complete the following:
+HCAPTCHA_SITEKEY = ''
+HCAPTCHA_SECRET = ''
+
+# ORCID Settings
+ENABLE_ORCID = True
+ORCID_API_URL = 'http://pub.orcid.org/v1.2_rc7/'
+ORCID_URL = 'https://orcid.org/oauth/authorize'
+ORCID_TOKEN_URL = 'https://pub.orcid.org/oauth/token'
+ORCID_CLIENT_SECRET = ''
+ORCID_CLIENT_ID = ''
+
+# Default Langague
+LANGUAGE_CODE = 'en'
+
+URL_CONFIG = 'path'  # path or domain
+
+DATABASES = {
+    'default': {
+        #Example ENGINEs:
+        #   sqlite:     'django.db.backends.sqlite
+        #   mysql:      'django.db.backends.mysql
+        #   postgres:   'django.db.backends.postgresql
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'janeway',
+        'USER': 'postgres',
+        'PASSWORD': '',
+        'HOST': 'db.janeway.internal',
+        'PORT': '5432',
+    }
+}
+
+
+# OIDC Settings
+ENABLE_OIDC = False
+OIDC_SERVICE_NAME = 'OIDC Service Name'
+OIDC_RP_CLIENT_ID = ''
+OIDC_RP_CLIENT_SECRET = ''
+OIDC_RP_SIGN_ALGO = 'RS256'
+OIDC_OP_AUTHORIZATION_ENDPOINT = ""
+OIDC_OP_TOKEN_ENDPOINT = ""
+OIDC_OP_USER_ENDPOINT = ""
+OIDC_OP_JWKS_ENDPOINT = ''
+
+
+ENABLE_FULL_TEXT_SEARCH = False # Read the docs before enabling full text
+
+# Model used for indexing full text files
+CORE_FILETEXT_MODEL = "core.FileText"  # Use "core.PGFileText" for Postgres


### PR DESCRIPTION
- use Python 3.8
- use python3 and pip3 throughout, some Debain images contain python 2 and 3
- add fix-debian-sources.sh script to handle an error message from apt when no deb-src lines are in the debian.sources config
- optionally install the python3-pip package if pip seems to be missing
- bump Postgres server version to 14
- add example_settings_for_lando.py