### PR TITLE
Crossref deposit improvements

### DIFF
--- a/src/identifiers/logic.py
+++ b/src/identifiers/logic.py
@@ -339,7 +339,8 @@ def create_crossref_article_context(article, identifier=None):
         'date_accepted': article.date_accepted,
         'date_published': article.date_published,
         'license': article.license.url if article.license else '',
-        'pages': article.page_numbers,
+        'first_page': article.first_page,
+        'last_page': article.last_page,
         'scheduled': article.scheduled_for_publication,
     }
 

--- a/src/identifiers/logic.py
+++ b/src/identifiers/logic.py
@@ -341,6 +341,7 @@ def create_crossref_article_context(article, identifier=None):
         'license': article.license.url if article.license else '',
         'first_page': article.first_page,
         'last_page': article.last_page,
+        'other_pages': article.page_numbers,
         'scheduled': article.scheduled_for_publication,
     }
 

--- a/src/identifiers/tests/test_logic.py
+++ b/src/identifiers/tests/test_logic.py
@@ -62,7 +62,8 @@ class TestLogic(TestCase):
         cls.article_one.license = submission_models.Licence.objects.filter(
             journal=cls.journal_one,
         ).first()
-        cls.article_one.page_numbers = '1-72'
+        cls.article_one.first_page = 1
+        cls.article_one.last_page = 72
         cls.article_one.save()
 
         cls.issue_five_three.save()
@@ -120,7 +121,8 @@ class TestLogic(TestCase):
         cls.article_six.license = submission_models.Licence.objects.filter(
             journal=cls.journal_two,
         ).first()
-        cls.article_six.page_numbers = '58-62'
+        cls.article_six.first_page = 58
+        cls.article_six.last_page = 62
         cls.article_six.save()
 
         cls.article_seven = helpers.create_article(cls.journal_two, with_author=True)
@@ -241,7 +243,8 @@ class TestLogic(TestCase):
             'doi': f'10.0000/TST.{self.article_published.id}',
             'id': self.article_published.id,
             'license': '',
-            'pages': self.article_published.page_numbers,
+            'first_page': self.article_published.first_page,
+            'last_page': self.article_published.last_page,
             'scheduled': True,
         }
 
@@ -265,7 +268,8 @@ class TestLogic(TestCase):
             'license': submission_models.Licence.objects.filter(
                 journal=self.journal_one,
             ).first().url,
-            'pages': self.article_one.page_numbers,
+            'first_page': self.article_one.first_page,
+            'last_page': self.article_one.last_page,
             'scheduled': False,
         }
 

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -1158,6 +1158,13 @@ class Issue(AbstractLastModifiedModel):
                 self.update_display_title(save=False)
         super().save(*args, **kwargs)
 
+    @property
+    def publisher(self):
+        return (
+            self.journal.publisher
+            or self.journal.press.name
+        )
+
     def __str__(self):
         return (
             '{self.issue_type.pretty_name}: '

--- a/src/templates/common/identifiers/crossref_article.xml
+++ b/src/templates/common/identifiers/crossref_article.xml
@@ -49,6 +49,16 @@
                     <year>{{ article.date_accepted.year }}</year>
                 </acceptance_date>
                 {% endif %}
+                {% if first_page or last_page %}
+                    <pages>
+                        {% if first_page %}
+                            <first_page>{{ first_page }}</first_page>
+                        {% endif %}
+                        {% if last_page %}
+                            <last_page>{{ last_page }}</last_page>
+                        {% endif %}
+                    </pages>
+                {% endif %}
                 {% if article.license %}
                 <ai:program name="AccessIndicators">
                     <ai:license_ref>{{ article.license }}</ai:license_ref>

--- a/src/templates/common/identifiers/crossref_article.xml
+++ b/src/templates/common/identifiers/crossref_article.xml
@@ -49,13 +49,16 @@
                     <year>{{ article.date_accepted.year }}</year>
                 </acceptance_date>
                 {% endif %}
-                {% if first_page or last_page %}
+                {% if first_page or last_page or other_pages %}
                     <pages>
                         {% if first_page %}
                             <first_page>{{ first_page }}</first_page>
                         {% endif %}
                         {% if last_page %}
                             <last_page>{{ last_page }}</last_page>
+                        {% endif %}
+                        {% if other_pages %}
+                            <other_pages>{{ other_pages }}</other_pages>
                         {% endif %}
                     </pages>
                 {% endif %}

--- a/src/templates/common/identifiers/crossref_conference.xml
+++ b/src/templates/common/identifiers/crossref_conference.xml
@@ -4,17 +4,19 @@
                 {% if crossref_issue.issue.issue_title %}
                 <conference_name>{{ crossref_issue.issue.issue_title }}</conference_name>
                 {% else %}
-                <conference_name>{{ crossref_issue.journal.title }} - {{ crossref_issue.issue.year }}</conference_name>
+                <conference_name>{{ crossref_issue.journal.title }}</conference_name>
                 {% endif %}
             </event_metadata>
             <proceedings_metadata>
                 {% if crossref_issue.issue.issue_title %}
                 <proceedings_title>{{ crossref_issue.issue.issue_title }}</proceedings_title>
                 {% else %}
-                <proceedings_title>{{ crossref_issue.journal.title }} - {{ crossref_issue.issue.year }}</proceedings_title>
+                <proceedings_title>{{ crossref_issue.journal.title }}</proceedings_title>
                 {% endif %}
                 <publisher>
-                  <publisher_name>{{ crossref_issue.issue.journal.press.name }}</publisher_name>
+                    <publisher_name>
+                        {{ crossref_issue.issue.publisher }}
+                    </publisher_name>
                 </publisher>
                 <publication_date media_type="online">
                     <month>{{ crossref_issue.issue.date.month }}</month>


### PR DESCRIPTION
This completes 3 of 5 requests in #3131:

- map Janeway's first page and last page fields to Crossref
- output clean proceedings title
- respect custom publisher names set at journal level

Depending on if the reporter is happy with these fixes alone, closes #3131.