### PR TITLE
Fix migration order error

### DIFF
--- a/src/core/migrations/0095_auto_20240605_1024.py
+++ b/src/core/migrations/0095_auto_20240605_1024.py
@@ -29,7 +29,7 @@ def delete_notification_acceptance_setting(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('core', '0094_alter_account_preferred_timezone'),
+        ('core', '0095_merge_20240621_0722'),
     ]
 
     operations = [


### PR DESCRIPTION
There is a migration order mismatch on `master`

Same as #4316 with the correct commit