### PR TITLE
Add event on submission start

### DIFF
--- a/src/events/logic.py
+++ b/src/events/logic.py
@@ -17,6 +17,10 @@ class Events:
     # list of event constants used internally by Janeway
 
     # kwargs: article, request
+    # raised when an article submission has started
+    ON_ARTICLE_SUBMISSION_START = 'on_article_submission_start'
+
+    # kwargs: article, request
     # raised when an article is submitted
     ON_ARTICLE_SUBMITTED = 'on_article_submitted'
 

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -70,6 +70,11 @@ def start(request, type=None):
             ).processed_value:
                 logic.add_user_as_author(request.user, new_article)
 
+            event_logic.Events.raise_event(
+                event_logic.Events.ON_ARTICLE_SUBMISSION_START,
+                **{'request': request, 'article': new_article}
+            )
+
             return redirect(reverse('submit_info', kwargs={'article_id': new_article.pk}))
 
     template = 'admin/submission/start.html'


### PR DESCRIPTION
Raising an event when submission start has completed allows to trigger actions before ON_ARTICLE_SUBMITTED