### PR TITLE
Fix issue #4027.

### DIFF
--- a/src/press/migrations/0031_staffgroup_staffgroupmember.py
+++ b/src/press/migrations/0031_staffgroup_staffgroupmember.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('press', '0030_press_secondary_image_url'),
+        ('press', '0031_press_journal_footer_text'),
     ]
 
     operations = [


### PR DESCRIPTION
Ensure that column 'press_press.journal_footer_text' is created during the  clean install.