### PR TITLE
Updates logger output when extracting citations fails

### DIFF
--- a/src/identifiers/logic.py
+++ b/src/identifiers/logic.py
@@ -388,7 +388,7 @@ def extract_citations_for_crossref(article):
                     "</cyear", "</cYear"
                 )
         except Exception as e:
-            logger.error('Error transforming Crossref citations: %s' % e)
+            logger.info('Error transforming Crossref citations: %s' % e)
     else:
         logger.debug('No XML galleys found for crossref citation extraction')
 


### PR DESCRIPTION
Swapped `logger.error` to `logger.info` as its expected that this may fail and is not actually an error.

Closes #2190 