### PR TITLE
Request to display JATS notes as an ordered list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ src/media/profile_images/*
 
 # PyCharm
 .idea
+*.iml
 
 # vim
 *.swp

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -3873,6 +3873,15 @@
        </pre>
     </xsl:template>
 
+    <!-- Add support for email links in all contexts. -->
+    <xsl:template match="email">
+        <xsl:element name="a">
+            <xsl:attribute name="href"><xsl:value-of select="concat('mailto:',.)"/></xsl:attribute>
+            <xsl:attribute name="class"><xsl:value-of select="'email'"/></xsl:attribute>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
     <!-- END - general format -->
 
     <xsl:template match="sub-article//title-group | sub-article/front-stub | fn-group[@content-type='competing-interest']/fn/p | //history//*[@publication-type='journal']/article-title">

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -3790,7 +3790,18 @@
       </xsl:template>
 
       <xsl:template match="verse-line">
-        <xsl:apply-templates/>
+        <xsl:choose>
+            <xsl:when test="@style">
+                <!-- Provide support for the verse-line/@style attribute -->
+                <xsl:element name="span">
+                    <xsl:attribute name="style"><xsl:value-of select="@style"/></xsl:attribute>
+                    <xsl:apply-templates/>
+                </xsl:element>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates/>
+            </xsl:otherwise>
+        </xsl:choose>
       </xsl:template>
 
     <xsl:template match="title">


### PR DESCRIPTION
Currently, the following JATS markup
`<notes><title>Notes</title><fn-group><fn id="n1"><p>...</p></fn><fn id="n2"><p>...</p></fn>...</fn-group></notes>`

produces the following HTML output using the **fn-group/fn** template:

`<h2>Notes</h2><li xmlns:tei="http://www.tei-c.org/ns/1.0" id="n1">...</li><li xmlns:tei="http://www.tei-c.org/ns/1.0" id="n2"></li>...`

This request should modify the HTML output using a new template **back/notes/fn-group** to be the following and allow the notes to appear as an ordered list:

`<h2>Notes</h2><ol class="footnotes"><li xmlns:tei="http://www.tei-c.org/ns/1.0" id="n1">...</li><li xmlns:tei="http://www.tei-c.org/ns/1.0" id="n2">...</li>...</ol>`
