### PR TITLE
Resolves a backwards incompatible changed introduced in ORCID login template

### DIFF
--- a/src/core/templatetags/orcid.py
+++ b/src/core/templatetags/orcid.py
@@ -6,7 +6,7 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def orcid_redirect_uri(context, action):
+def orcid_redirect_uri(context, action="login"):
     request = context.get('request')
     if request:
         return build_redirect_uri(request.site_type, action=action)


### PR DESCRIPTION
Small tweak in order to continue supporting login through custom themes, it is important to preserve the default behaviour.

Registration behaviour also changes, however due to the use of a new shared template, the impact is less severe/non-existing