### PR TITLE
Reverts account and frozen author fields to charfields.

### DIFF
--- a/src/core/migrations/0096_alter_account_activation_code_and_more.py
+++ b/src/core/migrations/0096_alter_account_activation_code_and_more.py
@@ -19,32 +19,32 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='account',
             name='department',
-            field=core.model_utils.JanewayBleachCharField(blank=True, max_length=300, verbose_name='Department'),
+            field=models.CharField(blank=True, max_length=300, verbose_name='Department'),
         ),
         migrations.AlterField(
             model_name='account',
             name='first_name',
-            field=core.model_utils.JanewayBleachCharField(max_length=300, verbose_name='First name'),
+            field=models.CharField(max_length=300, verbose_name='First name'),
         ),
         migrations.AlterField(
             model_name='account',
             name='institution',
-            field=core.model_utils.JanewayBleachCharField(blank=True, max_length=1000, verbose_name='Institution'),
+            field=models.CharField(blank=True, max_length=1000, verbose_name='Institution'),
         ),
         migrations.AlterField(
             model_name='account',
             name='last_name',
-            field=core.model_utils.JanewayBleachCharField(max_length=300, verbose_name='Last name'),
+            field=models.CharField(max_length=300, verbose_name='Last name'),
         ),
         migrations.AlterField(
             model_name='account',
             name='middle_name',
-            field=core.model_utils.JanewayBleachCharField(blank=True, max_length=300, verbose_name='Middle name'),
+            field=models.CharField(blank=True, max_length=300, verbose_name='Middle name'),
         ),
         migrations.AlterField(
             model_name='account',
             name='salutation',
-            field=core.model_utils.JanewayBleachCharField(blank=True, choices=[('Miss', 'Miss'), ('Ms', 'Ms'), ('Mrs', 'Mrs'), ('Mr', 'Mr'), ('Mx', 'Mx'), ('Dr', 'Dr'), ('Prof.', 'Prof.')], max_length=10, verbose_name='Salutation'),
+            field=models.CharField(blank=True, choices=[('Miss', 'Miss'), ('Ms', 'Ms'), ('Mrs', 'Mrs'), ('Mr', 'Mr'), ('Mx', 'Mx'), ('Dr', 'Dr'), ('Prof.', 'Prof.')], max_length=10, verbose_name='Salutation'),
         ),
         migrations.AlterField(
             model_name='account',
@@ -54,6 +54,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='account',
             name='suffix',
-            field=core.model_utils.JanewayBleachCharField(blank=True, max_length=300, verbose_name='Name suffix'),
+            field=models.CharField(blank=True, max_length=300, verbose_name='Name suffix'),
         ),
     ]

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -235,30 +235,30 @@ class Account(AbstractBaseUser, PermissionsMixin):
     username = models.CharField(max_length=254, unique=True, verbose_name=_('Username'))
 
     name_prefix = models.CharField(max_length=10, blank=True)
-    first_name = JanewayBleachCharField(
+    first_name = models.CharField(
         max_length=300,
         blank=False,
         verbose_name=_('First name'),
     )
-    middle_name = JanewayBleachCharField(
+    middle_name = models.CharField(
         max_length=300,
         blank=True,
         verbose_name=_('Middle name'),
     )
-    last_name = JanewayBleachCharField(
+    last_name = models.CharField(
         max_length=300,
         blank=False,
         verbose_name=_('Last name'),
     )
 
     activation_code = models.CharField(max_length=100, null=True, blank=True)
-    salutation = JanewayBleachCharField(
+    salutation = models.CharField(
         max_length=10,
         choices=SALUTATION_CHOICES,
         blank=True,
         verbose_name=_('Salutation'),
     )
-    suffix = JanewayBleachCharField(
+    suffix = models.CharField(
         max_length=300,
         blank=True,
         verbose_name=_('Name suffix'),
@@ -268,12 +268,12 @@ class Account(AbstractBaseUser, PermissionsMixin):
         verbose_name=_('Biography'),
     )
     orcid = models.CharField(max_length=40, null=True, blank=True, verbose_name=_('ORCiD'))
-    institution = JanewayBleachCharField(
+    institution = models.CharField(
         max_length=1000,
         blank=True,
         verbose_name=_('Institution'),
     )
-    department = JanewayBleachCharField(
+    department = models.CharField(
         max_length=300,
         blank=True,
         verbose_name=_('Department'),

--- a/src/submission/migrations/0080_frozen_author_bleach_20240507_1350.py
+++ b/src/submission/migrations/0080_frozen_author_bleach_20240507_1350.py
@@ -15,12 +15,12 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='frozenauthor',
             name='department',
-            field=core.model_utils.JanewayBleachCharField(blank=True, max_length=300),
+            field=models.CharField(blank=True, max_length=300),
         ),
         migrations.AlterField(
             model_name='frozenauthor',
             name='first_name',
-            field=core.model_utils.JanewayBleachCharField(blank=True, max_length=300),
+            field=models.CharField(blank=True, max_length=300),
         ),
         migrations.AlterField(
             model_name='frozenauthor',
@@ -40,26 +40,26 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='frozenauthor',
             name='institution',
-            field=core.model_utils.JanewayBleachCharField(blank=True, max_length=1000),
+            field=models.CharField(blank=True, max_length=1000),
         ),
         migrations.AlterField(
             model_name='frozenauthor',
             name='last_name',
-            field=core.model_utils.JanewayBleachCharField(blank=True, max_length=300),
+            field=models.CharField(blank=True, max_length=300),
         ),
         migrations.AlterField(
             model_name='frozenauthor',
             name='middle_name',
-            field=core.model_utils.JanewayBleachCharField(blank=True, max_length=300),
+            field=models.CharField(blank=True, max_length=300),
         ),
         migrations.AlterField(
             model_name='frozenauthor',
             name='name_prefix',
-            field=core.model_utils.JanewayBleachCharField(blank=True, help_text='Optional name prefix (e.g: Prof or Dr)', max_length=300),
+            field=models.CharField(blank=True, help_text='Optional name prefix (e.g: Prof or Dr)', max_length=300),
         ),
         migrations.AlterField(
             model_name='frozenauthor',
             name='name_suffix',
-            field=core.model_utils.JanewayBleachCharField(blank=True, help_text='Optional name suffix (e.g.: Jr or III)', max_length=300),
+            field=models.CharField(blank=True, help_text='Optional name suffix (e.g.: Jr or III)', max_length=300),
         ),
     ]

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1911,23 +1911,23 @@ class FrozenAuthor(AbstractLastModifiedModel):
         on_delete=models.SET_NULL,
     )
 
-    name_prefix = JanewayBleachCharField(
+    name_prefix = models.CharField(
         max_length=300,
         blank=True,
         help_text=_("Optional name prefix (e.g: Prof or Dr)")
 
         )
-    name_suffix = JanewayBleachCharField(
+    name_suffix = models.CharField(
         max_length=300,
         blank=True,
         help_text=_("Optional name suffix (e.g.: Jr or III)")
     )
-    first_name = JanewayBleachCharField(max_length=300, blank=True)
-    middle_name = JanewayBleachCharField(max_length=300, blank=True)
-    last_name = JanewayBleachCharField(max_length=300, blank=True)
+    first_name = models.CharField(max_length=300, blank=True)
+    middle_name = models.CharField(max_length=300, blank=True)
+    last_name = models.CharField(max_length=300, blank=True)
 
-    institution = JanewayBleachCharField(max_length=1000, blank=True)
-    department = JanewayBleachCharField(max_length=300, blank=True)
+    institution = models.CharField(max_length=1000, blank=True)
+    department = models.CharField(max_length=300, blank=True)
     frozen_biography = JanewayBleachField(
         blank=True,
         verbose_name=_('Frozen Biography'),


### PR DESCRIPTION
This PR reverts changes to Account and FrozenAuthor models, returning them to CharFields. There were three reasons for this:

1. As reported in #4405 when form media is not present these fields display as text-areas (even in material, they just happened to be a single line)
2. We're not sure that down-stream indexers will accept these fields with HTML in them
3. Overwriting the widgets to be charfields doesn't work out of the box

- Closes #4405 