### PR TITLE
Splits back content archive into two views, removes query round trips to improve load time.

### DIFF
--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -19,7 +19,8 @@ from django.db.models import (
     Value,
     TextField,
     F,
-    ExpressionWrapper
+    ExpressionWrapper,
+    DateTimeField
 )
 from django.db.models.functions import Concat, Coalesce
 from django.db.models.signals import post_save, m2m_changed
@@ -676,7 +677,10 @@ class Journal(AbstractSiteModel):
                 ),
                 output_field=TextField()
             ),
-            date_archived=Subquery(date_archived_subquery)
+            date_archived=Subquery(
+                date_archived_subquery,
+                output_field=DateTimeField(),
+            )
         ).order_by(
             '-date_declined'
         )

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -45,7 +45,12 @@ from core.model_utils import (
 )
 from press import models as press_models
 from submission import models as submission_models
-from utils import setting_handler, logic, install, db_functions
+from utils import (
+    setting_handler,
+    logic,
+    install,
+    db_functions,
+)
 from utils.function_cache import cache, mutable_cached_property
 from utils.logger import get_logger
 from review import models as review_models
@@ -647,6 +652,11 @@ class Journal(AbstractSiteModel):
         return articles_with_identifiers
 
     def rejected_and_archived_articles(self):
+        date_archived_subquery = submission_models.ArticleStageLog.objects.filter(
+            article=OuterRef('pk'),
+            stage_to='Archived'
+        ).order_by('date_time').values('date_time')[:1]
+
         return submission_models.Article.objects.filter(
             journal=self,
             stage__in=[
@@ -665,7 +675,8 @@ class Journal(AbstractSiteModel):
                     ),
                 ),
                 output_field=TextField()
-            )
+            ),
+            date_archived=Subquery(date_archived_subquery)
         ).order_by(
             '-date_declined'
         )

--- a/src/journal/urls.py
+++ b/src/journal/urls.py
@@ -160,8 +160,16 @@ urlpatterns = [
         views.sort_issue_sections, name='manage_sort_issue_sections'),
 
     # Article Archive
-    re_path(r'^manage/archive/$',
-        views.manage_archive, name='manage_archive'),
+    re_path(
+        r'^manage/archive/$',
+        views.published_article_archive,
+        name='manage_archive',
+    ),
+    re_path(
+        r'^manage/archive/rejected-archived/$',
+        views.rejected_archived_article_archive,
+        name='manage_rejected_archived_archive',
+    ),
     re_path(r'^manage/archive/article/(?P<article_id>\d+)/$',
         views.manage_archive_article, name='manage_archive_article'),
 

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -1757,35 +1757,38 @@ def issue_article_order(request, issue_id=None):
 
 
 @editor_user_required
-def manage_archive(request):
+def published_article_archive(request):
     """
     Allows the editor to view information about an article that has been published already.
     :param request: request object
     :return: contextualised django template
     """
-    published_articles = submission_models.Article.objects.filter(
-        journal=request.journal,
-        stage=submission_models.STAGE_PUBLISHED
-    ).order_by(
-        '-date_published'
-    )
-    rejected_articles = submission_models.Article.objects.filter(
-        journal=request.journal,
-        stage__in=[
-            submission_models.STAGE_REJECTED,
-            submission_models.STAGE_ARCHIVED,
-        ],
-    ).order_by(
-        '-date_declined'
-    )
-
-    template = 'journal/manage/archive.html'
+    template = 'journal/manage/published_article_archive.html'
     context = {
-        'published_articles': published_articles,
-        'rejected_articles': rejected_articles,
+        'published_articles': request.journal.archive_published_articles(),
     }
 
-    return render(request, template, context)
+    return render(
+        request,
+        template,
+        context,
+    )
+
+
+@editor_user_required
+def rejected_archived_article_archive(request):
+    """
+    Allows an editor to view rejected and archived articles.
+    """
+    template = 'journal/manage/rejected_archived_article_archive.html'
+    context = {
+        'articles': request.journal.rejected_and_archived_articles(),
+    }
+    return render(
+        request,
+        template,
+        context,
+    )
 
 
 @editor_user_required

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1154,6 +1154,22 @@ class Article(AbstractLastModifiedModel):
         """Method replaces the funders m2m model for backwards compat."""
         return ArticleFunding.objects.filter(article=self)
 
+    @property
+    def date_archived(self):
+        # Return early if the article is not actually archived.
+        if self.stage != STAGE_ARCHIVED:
+            return None
+
+        log_entry = ArticleStageLog.objects.filter(
+            article=self,
+            stage_to='Archived',
+        ).first()
+
+        if log_entry:
+            return log_entry.date_time
+
+        return None
+
     def __str__(self):
         return u'%s - %s' % (self.pk, truncatesmart(self.title))
 

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1154,22 +1154,6 @@ class Article(AbstractLastModifiedModel):
         """Method replaces the funders m2m model for backwards compat."""
         return ArticleFunding.objects.filter(article=self)
 
-    @property
-    def date_archived(self):
-        # Return early if the article is not actually archived.
-        if self.stage != STAGE_ARCHIVED:
-            return None
-
-        log_entry = ArticleStageLog.objects.filter(
-            article=self,
-            stage_to='Archived',
-        ).first()
-
-        if log_entry:
-            return log_entry.date_time
-
-        return None
-
     def __str__(self):
         return u'%s - %s' % (self.pk, truncatesmart(self.title))
 

--- a/src/templates/admin/core/nav.html
+++ b/src/templates/admin/core/nav.html
@@ -102,7 +102,12 @@
             </li>
             <li>
                 <a href="{% url 'manage_archive' %}">
-                    <i class="fa fa-file">&nbsp;</i> Articles
+                    <i class="fa fa-file">&nbsp;</i> Published Articles
+                </a>
+            </li>
+            <li>
+                <a href="{% url 'manage_rejected_archived_archive' %}">
+                    <i class="fa fa-archive">&nbsp;</i> Rejected & Archived Articles
                 </a>
             </li>
             <li>

--- a/src/templates/admin/core/nav.html
+++ b/src/templates/admin/core/nav.html
@@ -107,7 +107,7 @@
             </li>
             <li>
                 <a href="{% url 'manage_rejected_archived_archive' %}">
-                    <i class="fa fa-archive">&nbsp;</i> Rejected & Archived Articles
+                    <i class="fa fa-archive">&nbsp;</i> Archived Articles
                 </a>
             </li>
             <li>

--- a/src/templates/admin/journal/manage/published_article_archive.html
+++ b/src/templates/admin/journal/manage/published_article_archive.html
@@ -14,7 +14,7 @@
 
 
 {% block body %}
-    <div class="large-6 columns">
+    <div class="large-12 columns">
         <div class="box">
             <div class="title-area">
                 <h2>Published Articles</h2>
@@ -27,6 +27,7 @@
                         <td>Title</td>
                         <td>Published</td>
                         <td>Identifier</td>
+                        <td>Authors</td>
                     </tr>
                     </thead>
 
@@ -36,38 +37,12 @@
                             <td>{{ article.pk }}</td>
                             <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a></td>
                             <td>{{ article.date_published }}</td>
-                            <td>{{ article.identifier }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-
-    <div class="large-6 columns">
-        <div class="box">
-            <div class="title-area">
-                <h2>Rejected & Archived Articles</h2>
-            </div>
-            <div class="content">
-                <table class="small article_list scroll">
-                    <thead>
-                    <tr>
-                        <td>ID</td>
-                        <td>Title</td>
-                        <td>Declined</td>
-                        <td>Identifier</td>
-                    </tr>
-                    </thead>
-
-                    <tbody>
-                    {% for article in rejected_articles %}
-                        <tr>
-                            <td>{{ article.pk }}</td>
-                            <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a></td>
-                            <td>{{ article.date_declined|default_if_none:"Archived" }}</td>
-                            <td>{{ article.identifier }}</td>
+                            <td>
+                              {{ article.preferred_identifier }}
+                            </td>
+                            <td>
+                              {{ article.frozen_authors }}
+                            </td>
                         </tr>
                     {% endfor %}
                     </tbody>

--- a/src/templates/admin/journal/manage/published_article_archive.html
+++ b/src/templates/admin/journal/manage/published_article_archive.html
@@ -9,7 +9,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    <li>Article Archive</li>
+    <li>Published Articles</li>
 {% endblock breadcrumbs %}
 
 

--- a/src/templates/admin/journal/manage/published_article_archive.html
+++ b/src/templates/admin/journal/manage/published_article_archive.html
@@ -4,8 +4,8 @@
 {% load static %}
 {% load foundation %}
 
-{% block title %}Article Archive{% endblock title %}
-{% block title-section %}Article Archive{% endblock %}
+{% block title %}Published Articles{% endblock title %}
+{% block title-section %}Published Articles{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -16,9 +16,6 @@
 {% block body %}
     <div class="large-12 columns">
         <div class="box">
-            <div class="title-area">
-                <h2>Published Articles</h2>
-            </div>
             <div class="content">
                 <table class="small article_list scroll">
                     <thead>

--- a/src/templates/admin/journal/manage/rejected_archived_article_archive.html
+++ b/src/templates/admin/journal/manage/rejected_archived_article_archive.html
@@ -26,6 +26,7 @@
                         <td>ID</td>
                         <td>Title</td>
                         <td>Rejected or Archived</td>
+                        <td>Date Rejected or Archived</td>
                         <td>Authors</td>
                     </tr>
                     </thead>
@@ -39,7 +40,14 @@
                               {% if article.stage == 'Archived' %}
                               Archived
                               {% else %}
-                              Rejected {{ article.date_declined|date:"Y-m-d" }}
+                              Rejected
+                              {% endif %}
+                            </td>
+                            <td>
+                              {% if article.stage == 'Archived' %}
+                              {{ article.date_archived|date:"Y-m-d" }}
+                              {% else %}
+                              {{ article.date_declined|date:"Y-m-d" }}
                               {% endif %}
                             </td>
                             <td>

--- a/src/templates/admin/journal/manage/rejected_archived_article_archive.html
+++ b/src/templates/admin/journal/manage/rejected_archived_article_archive.html
@@ -9,7 +9,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    <li>Rejected and Archived Article Archive</li>
+    <li>Rejected and Archived Articles</li>
 {% endblock breadcrumbs %}
 
 

--- a/src/templates/admin/journal/manage/rejected_archived_article_archive.html
+++ b/src/templates/admin/journal/manage/rejected_archived_article_archive.html
@@ -41,9 +41,13 @@
                             </td>
                             <td>
                               {% if article.stage == 'Archived' %}
-                              {{ article.date_archived|date:"Y-m-d" }}
+                                {% if article.date_archived %}
+                                  {{ article.date_archived|date:"Y-m-d" }}
+                                {% else %}
+                                  No archive date recorded
+                                {% endif %}
                               {% else %}
-                              {{ article.date_declined|date:"Y-m-d" }}
+                                {{ article.date_declined|date:"Y-m-d" }}
                               {% endif %}
                             </td>
                             <td>

--- a/src/templates/admin/journal/manage/rejected_archived_article_archive.html
+++ b/src/templates/admin/journal/manage/rejected_archived_article_archive.html
@@ -4,21 +4,17 @@
 {% load static %}
 {% load foundation %}
 
-{% block title %}Article Archive{% endblock title %}
-{% block title-section %}Article Archive{% endblock %}
+{% block title %}Rejected and Archived Articles{% endblock title %}
+{% block title-section %}Rejected and Archived Articles{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
     <li>Rejected and Archived Articles</li>
 {% endblock breadcrumbs %}
 
-
 {% block body %}
     <div class="large-12 columns">
         <div class="box">
-            <div class="title-area">
-                <h2>Rejected and Archived Articles</h2>
-            </div>
             <div class="content">
                 <table class="small article_list scroll">
                     <thead>

--- a/src/templates/admin/journal/manage/rejected_archived_article_archive.html
+++ b/src/templates/admin/journal/manage/rejected_archived_article_archive.html
@@ -1,0 +1,60 @@
+{% extends "admin/core/base.html" %}}
+{% load securitytags %}
+{% load files %}
+{% load static %}
+{% load foundation %}
+
+{% block title %}Article Archive{% endblock title %}
+{% block title-section %}Article Archive{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li>Rejected and Archived Article Archive</li>
+{% endblock breadcrumbs %}
+
+
+{% block body %}
+    <div class="large-12 columns">
+        <div class="box">
+            <div class="title-area">
+                <h2>Rejected and Archived Articles</h2>
+            </div>
+            <div class="content">
+                <table class="small article_list scroll">
+                    <thead>
+                    <tr>
+                        <td>ID</td>
+                        <td>Title</td>
+                        <td>Rejected or Archived</td>
+                        <td>Authors</td>
+                    </tr>
+                    </thead>
+
+                    <tbody>
+                    {% for article in articles %}
+                        <tr>
+                            <td>{{ article.pk }}</td>
+                            <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a></td>
+                            <td>
+                              {% if article.stage == 'Archived' %}
+                              Archived
+                              {% else %}
+                              Rejected {{ article.date_declined|date:"Y-m-d" }}
+                              {% endif %}
+                            </td>
+                            <td>
+                              {{ article.frozen_authors }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+{% endblock body %}
+
+{% block js %}
+{% include "elements/datatables.html" with target=".article_list" %}
+{% endblock %}

--- a/src/utils/db_functions.py
+++ b/src/utils/db_functions.py
@@ -1,0 +1,52 @@
+from django.db import connection
+from django.db.models import Aggregate, TextField
+
+
+class GroupConcat(Aggregate):
+    """
+    Custom db function to concatenate values from a queryset into a single
+    string.
+
+    Supports PostgresSQL, MSSQL, MySQL, MariaDB, and SQLite.
+    Note:
+        MariaDB does not have its own vendor string and is covered by MySQL
+
+    Usage:
+        articles_with_authors = Article.objects.annotate(
+            author_names=GroupConcat(
+                Concat(
+                    F('author__first_name'),
+                    Value(' '),
+                    F('author__last_name')
+                ),
+                separator='; '  # can be added to override default comma
+            )
+        )
+
+    Raises:
+        NotImplementedError: If the given database backend is not supported.
+    """
+
+    output_field = TextField()
+
+    def __init__(self, expression, separator=', ', distinct=False, **extra):
+        super().__init__(expression, distinct=distinct, **extra)
+        self.extra['separator'] = separator
+        self.vendor = connection.vendor
+
+        if self.vendor == 'postgresql':
+            self.function = 'STRING_AGG'
+            self.template = "%(function)s(%(distinct)s%(expressions)s, '%(separator)s')"
+        elif self.vendor == 'mysql':
+            self.function = 'GROUP_CONCAT'
+            self.template = "%(function)s(%(distinct)s%(expressions)s SEPARATOR '%(separator)s')"
+        elif self.vendor == 'sqlite':
+            self.function = 'GROUP_CONCAT'
+            self.template = "%(function)s(%(expressions)s, '%(separator)s')"
+        elif self.vendor == 'mssql':
+            self.function = 'STRING_AGG'
+            self.template = "%(function)s(%(expressions)s, '%(separator)s')"
+        else:
+            raise NotImplementedError(
+                f"{self.vendor} is not supported for GroupConcat"
+            )


### PR DESCRIPTION
This PR:

- Closes #4362 
- Closes #3952

This PR introduces a custom Aggregate function, GroupConcat, to concatenate query results into a single string with support for PostgreSQL, MySQL/MariaDB, SQLite, and MSSQL

This PR splits the archive page into two views. One for published articles and one for archived articles.

Additionally the use of subqueries massively reduces the number of database round trips and speeds the page up exponentially for installs with large numbers of published or archived articles.