### PR TITLE
RFC: Use setting to get submit_info form

### DIFF
--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -6,6 +6,7 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 import re
 
 from django import forms
+from django.utils.module_loading import import_string
 from django.utils.translation import gettext, gettext_lazy as _
 
 from submission import models
@@ -20,6 +21,19 @@ from utils.forms import (
 from utils import setting_handler
 
 from tinymce.widgets import TinyMCE
+
+
+def get_submit_info_form(request):
+    if request.user.is_editor(request):
+        custom_form = setting_handler.get_setting(
+            "general", "submit_info_form_editor_version", request.journal
+        )
+    else:
+        custom_form = setting_handler.get_setting(
+            "general", "submit_info_form_general_version", request.journal
+        )
+    form_path = custom_form.processed_value
+    return import_string(form_path)
 
 
 class PublisherNoteForm(forms.ModelForm):

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -36,6 +36,15 @@ def get_submit_info_form(request):
     return import_string(form_path)
 
 
+
+def get_submit_info_edit_form(request):
+    custom_form = setting_handler.get_setting(
+        "general", "submit_info_form_general_version", request.journal
+    )
+    form_path = custom_form.processed_value
+    return import_string(form_path)
+
+
 class PublisherNoteForm(forms.ModelForm):
 
     class Meta:

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -730,7 +730,7 @@ def edit_metadata(request, article_id):
             article=article,
         )
 
-        info_form = forms.ArticleInfo(
+        info_form = forms.get_submit_info_edit_form(request)(
             instance=article,
             additional_fields=additional_fields,
             submission_summary=submission_summary,
@@ -764,7 +764,7 @@ def edit_metadata(request, article_id):
                     return redirect(reverse_url)
 
             if 'metadata' in request.POST:
-                info_form = forms.ArticleInfo(
+                info_form = forms.get_submit_info_edit_form(request)(
                     request.POST,
                     instance=article,
                     additional_fields=additional_fields,

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -185,10 +185,7 @@ def submit_info(request, article_id):
             request.journal,
         ).processed_value
 
-        # Determine the form to use depending on whether the user is an editor.
-        article_info_form = forms.ArticleInfoSubmit
-        if request.user.is_editor(request):
-            article_info_form = forms.EditorArticleInfoSubmit
+        article_info_form = forms.get_submit_info_form(request)
 
         form = article_info_form(
             instance=article,

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5117,5 +5117,43 @@
         "value": {
             "default": ""
         }
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "Dotted path of the form used during the submission phase for editors.",
+            "is_translatable": true,
+            "name": "submit_info_form_editor_version",
+            "pretty_name": "General Publication Editor info form",
+            "type": "char"
+        },
+        "value": {
+            "default": "submission.forms.EditorArticleInfoSubmit"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "Dotted path of the form used during the submission phase for authors.",
+            "is_translatable": true,
+            "name": "submit_info_form_general_version",
+            "pretty_name": "General Publication info form",
+            "type": "char"
+        },
+        "value": {
+            "default": "submission.forms.ArticleInfoSubmit"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
 ]

--- a/src/utils/install/submission_items.json
+++ b/src/utils/install/submission_items.json
@@ -43,5 +43,15 @@
     "group": "special",
     "name": "sections",
     "title": "sections"
+  },
+  {
+    "group": "general",
+    "name": "submit_info_form_editor_version",
+    "title": "submission.forms.EditorArticleInfoSubmit"
+  },
+  {
+    "group": "general",
+    "name": "submit_info_form_general_version",
+    "title": "submission.forms.ArticleInfoSubmit"
   }
 ]


### PR DESCRIPTION
I would like to be able to customize submission forms (and templates as a consequence) to modify the widgets and the behaviour of the form, without having to override the views or doing something tricky as that.

Replacing direct import of forms with import_string function + settings would make the overriding effortless, with any significant complexity in the janeway code and in a completely backward compatible code.

I attached an example about an implementation for ArticleInfoSubmit to get your feedback about the general idea