### PR TITLE
Fixes the copyright notice label.

### DIFF
--- a/src/templates/admin/submission/start.html
+++ b/src/templates/admin/submission/start.html
@@ -62,7 +62,7 @@
                         {{ journal_settings.general.copyright_notice|safe }}
                         <br />
                         {{ form.copyright_notice }}&nbsp;&nbsp;<label
-                            for="id_copyright_notice">{{ form.copyright_notice.label }}</label>
+                            for="id_copyright_notice">{{ form.copyright_notice.label|safe }}</label>
                     </div>
                 {% endif %}
 


### PR DESCRIPTION
This PR fixes the display of the copyright notice agreement label.

Before:
<img width="1031" alt="Screenshot 2024-09-13 at 11 07 12" src="https://github.com/user-attachments/assets/7f81d2be-48fa-4521-a08f-d828c68a04c9">

After:
<img width="661" alt="Screenshot 2024-09-13 at 11 07 16" src="https://github.com/user-attachments/assets/c37746de-b97e-4ccf-9f2c-af4c5fb4a1d3">
