### PR TITLE
Drop unused libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
-beautifulsoup4==4.9.3
 boto==2.46.1
 bs4==0.0.1
-colorlog==3.1.4
-chardet==3.0.4
-crossrefapi==1.5.0
 Django==4.2.11
 django-bleach==3.0.1
 django-bootstrap4==23.2
@@ -27,16 +23,11 @@ djangorestframework==3.15.1
 Faker==17.6.0
 freezegun==1.2.0
 geoip2==4.8.0
-html2text==2017.10.4
 idna==2.7
-ipaddress==1.0.16
 more-itertools==10.1.0
 jsmin==3.0.1
-kitchen==1.2.4
-libsass==0.23.0
 lxml==4.9.2
 markdown
-maxminddb==2.5.1
 mock
 mozilla-django-oidc==4.0.1
 orcid==1.0.3
@@ -44,20 +35,8 @@ packaging==23.2
 pdfkit==1.0.0
 pdfminer.six
 psycopg2-binary~=2.9.8
-pyasn1==0.1.9
-pycparser==2.14
-PyJWT==2.4.0
-Pillow==10.2.0
-python-crontab==2.2.3
-python-dateutil==2.8.1
-python-docx==0.8.11
-python-magic==0.4.13
 requests==2.31.0
-six==1.14.0
-sqlparse==0.4.4
 swapper==1.3.0
 tqdm==4.65.0
-ua-parser==0.16.1
 # See #3736
 urllib3<2
-user-agents==2.2.0

--- a/src/api/oai/base.py
+++ b/src/api/oai/base.py
@@ -4,12 +4,11 @@ from urllib.parse import (
     urlencode,
     parse_qsl,
 )
-from datetime import datetime
 
 from dateutil import parser as date_parser
 from django.views.generic.list import BaseListView
 from django.views.generic.base import View, TemplateResponseMixin
-from django.utils.timezone import make_aware, utc
+from django.utils.timezone import utc
 
 from api.oai import exceptions
 from utils.http import allow_mutating_GET

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -1,6 +1,5 @@
 import collections
 import csv
-import io
 import json
 import re
 
@@ -9,7 +8,7 @@ from django.shortcuts import render
 from django.utils import timezone
 from django.db.models import Q
 
-from rest_framework import viewsets, generics
+from rest_framework import viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework import permissions
 

--- a/src/cms/forms.py
+++ b/src/cms/forms.py
@@ -5,7 +5,6 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
 
 from django import forms
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 
 from cms import logic, models

--- a/src/cms/logic.py
+++ b/src/cms/logic.py
@@ -18,7 +18,6 @@ from django.core.files.base import ContentFile
 
 from cms import models as models
 from journal import models as journal_models
-from press import models as press_models
 from repository import models as repository_models
 from utils import setting_handler
 from utils.function_cache import cache

--- a/src/cms/models.py
+++ b/src/cms/models.py
@@ -10,7 +10,6 @@ from django.db.models import Q
 from django.utils import timezone
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.conf import settings
 
 from core.file_system import JanewayFileSystemStorage
 from core.model_utils import JanewayBleachField

--- a/src/comms/forms.py
+++ b/src/comms/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 
-from django_summernote.widgets import SummernoteWidget
 
 from comms import models
 

--- a/src/copyediting/tests.py
+++ b/src/copyediting/tests.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 from django.shortcuts import reverse
-from django.utils import timezone
 
 from copyediting import models
 from utils.testing import helpers

--- a/src/copyediting/views.py
+++ b/src/copyediting/views.py
@@ -10,7 +10,6 @@ from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils import timezone
-from django.utils.translation import gettext as _
 
 from copyediting import models, logic, forms
 from core import (
@@ -21,10 +20,9 @@ from core import (
 )
 from events import logic as event_logic
 from security.decorators import (
-    production_user_or_editor_required, copyeditor_user_required,
+    copyeditor_user_required,
     copyeditor_for_copyedit_required, article_author_required,
-    editor_user_required, senior_editor_user_required,
-    any_editor_user_required
+    editor_user_required, any_editor_user_required
 )
 
 from submission import models as submission_models

--- a/src/core/forms/forms.py
+++ b/src/core/forms/forms.py
@@ -7,7 +7,6 @@ import uuid
 import json
 
 from django import forms
-from django.forms.fields import Field
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.forms import UserCreationForm
@@ -24,7 +23,6 @@ from utils.forms import (
     KeywordModelForm,
     JanewayTranslationModelForm,
     CaptchaForm,
-    HTMLDateInput,
 )
 from utils.logger import get_logger
 from submission import models as submission_models

--- a/src/core/homepage_elements/journals/hooks.py
+++ b/src/core/homepage_elements/journals/hooks.py
@@ -6,7 +6,6 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 import random
 
 from journal import models as journal_models
-from utils.function_cache import cache
 
 
 def get_random_journals():

--- a/src/core/homepage_elements/journals_and_html/plugin_settings.py
+++ b/src/core/homepage_elements/journals_and_html/plugin_settings.py
@@ -6,7 +6,6 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 from django.db.utils import OperationalError
 from django.contrib.contenttypes.models import ContentType
 
-from utils import models
 
 PLUGIN_NAME = 'Journals and HTML'
 DESCRIPTION = 'This plugin displays featured journals.'

--- a/src/core/homepage_elements/news/forms.py
+++ b/src/core/homepage_elements/news/forms.py
@@ -1,7 +1,6 @@
 from django import forms
 
 from utils import setting_handler
-from core.homepage_elements.popular import plugin_settings, logic
 
 
 class NewsForm(forms.Form):

--- a/src/core/homepage_elements/news/views.py
+++ b/src/core/homepage_elements/news/views.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 from django.shortcuts import redirect, render
 from django.contrib import messages
 
-from utils import setting_handler, models
 from security.decorators import editor_user_required
 from core.homepage_elements.news import forms
 

--- a/src/core/homepage_elements/search_bar/plugin_settings.py
+++ b/src/core/homepage_elements/search_bar/plugin_settings.py
@@ -2,7 +2,7 @@ from django.db.utils import OperationalError
 from django.db.utils import ProgrammingError
 from django.contrib.contenttypes.models import ContentType
 
-from utils import models, setting_handler
+from utils import models
 
 PLUGIN_NAME = 'Search Bar'
 SHORT_NAME = 'search_bar'

--- a/src/core/model_utils.py
+++ b/src/core/model_utils.py
@@ -17,7 +17,6 @@ from django.contrib.postgres.search import (
     SearchVector as DjangoSearchVector,
     SearchVectorField,
 )
-from django.core import validators
 from django.core.exceptions import ValidationError
 from django.db import(
     connection,
@@ -26,8 +25,8 @@ from django.db import(
     ProgrammingError,
     transaction,
 )
-from django.db.models import fields, Q, Manager
-from django.db.models.fields.related import ForeignObjectRel, ManyToManyField
+from django.db.models import Q, Manager
+from django.db.models.fields.related import ManyToManyField
 from django.db.models.functions import Coalesce, Greatest
 from django.core.validators import (
     FileExtensionValidator,
@@ -41,11 +40,9 @@ from django.http.request import split_domain_port
 from django.utils.functional import cached_property
 from django.utils import translation, timezone
 from django.conf import settings
-from django.db.models.query import QuerySet
 from django_bleach.models import BleachField
 
 from modeltranslation.manager import MultilingualManager, MultilingualQuerySet
-from modeltranslation.utils import auto_populate
 from PIL import Image
 import xml.etree.cElementTree as et
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -19,12 +19,11 @@ from django.core.exceptions import ValidationError
 from django.db import (
     connection,
     models,
-    transaction,
 )
 from django.utils import timezone
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.postgres.search import SearchVector, SearchVectorField
+from django.contrib.postgres.search import SearchVectorField
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils.translation import gettext_lazy as _
@@ -32,7 +31,6 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.template.defaultfilters import linebreaksbr
 import swapper
 
 from core import files, validators
@@ -43,7 +41,6 @@ from core.model_utils import (
     DynamicChoiceField,
     JanewayBleachField,
     PGCaseInsensitiveEmailField,
-    SearchLookup,
     default_press_id,
 )
 from review import models as review_models

--- a/src/core/templatetags/fqdn.py
+++ b/src/core/templatetags/fqdn.py
@@ -1,5 +1,5 @@
 from django import template
-from django.urls import reverse, NoReverseMatch
+from django.urls import reverse
 
 register = template.Library()
 

--- a/src/core/tests/test_files.py
+++ b/src/core/tests/test_files.py
@@ -1,10 +1,9 @@
 import os
-import shutil
 from tempfile import NamedTemporaryFile
 
 from django.urls import reverse
 from django.urls.base import clear_script_prefix
-from django.test import TestCase, Client, override_settings
+from django.test import TestCase, override_settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.conf import settings
 from django.utils import timezone

--- a/src/core/tests/test_logic.py
+++ b/src/core/tests/test_logic.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
 from core import logic
-from core.models import SettingGroup
 from utils.testing import helpers
 
 class TestLogic(TestCase):

--- a/src/core/tests/test_middleware.py
+++ b/src/core/tests/test_middleware.py
@@ -6,7 +6,6 @@ from django.shortcuts import redirect
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
-from django.core.management import call_command
 
 from core.middleware import (
     SiteSettingsMiddleware,

--- a/src/core/tests/test_validators.py
+++ b/src/core/tests/test_validators.py
@@ -1,7 +1,7 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.core.exceptions import ValidationError
-from core import models, validators
+from core import validators
 
 class TestValidators(TestCase):
 

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -6,7 +6,6 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
 from django.urls import include, re_path, path
 from django.contrib import admin
-from django.views.generic import TemplateView
 from django.conf import settings
 from django.views.static import serve
 
@@ -27,7 +26,6 @@ urlpatterns = [
 
 try:
     if settings.DEBUG or settings.IN_TEST_RUNNER:
-        import debug_toolbar
 
         urlpatterns += [
             re_path(r'^media/(?P<path>.*)$', serve, {'document_root': settings.MEDIA_ROOT}),

--- a/src/core/wsgi.py
+++ b/src/core/wsgi.py
@@ -10,10 +10,7 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
-import logging
 import os
-import sys
-import urllib.parse
 
 from utils import load_janeway_settings
 

--- a/src/cron/tests/test_commands.py
+++ b/src/cron/tests/test_commands.py
@@ -1,8 +1,7 @@
 from django.test import TestCase
 from django.core.management import call_command
 from utils.testing import helpers
-from cron.management.commands import send_reminders
-from cron import forms, models
+from cron import models
 from django.utils import timezone
 
 class SendRemindersCommandTests(TestCase):

--- a/src/cron/tests/test_models.py
+++ b/src/cron/tests/test_models.py
@@ -1,7 +1,5 @@
 from django.test import TestCase
-from django.core.management import call_command
 from utils.testing import helpers
-from cron import forms, models
 
 class ModelTests(TestCase):
     """

--- a/src/discussion/models.py
+++ b/src/discussion/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from django.utils import timezone
 

--- a/src/discussion/tests.py
+++ b/src/discussion/tests.py
@@ -1,3 +1,2 @@
-from django.test import TestCase
 
 # Create your tests here.

--- a/src/identifiers/admin.py
+++ b/src/identifiers/admin.py
@@ -6,7 +6,6 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 from django.contrib import admin
 from utils import admin_utils
 from identifiers import models
-from journal import models as journal_models
 
 
 class BrokenDOIAdmin(admin.ModelAdmin):

--- a/src/identifiers/forms.py
+++ b/src/identifiers/forms.py
@@ -1,4 +1,3 @@
-import re
 
 from django import forms
 

--- a/src/identifiers/logic.py
+++ b/src/identifiers/logic.py
@@ -9,17 +9,13 @@ from uuid import uuid4
 import requests
 from bs4 import BeautifulSoup
 import time
-import itertools
 
 from django.urls import reverse
 from django.template.loader import render_to_string
-from django.utils.http import urlencode
 from django.utils.html import strip_tags
 from django.conf import settings
 from django.contrib import messages
-from django.utils import timezone
 
-import sys
 from utils import models as util_models
 from utils.function_cache import cache
 from utils.logger import get_logger
@@ -27,7 +23,6 @@ from utils.shared import clear_cache
 from utils import setting_handler, render_template
 from crossref.restful import Depositor
 from identifiers import models
-from submission import models as submission_models
 
 logger = get_logger(__name__)
 

--- a/src/identifiers/management/commands/poll_crossref.py
+++ b/src/identifiers/management/commands/poll_crossref.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-from django.core.management import call_command
 from django.db.models import Q
 
 from identifiers import models

--- a/src/identifiers/models.py
+++ b/src/identifiers/models.py
@@ -11,12 +11,10 @@ import requests
 from django.db import models
 from django.dispatch import receiver
 from django.db.models.signals import post_save
-from django.core.exceptions import ObjectDoesNotExist
 
 from identifiers import logic
 from utils import shared
 from utils.logger import get_logger
-from utils import setting_handler
 from utils.function_cache import cache
 
 from django.conf import settings

--- a/src/identifiers/tests/test_logic.py
+++ b/src/identifiers/tests/test_logic.py
@@ -1,8 +1,5 @@
-import datetime
-from io import BytesIO, StringIO
-import json
+from io import BytesIO
 import mock
-import pytz
 import os
 
 
@@ -11,7 +8,6 @@ from django.conf import settings
 from django.utils import timezone
 
 from identifiers import logic, models
-from core.models import SettingGroup
 from journal import logic as journal_logic
 from submission import models as submission_models
 from utils.testing import helpers
@@ -19,7 +15,6 @@ from utils.setting_handler import save_setting
 from utils.shared import clear_cache
 from lxml import etree
 from bs4 import BeautifulSoup
-import requests
 class TestLogic(TestCase):
 
     @classmethod
@@ -416,7 +411,6 @@ class TestLogic(TestCase):
         mock_messages = mock.patch('journal.logic.messages').start()
         mock_messages.messages = mock.MagicMock()
         save_setting('Identifiers', 'register_issue_dois', self.journal_one, 'on')
-        from events import registration # Forces events to load into memory
         journal_logic.handle_assign_issue(self.request, self.article_one, issue)
         issue.refresh_from_db()
         self.assertTrue(issue.doi)
@@ -427,7 +421,6 @@ class TestLogic(TestCase):
         mock_messages = mock.patch('journal.logic.messages').start()
         mock_messages.messages = mock.MagicMock()
         save_setting('Identifiers', 'register_issue_dois', self.journal_one, '')
-        from events import registration # Forces events to load into memory
         journal_logic.handle_assign_issue(self.request, self.article_one, issue)
         issue.refresh_from_db()
         self.assertEqual(issue.doi, None)

--- a/src/identifiers/tests/test_models.py
+++ b/src/identifiers/tests/test_models.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 
 from identifiers import logic, models
 from utils.testing import helpers
-from utils.shared import clear_cache
 from uuid import uuid4
 
 

--- a/src/identifiers/views.py
+++ b/src/identifiers/views.py
@@ -17,12 +17,9 @@ from journal import models as journal_models
 from security.decorators import production_user_or_editor_required, editor_user_required
 from identifiers import logic
 
-import datetime
-from uuid import uuid4
 
 from django.urls import reverse
 from django.contrib import messages
-from django.utils import timezone
 
 
 from utils import models as util_models
@@ -135,7 +132,6 @@ def show_doi(request, article_id, identifier_id):
     :param identifier_id: Identifier object PK
     :return: HttpRedirect
     """
-    from utils import setting_handler
     article = get_object_or_404(
         submission_models.Article,
         pk=article_id,
@@ -168,7 +164,6 @@ def poll_doi(request, article_id, identifier_id):
     :param identifier_id: Identifier object PK
     :return: HttpRedirect
     """
-    from utils import setting_handler
     article = get_object_or_404(
         submission_models.Article,
         pk=article_id,
@@ -221,7 +216,6 @@ def poll_doi_output(request, article_id, identifier_id):
     :param identifier_id: Identifier object PK
     :return: HttpRedirect
     """
-    from utils import setting_handler
     article = get_object_or_404(
         submission_models.Article,
         pk=article_id,

--- a/src/journal/forms.py
+++ b/src/journal/forms.py
@@ -12,7 +12,7 @@ from django.utils.safestring import mark_safe
 from tinymce.widgets import TinyMCE
 
 from core import models as core_models
-from journal import models as journal_models, logic
+from journal import models as journal_models
 from utils.forms import CaptchaForm
 
 SEARCH_SORT_OPTIONS = [

--- a/src/journal/logic.py
+++ b/src/journal/logic.py
@@ -27,7 +27,6 @@ from django.utils.timezone import make_aware
 from core import models as core_models, files
 from journal import models as journal_models, issue_forms
 from journal.forms import SearchForm
-from submission import models as submission_models
 from identifiers import models as identifier_models
 from utils import render_template, notify_helpers
 from utils.logger import get_logger

--- a/src/journal/management/commands/galley_healthcheck.py
+++ b/src/journal/management/commands/galley_healthcheck.py
@@ -5,7 +5,6 @@ from django.core.management.base import BaseCommand
 
 from journal import models as journal_models
 from submission import models
-from core.templatetags.files import has_missing_supplements
 
 
 class Command(BaseCommand):

--- a/src/journal/tests/test_journal_frontend.py
+++ b/src/journal/tests/test_journal_frontend.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from django.urls.base import clear_script_prefix

--- a/src/journal/tests/test_models.py
+++ b/src/journal/tests/test_models.py
@@ -2,7 +2,6 @@ from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from core.middleware import SiteSettingsMiddleware
 from journal import models
 from journal.tests.utils import make_test_journal
 from press.models import Press

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -37,7 +37,7 @@ from core import (
 )
 from identifiers import models as id_models
 from journal import logic, models, issue_forms, forms, decorators
-from journal.logic import get_best_galley, get_galley_content
+from journal.logic import get_best_galley
 from metrics.logic import store_article_access
 from review import forms as review_forms, models as review_models
 from submission import encoding
@@ -2074,7 +2074,6 @@ def old_search(request):
 
     if redir:
         return redir
-    from itertools import chain
     if search_term:
         escaped = re.escape(search_term)
         # checks titles, keywords and subtitles first,

--- a/src/manage.py
+++ b/src/manage.py
@@ -3,7 +3,6 @@
 import os
 import sys
 
-from django.conf import settings
 
 from utils import load_janeway_settings
 

--- a/src/metrics/tests.py
+++ b/src/metrics/tests.py
@@ -2,9 +2,6 @@ import datetime
 import pytz
 
 from django.test import TestCase, override_settings
-from django.urls import reverse
-from django.utils import timezone
-from freezegun import freeze_time
 
 from metrics.models import ArticleAccess
 from utils import install

--- a/src/preprint/models.py
+++ b/src/preprint/models.py
@@ -3,7 +3,6 @@ __author__ = "Martin Paul Eve & Andy Byers"
 __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
-from django.db import models
 
 # AS OF 1.3.8 PREPRINTS HAS BEEN RENAMED REPOSITORY.
 # THIS DIRECTORY WILL BE REMOVED IN 1.3.9 ALONG WITH ALL OF THE

--- a/src/repository/forms.py
+++ b/src/repository/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
-from django.conf import settings
 from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.utils.text import slugify
 from django.contrib import messages

--- a/src/repository/logic.py
+++ b/src/repository/logic.py
@@ -1,6 +1,6 @@
 from dateutil.relativedelta import relativedelta
 from user_agents import parse as parse_ua_string
-from datetime import datetime, timedelta
+from datetime import timedelta
 from collections import Counter
 
 from django.utils import timezone
@@ -13,7 +13,6 @@ from django.db.models import (
     OuterRef,
     Subquery,
     Value,
-    Count,
 )
 from django.db.models.functions import Concat
 

--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -6,7 +6,6 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 import os
 import uuid
 import json
-from dateutil import parser as dateparser
 
 from django.db import models
 from django.db.models import Q
@@ -16,7 +15,6 @@ from django.utils.html import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.dispatch import receiver
 from django.shortcuts import reverse
-from django.http.request import split_domain_port
 from simple_history.models import HistoricalRecords
 
 from core.file_system import JanewayFileSystemStorage

--- a/src/repository/views.py
+++ b/src/repository/views.py
@@ -4,7 +4,6 @@ __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
 import operator
-from dateutil.relativedelta import relativedelta
 from datetime import datetime
 from dateutil import tz
 
@@ -29,7 +28,6 @@ from core import (
     models as core_models,
 )
 from journal import models as journal_models
-from submission import models as submission_models
 
 
 from utils import (

--- a/src/review/forms.py
+++ b/src/review/forms.py
@@ -14,7 +14,6 @@ from tinymce.widgets import TinyMCE
 
 from review import models, logic
 from core import models as core_models, forms as core_forms
-from core.widgets import JanewayFileInput
 from utils import setting_handler
 from utils.forms import FakeModelForm, HTMLDateInput, HTMLSwitchInput
 

--- a/src/review/hypothesis.py
+++ b/src/review/hypothesis.py
@@ -1,5 +1,4 @@
 import jwt
-import base64
 from datetime import timedelta, datetime
 import requests
 from requests.auth import HTTPBasicAuth

--- a/src/review/models.py
+++ b/src/review/models.py
@@ -5,7 +5,7 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
 from django.db import models
 from django.utils import timezone
-from django.db.models import Max, Q, Value
+from django.db.models import Max, Q
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext as _

--- a/src/review/tests.py
+++ b/src/review/tests.py
@@ -9,7 +9,6 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
-from django.conf import settings
 
 from core import models as core_models, files
 from journal import models as journal_models

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -4,7 +4,6 @@ __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
 
-from uuid import uuid4
 from collections import Counter
 from datetime import timedelta
 

--- a/src/security/test_security.py
+++ b/src/security/test_security.py
@@ -16,7 +16,7 @@ from django.urls import reverse
 from django.core.management import call_command
 from mock import Mock
 
-from core import models as core_models, forms as core_forms, logic as core_logic
+from core import models as core_models, forms as core_forms
 from journal import models as journal_models
 from production import models as production_models
 from security import decorators

--- a/src/submission/logic.py
+++ b/src/submission/logic.py
@@ -10,7 +10,7 @@ from bs4 import BeautifulSoup
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.contrib import messages
-from django.utils.translation import get_language, gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from core import files
 from core import models as core_models

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -54,10 +54,6 @@ from review import models as review_models
 from utils.function_cache import cache
 from utils.logger import get_logger
 from journal import models as journal_models
-from review.const import (
-    ReviewerDecisions as RD,
-    VisibilityOptions as VO,
-)
 
 logger = get_logger(__name__)
 

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -2,8 +2,6 @@ __copyright__ = "Copyright 2017 Birkbeck, University of London"
 __author__ = "Martin Paul Eve & Andy Byers"
 __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
-from datetime import datetime
-from dateutil import parser as dateparser
 from mock import Mock
 import os
 
@@ -18,7 +16,7 @@ from django.test.utils import override_settings
 
 import swapper
 
-from core.models import Account, File, Galley
+from core.models import Account, File
 from identifiers import logic as id_logic
 from journal import models as journal_models
 from submission import (
@@ -31,7 +29,7 @@ from submission import (
 from utils.install import update_xsl_files, update_settings, update_issue_types
 from utils.shared import clear_cache
 from utils.testing import helpers
-from utils.testing.helpers import create_galley, request_context
+from utils.testing.helpers import create_galley
 
 FROZEN_DATETIME_2020 = timezone.make_aware(timezone.datetime(2020, 1, 1, 0, 0, 0))
 FROZEN_DATETIME_1990 = timezone.make_aware(timezone.datetime(1990, 1, 1, 12, 0, 0))

--- a/src/submission/translation.py
+++ b/src/submission/translation.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 
 from modeltranslation.translator import register, TranslationOptions
 

--- a/src/transform/cassius/cassius-import/bin/cassius-import.py
+++ b/src/transform/cassius/cassius-import/bin/cassius-import.py
@@ -17,9 +17,6 @@ Options:
 
 
 import os
-from os import listdir
-from os.path import isfile, join
-import re
 from debug import Debug, Debuggable
 from docopt import docopt
 from interactive import Interactive

--- a/src/transform/cassius/cassius-import/bin/debug.py
+++ b/src/transform/cassius/cassius-import/bin/debug.py
@@ -4,7 +4,6 @@ __author__ = 'Martin Paul Eve'
 __email__ = "martin@martineve.com"
 
 import sys
-import os
 
 
 class Debug(object):

--- a/src/utils/logic.py
+++ b/src/utils/logic.py
@@ -2,7 +2,6 @@ import os
 import hashlib
 import hmac
 from urllib.parse import SplitResult, quote_plus, urlencode
-from tqdm import tqdm
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -12,7 +11,6 @@ from core.middleware import GlobalRequestMiddleware
 from cron.models import Request
 from utils import models, notify_helpers
 from utils.logger import get_logger
-from utils.function_cache import cache
 from janeway import __version__ as janeway_version
 from journal import models as journal_models
 from repository import models as repo_models

--- a/src/utils/management/commands/backup.py
+++ b/src/utils/management/commands/backup.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import boto
 from boto.s3.key import Key
-import subprocess
 from io import StringIO
 
 from django.core.management.base import BaseCommand

--- a/src/utils/management/commands/doi_check.py
+++ b/src/utils/management/commands/doi_check.py
@@ -7,7 +7,6 @@ from journal import models as journal_models
 from cron import models as cron_models
 from submission import models as submission_models
 from identifiers import models as ident_models
-from utils import setting_handler
 
 
 class Command(BaseCommand):

--- a/src/utils/management/commands/generate_search_indexes.py
+++ b/src/utils/management/commands/generate_search_indexes.py
@@ -1,6 +1,5 @@
 from django.db import connection
 from django.db.utils import OperationalError, ProgrammingError
-from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.conf import settings
 

--- a/src/utils/management/commands/generate_sitemaps.py
+++ b/src/utils/management/commands/generate_sitemaps.py
@@ -1,13 +1,10 @@
-import os
 from tqdm import tqdm
 
-from django.core.management.base import BaseCommand
 
 from utils import logic
 from utils.management.base import ProfiledCommand
 from journal import models as journal_models
 from repository import models as repository_models
-from press import models as press_models
 
 
 class Command(ProfiledCommand):

--- a/src/utils/management/commands/load_permissions.py
+++ b/src/utils/management/commands/load_permissions.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-from django.utils import translation
 
 from utils import install
 

--- a/src/utils/management/commands/scrape_up_collections.py
+++ b/src/utils/management/commands/scrape_up_collections.py
@@ -2,7 +2,6 @@ from django.core.management.base import BaseCommand
 
 from core.models import Account
 from journal.models import Journal
-from utils import importer
 from utils.importers import up
 
 

--- a/src/utils/management/commands/send_email.py
+++ b/src/utils/management/commands/send_email.py
@@ -1,6 +1,4 @@
-from django.contrib.auth.models import ContentType
 from django.core.management.base import BaseCommand
-from django.conf import settings
 
 import time
 import json

--- a/src/utils/management/commands/show_configured_journals.py
+++ b/src/utils/management/commands/show_configured_journals.py
@@ -1,6 +1,5 @@
 from django.core.management.base import BaseCommand
 
-from core.models import DomainAlias
 from journal import models as journal_models
 from press import models as press_models
 

--- a/src/utils/sessions/janeway_db.py
+++ b/src/utils/sessions/janeway_db.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 
 from django.contrib.sessions.backends import db
 from django.utils import timezone

--- a/src/utils/setting_handler.py
+++ b/src/utils/setting_handler.py
@@ -13,7 +13,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.utils import translation
 
 from core import models as core_models
-from utils import models
 from utils.logger import get_logger
 
 logger = get_logger(__name__)

--- a/src/utils/template_override_middleware.py
+++ b/src/utils/template_override_middleware.py
@@ -3,10 +3,7 @@ __author__ = "Martin Paul Eve & Andy Byers"
 __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
-import errno
-import io
 import os
-import warnings
 
 from django.conf import settings
 from django.template.loaders.filesystem import Loader as FileSystemLoader

--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -37,8 +37,7 @@ from review import models as review_models
 from submission import models as submission_models
 from core import (
     email as core_email,
-    models as core_models,
-    forms as core_forms
+    models as core_models
 )
 from copyediting import models as copyediting_models
 

--- a/src/utils/transactional_emails.py
+++ b/src/utils/transactional_emails.py
@@ -18,7 +18,6 @@ from core import (
     models as core_models,
 )
 from review import logic as review_logic
-from review.const import EditorialDecisions as ED
 
 
 def send_reviewer_withdrawl_notice(**kwargs):

--- a/src/workflow/admin.py
+++ b/src/workflow/admin.py
@@ -1,3 +1,2 @@
-from django.contrib import admin
 
 # Register your models here.


### PR DESCRIPTION
This is just some minor refactoring, so I didn't bother to open an issue just for that. I hope this is not a problem.
The CI does not show any regression (6 failures, 1 error - that happens with master as well).

I automatically dropped the unused imports with `ruff check src --select F401 --per-file-ignores '*/migrations/*.py:F401' --fix` and then detected the unused libraries with `deptry src --requirements-txt requirements.txt --requirements-files-dev dev-requirements.txt --json-output /dev/stdout 2>/dev/null | jq -r '.[] | select(.error.code == "DEP002") | .module' | grep -v ^django | grep -v ^psycopg`. I tried not to touch automatically generated code, like migrations.

It would be good to have a look to double-check, because:
- The CI could have missed some paths (if so, it would be nice to write such a missing test)
- I ignored the Django dependencies (should any of them be dropped?)
- There could be some corner case scenario, such as some dependencies might be optional and be there just to improve performances (it would be nice to add a comment on the side if that is the case)