### PR TITLE
Ensures that file download headers have clean filenames

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1415,7 +1415,7 @@ class File(AbstractLastModifiedModel):
             file_name = "{code}-{pk}{surname}{extension}".format(
                 code=article.journal.code,
                 pk=article.pk,
-                surname=author_surname,
+                surname=author_surname.strip(),
                 extension=extension,
             )
             return file_name.lower()

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -39,6 +39,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.text import get_valid_filename, slugify
 import swapper
 
 from core import files, validators
@@ -1399,26 +1400,25 @@ class File(AbstractLastModifiedModel):
             extension = file_elements[-1]
 
             if article.frozen_authors():
-                author_surname = "-{0}".format(
-                    article.frozen_authors()[0].last_name,
-                )
+                last_name = article.frozen_authors()[0].last_name or ""
             elif article.correspondence_author:
-                author_surname = "-{0}".format(
-                    article.correspondence_author.last_name,
-                )
+                last_name = article.correspondence_author.last_name or ""
             else:
                 logger.warning(
                     "Article {pk} has no author records".format(pk=article.pk)
                 )
-                author_surname = ""
+                last_name = ""
+
+            surname_slug = slugify(last_name, allow_unicode=False)
+            surname = "-{0}".format(surname_slug) if surname_slug else ""
 
             file_name = "{code}-{pk}{surname}{extension}".format(
                 code=article.journal.code,
                 pk=article.pk,
-                surname=author_surname.strip(),
+                surname=surname,
                 extension=extension,
             )
-            return file_name.lower()
+            return get_valid_filename(file_name.lower())
         else:
             return self.original_filename
 

--- a/src/core/tests/test_models.py
+++ b/src/core/tests/test_models.py
@@ -1346,3 +1346,67 @@ class TestOrganizationManagers(TestCase):
             self.affiliation_historian.organization,
             models.Organization.objects.get(ror_id="035dkdb55"),
         )
+
+
+class TestFilePublicDownloadName(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.press = helpers.create_press()
+        cls.journal_one, _ = helpers.create_journals()
+        cls.owner = helpers.create_user("downloader@janeway.systems")
+        cls.article = helpers.create_submission(
+            owner=cls.owner,
+            journal_id=cls.journal_one.pk,
+        )
+        cls.frozen_author = submission_models.FrozenAuthor.objects.create(
+            article=cls.article,
+            last_name="Smith",
+            order=1,
+        )
+        cls.file_obj = models.File.objects.create(
+            article_id=cls.article.pk,
+            label="public",
+            original_filename="paper.pdf",
+            uuid_filename="uuid-paper.pdf",
+        )
+        cls.prefix = "{0}-{1}".format(
+            cls.journal_one.code.lower(),
+            cls.article.pk,
+        )
+
+    def test_surname_sanitisation(self):
+        cases = [
+            ("Smith", "-smith"),
+            ("Müller", "-muller"),
+            ("  Smith  ", "-smith"),
+            ("Smith/../Jones", "-smithjones"),
+            ("李", ""),
+        ]
+        for last_name, expected_segment in cases:
+            with self.subTest(last_name=last_name):
+                self.frozen_author.last_name = last_name
+                self.frozen_author.save()
+                self.assertEqual(
+                    self.file_obj.public_download_name(),
+                    "{0}{1}.pdf".format(self.prefix, expected_segment),
+                )
+
+    def test_no_author_records(self):
+        submission_models.FrozenAuthor.objects.filter(
+            article=self.article,
+        ).delete()
+        self.assertEqual(
+            self.file_obj.public_download_name(),
+            "{0}.pdf".format(self.prefix),
+        )
+
+    def test_no_article_returns_original_filename(self):
+        orphan = models.File.objects.create(
+            label="orphan",
+            original_filename="Weird Name.pdf",
+            uuid_filename="uuid-orphan.pdf",
+        )
+        self.assertEqual(
+            orphan.public_download_name(),
+            "Weird Name.pdf",
+        )


### PR DESCRIPTION
Closes #4440 

A PR to protect against importing of content with these characters is available: https://github.com/openlibhums/imports/issues/101