### PR TITLE
Let automatic registration of DOIs be optional.

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -429,7 +429,7 @@ def get_settings_to_edit(display_group, journal, user):
 
     elif display_group == 'crossref':
         xref_settings = [
-            'use_crossref', 'crossref_test', 'crossref_username', 'crossref_password', 'crossref_email',
+            'use_crossref', 'register_doi_at_acceptance', 'crossref_test', 'crossref_username', 'crossref_password', 'crossref_email',
             'crossref_name', 'crossref_prefix', 'crossref_registrant', 'doi_display_prefix', 'doi_display_suffix',
             'doi_pattern', 'doi_manager_action_maximum_size', 'title_doi', 'issue_doi_pattern', 'register_issue_dois'
         ]
@@ -452,7 +452,7 @@ def get_settings_to_edit(display_group, journal, user):
             'publisher_url', 'contact_info', 'privacy_policy_url', 'auto_signature',
             'slack_logging', 'slack_webhook', 'twitter_handle',
             'switch_language', 'enable_language_text', 'google_analytics_code',
-            'use_ga_four', 'display_login_page_notice', 'login_page_notice', 
+            'use_ga_four', 'display_login_page_notice', 'login_page_notice',
             'display_register_page_notice', 'register_page_notice',
             'support_email', 'support_contact_message_for_staff',
             'from_address', 'replyto_address',

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -331,6 +331,11 @@ class Journal(AbstractSiteModel):
     def use_crossref(self):
         return setting_handler.get_setting('Identifiers', 'use_crossref', self, default=True).processed_value
 
+    @property
+    @cache(120)
+    def register_doi_at_acceptance(self):
+        return setting_handler.get_setting('Identifiers', 'register_doi_at_acceptance', self, default=True).processed_value
+
     @issn.setter
     def issn(self, value):
         setting_handler.save_setting('general', 'journal_issn', self, value)

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1513,7 +1513,8 @@ class Article(AbstractLastModifiedModel):
 
         if self.journal.use_crossref:
             id = id_logic.generate_crossref_doi_with_pattern(self)
-            id.register()
+            if self.journal.register_doi_at_acceptance:
+                id.register()
 
     def decline_article(self):
         self.date_declined = timezone.now()

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -667,6 +667,25 @@
             "name": "Identifiers"
         },
         "setting": {
+            "description": "Whether or not to automatically register DOIs with Crossref at acceptance. If set to false, DOIs are generated at acceptance but should manually registered. Has no effect if `use_crossref` if off.",
+            "is_translatable": false,
+            "name": "register_doi_at_acceptance",
+            "pretty_name": "Register DOI at acceptance",
+            "type": "boolean"
+        },
+        "value": {
+            "default": "on"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "group": {
+            "name": "Identifiers"
+        },
+        "setting": {
             "description": "Whether or not to use Crossref's test server.",
             "is_translatable": false,
             "name": "crossref_test",
@@ -4706,7 +4725,7 @@
         "editable_by": [
             "journal-manager"
         ]
-    },  
+    },
     {
         "group": {
             "name": "general"


### PR DESCRIPTION
Add a setting to make the automatic registrations of DOIs at acceptance be optional, while still allowing the manual registration.

Rationale: ATM that the same setting `use_crossref` is used
- for automatic registration at acceptance [`Article.accept_article()`](https://github.com/openlibhums/janeway/blob/dcc8f7c25e1e66b8cfda89d18add2a08aa1412ee/src/submission/models.py#L1516) 
- for manual registration after publication [`identifiers.views.issue_doi()`](https://github.com/openlibhums/janeway/blob/dcc8f7c25e1e66b8cfda89d18add2a08aa1412ee/src/identifiers/views.py#L272)

so that it's not possible to disable automatic registration at acceptance while retaining the possibility of manual registration at publication (for instance).
