### PR TITLE
Fixes a bug that blocked editors from changing author metadata

### DIFF
--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -1,8 +1,6 @@
 {% extends "admin/core/base.html" %}}
 {% load foundation static bool_fa securitytags %}
 
-{% can_see_pii_tag article as can_see_pii %}
-
 {% block title %}Edit Metadata - {{ article.pk }}{% endblock title %}
 
 
@@ -18,6 +16,7 @@
 {% endblock %}
 
 {% block body %}
+    {% can_see_pii_tag article as can_see_pii %}
     <div class="large-12 columns box">
         <div class="row expanded">
             <form method="POST"{% if journal_settings.general.abstract_required %} novalidate{% endif %}>
@@ -157,7 +156,7 @@
                             <td>{{ f_author.institution|se_can_see_pii:article }}</td>
                             <td>{% if article.correspondence_author and f_author.author == article.correspondence_author %}
                                 <i class="fa fa-check"></i>{% else %}<i class="fa fa-times"></i>{% endif %}</td>
-                            <td>{% if can_see_pii_tag %}
+                            <td>{% if can_see_pii %}
                               <a href="?author={{ f_author.pk }}&return={{ return }}"><i
                                     class="fa fa-edit">&nbsp;</i>Edit</a>
                               {% else %}

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -280,7 +280,7 @@
             </div>
         </div>
     </div>
-    {% if can_see_pii_tag %}
+    {% if can_see_pii %}
     {% include "admin/elements/submission/edit_author.html" %}
     {% endif %}
 {% endblock body %}


### PR DESCRIPTION
This is an emergency patch for v1.7 to fix a bug in the pii tag setup.

- Moves `can_see_pii` variable into the content block
- Updates if variable type