### PR TITLE
Fixes a bug where submit_info would clear CI.

### DIFF
--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -33,8 +33,12 @@ class ArticleStart(forms.ModelForm):
 
     class Meta:
         model = models.Article
-        fields = ('publication_fees', 'submission_requirements', 'copyright_notice',
-                  'competing_interests')
+        fields = (
+            'publication_fees',
+            'submission_requirements',
+            'copyright_notice',
+            'competing_interests',
+        )
 
     def __init__(self, *args, **kwargs):
         journal = kwargs.pop('journal', False)
@@ -208,7 +212,6 @@ class ArticleInfo(KeywordModelForm, JanewayTranslationModelForm):
                     if editor_view:
                         self.fields[element.name].required = False
 
-
     def save(self, commit=True, request=None):
         article = super(ArticleInfo, self).save(commit=False)
 
@@ -238,6 +241,10 @@ class ArticleInfoSubmit(ArticleInfo):
     # Filter licenses and sections to publicly available only
     FILTER_PUBLIC_FIELDS = True
 
+    def __init__(self, *args, **kwargs):
+        super(ArticleInfoSubmit, self).__init__(*args, **kwargs)
+        self.fields.pop('competing_interests')
+
 
 class EditorArticleInfoSubmit(ArticleInfo):
     # Used when an editor is making a submission.
@@ -245,6 +252,7 @@ class EditorArticleInfoSubmit(ArticleInfo):
 
     def __init__(self, *args, **kwargs):
         super(EditorArticleInfoSubmit, self).__init__(*args, **kwargs)
+        self.fields.pop('competing_interests')
         if self.fields.get('section'):
             self.fields['section'].label_from_instance = lambda obj: obj.display_name_public_submission
             self.fields['section'].help_text = "As an editor you will see all " \

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -81,7 +81,7 @@ class ArticleInfo(KeywordModelForm, JanewayTranslationModelForm):
             'language', 'section', 'license', 'primary_issue',
             'article_number', 'is_remote', 'remote_url', 'peer_reviewed',
             'first_page', 'last_page', 'page_numbers', 'total_pages',
-            'competing_interests', 'custom_how_to_cite', 'rights',
+            'custom_how_to_cite', 'rights',
         )
         widgets = {
             'title': forms.TextInput(attrs={'placeholder': _('Title')}),
@@ -241,10 +241,6 @@ class ArticleInfoSubmit(ArticleInfo):
     # Filter licenses and sections to publicly available only
     FILTER_PUBLIC_FIELDS = True
 
-    def __init__(self, *args, **kwargs):
-        super(ArticleInfoSubmit, self).__init__(*args, **kwargs)
-        self.fields.pop('competing_interests')
-
 
 class EditorArticleInfoSubmit(ArticleInfo):
     # Used when an editor is making a submission.
@@ -252,12 +248,16 @@ class EditorArticleInfoSubmit(ArticleInfo):
 
     def __init__(self, *args, **kwargs):
         super(EditorArticleInfoSubmit, self).__init__(*args, **kwargs)
-        self.fields.pop('competing_interests')
         if self.fields.get('section'):
             self.fields['section'].label_from_instance = lambda obj: obj.display_name_public_submission
             self.fields['section'].help_text = "As an editor you will see all " \
                                                "sections even if they are  " \
                                                "closed for public submission"
+
+
+class EditArticleMetadata(ArticleInfo):
+    class Meta(ArticleInfo.Meta):
+        fields = ArticleInfo.Meta.fields + ('competing_interests',)
 
 
 class AuthorForm(forms.ModelForm):

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -906,3 +906,35 @@ class FrozenAuthorModelTest(TestCase):
 
     def test_full_name(self):
         self.assertEqual('Dr. S. Bella Rogers Esq.', self.frozen_author.full_name())
+
+
+from django.test import TestCase
+from .forms import EditArticleMetadata, ArticleInfoSubmit, \
+    EditorArticleInfoSubmit
+
+
+class ArticleFormTests(TestCase):
+
+    def test_competing_interests_in_edit_article_metadata(self):
+        form = EditArticleMetadata()
+        self.assertIn(
+            'competing_interests',
+            form.fields,
+            "'competing_interests' should be present in EditArticleMetadata",
+        )
+
+    def test_competing_interests_not_in_article_info_submit(self):
+        form = ArticleInfoSubmit()
+        self.assertNotIn(
+            'competing_interests',
+            form.fields,
+            "'competing_interests' should NOT be present in ArticleInfoSubmit",
+        )
+
+    def test_competing_interests_not_in_editor_article_info_submit(self):
+        form = EditorArticleInfoSubmit()
+        self.assertNotIn(
+            'competing_interests',
+            form.fields,
+            "'competing_interests' should NOT be present in EditorArticleInfoSubmit"
+        )

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -908,15 +908,10 @@ class FrozenAuthorModelTest(TestCase):
         self.assertEqual('Dr. S. Bella Rogers Esq.', self.frozen_author.full_name())
 
 
-from django.test import TestCase
-from .forms import EditArticleMetadata, ArticleInfoSubmit, \
-    EditorArticleInfoSubmit
-
-
 class ArticleFormTests(TestCase):
 
     def test_competing_interests_in_edit_article_metadata(self):
-        form = EditArticleMetadata()
+        form = forms.EditArticleMetadata()
         self.assertIn(
             'competing_interests',
             form.fields,
@@ -924,7 +919,7 @@ class ArticleFormTests(TestCase):
         )
 
     def test_competing_interests_not_in_article_info_submit(self):
-        form = ArticleInfoSubmit()
+        form = forms.ArticleInfoSubmit()
         self.assertNotIn(
             'competing_interests',
             form.fields,
@@ -932,7 +927,7 @@ class ArticleFormTests(TestCase):
         )
 
     def test_competing_interests_not_in_editor_article_info_submit(self):
-        form = EditorArticleInfoSubmit()
+        form = forms.EditorArticleInfoSubmit()
         self.assertNotIn(
             'competing_interests',
             form.fields,

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -75,7 +75,13 @@ def start(request, type=None):
                 **{'request': request, 'article': new_article}
             )
 
-            return redirect(reverse('submit_info', kwargs={'article_id': new_article.pk}))
+            return redirect(
+                reverse(
+                    'submit_info',
+                    kwargs={
+                        'article_id': new_article.pk},
+                ),
+            )
 
     template = 'admin/submission/start.html'
     context = {
@@ -697,7 +703,7 @@ def submit_review(request, article_id):
 
             return redirect(reverse('core_dashboard'))
 
-    template = "admin/submission//submit_review.html"
+    template = "admin/submission/submit_review.html"
     context = {
         'article': article,
         'form': form,

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -739,7 +739,7 @@ def edit_metadata(request, article_id):
             article=article,
         )
 
-        info_form = forms.ArticleInfo(
+        info_form = forms.EditArticleMetadata(
             instance=article,
             additional_fields=additional_fields,
             submission_summary=submission_summary,
@@ -773,7 +773,7 @@ def edit_metadata(request, article_id):
                     return redirect(reverse_url)
 
             if 'metadata' in request.POST:
-                info_form = forms.ArticleInfo(
+                info_form = forms.EditArticleMetadata(
                     request.POST,
                     instance=article,
                     additional_fields=additional_fields,

--- a/src/templates/admin/submission/submit_review.html
+++ b/src/templates/admin/submission/submit_review.html
@@ -85,6 +85,17 @@
                                 <td>{{ article.license.name }}</td>{% endif %}
                         </tr>
 
+                        {% if request.journal.submissionconfiguration.competing_interests %}
+                            <tr>
+                                <th colspan="3">Competing Interests</th>
+                            </tr>
+                            <tr>
+                                <td colspan="3">
+                                    {{ article.competing_interests|safe|default:"No competing interests declared" }}
+                                </td>
+                            </tr>
+                        {% endif %}
+
                         {% for field_answer in article.fieldanswer_set.all %}
                         <tr>
                             <th colspan="3">{{ field_answer.field.name }}</th>


### PR DESCRIPTION
Closes #4421

- Removes `competing_interests` from ArticleInfo base class
- Adds new child class `EditArticleMetadata` which inherits from `ArticleInfo`
- `EditArticleMetadata` adds `competing_interests` as one of its fields