### PR TITLE
Ensures that active reviews count is accurate

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -1133,13 +1133,9 @@ def role(request, slug):
                 filter=Q(user__reviewer__article__journal=request.journal),
             ),
             last_completed_review=Subquery(
-                review_models.ReviewAssignment.objects.filter(
-                    reviewer=OuterRef('user__pk'),
-                    date_accepted__isnull=False,
-                    date_complete__isnull=False,
+                review_models.ReviewAssignment.completed_reviews.filter(
                     article__journal=request.journal,
-                ).exclude(
-                    decision='withdrawn',
+                    reviewer=OuterRef('user__pk'),
                 ).order_by('-date_complete').values('date_complete')[:1]
             ),
             average_score=Subquery(

--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -22,6 +22,7 @@ from django.db.models import (
     When,
     BooleanField,
     Value,
+    Q,
 )
 from django.shortcuts import redirect, reverse
 from django.utils import timezone
@@ -49,7 +50,8 @@ def get_reviewers(article, candidate_queryset, exclude_pks):
         ).exclude(date_complete__isnull=True).order_by("-date_complete")
     )
     active_reviews_count = models.ReviewAssignment.objects.filter(
-        is_complete=False,
+        Q(date_complete__isnull=True) | Q(is_complete=True),
+        article__journal=article.journal,
         reviewer=OuterRef("id"),
     ).values(
         "reviewer_id",

--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -45,12 +45,8 @@ from submission import models as submission_models
 def get_reviewers(article, candidate_queryset, exclude_pks):
     prefetch_review_assignment = Prefetch(
         "reviewer",
-        queryset=models.ReviewAssignment.objects.filter(
+        queryset=models.ReviewAssignment.completed_reviews.filter(
             article__journal=article.journal,
-            date_accepted__isnull=False,
-            date_complete__isnull=False,
-        ).exclude(
-            decision="withdrawn",
         ).order_by("-date_complete"),
     )
 

--- a/src/review/models.py
+++ b/src/review/models.py
@@ -287,7 +287,7 @@ class ReviewAssignment(models.Model):
                 'date': '',
                 'reminder': None,
             }
-        elif self.date_complete:
+        elif self.date_complete and self.date_accepted:
             return {
                 'code': 'complete',
                 'display': 'Complete',
@@ -323,6 +323,8 @@ class ReviewAssignment(models.Model):
     def request_decision_status(self):
         if self.decision == RD.DECISION_WITHDRAWN.value:
             return f'Withdrawn {self.date_complete.date()}'
+        elif self.date_complete and self.date_accepted:
+            return f'Complete {self.date_complete.date()}'
         elif self.date_accepted:
             return f'Accepted {self.date_accepted.date()}'
         elif self.date_declined:

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -1546,8 +1546,6 @@ def withdraw_review(request, article_id, review_id):
     )
 
     if request.POST:
-
-
         skip = request.POST.get("skip")
         form = core_forms.SettingEmailForm(
             request.POST, request.FILES,
@@ -1555,8 +1553,6 @@ def withdraw_review(request, article_id, review_id):
             email_context=email_context,
             request=request,
         )
-
-
         if form.is_valid() or skip:
             review.date_complete = timezone.now()
             review.decision = models.RD.DECISION_WITHDRAWN.value

--- a/src/templates/admin/core/manager/users/history.html
+++ b/src/templates/admin/core/manager/users/history.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block title-section %}User History{% endblock %}
-{% block title-sub %}Displays history objects that the user was involved with{% endblock %}
+{% block title-sub %}Displaying workflow history for {{ user.full_name }}{% endblock %}
 
 {% block body %}
     <div class="box">
@@ -52,14 +52,16 @@
                             <th>Article</th>
                             <th>Assigned</th>
                             <th>Due</th>
-                            <th>Complete</th>
+                            <th>Status</th>
                         </tr>
                         {% for assignment in review_assignments %}
                             <tr>
                                 <td>{{ assignment.article.safe_title }}</td>
                                 <td>{{ assignment.date_requested }}</td>
-                                <td>{{ assignment.date_due }}</td>
-                                <td>{{ assignment.date_complete }}</td>
+                                <td>{{ assignment.date_due|date:"Y-m-d" }}</td>
+                                <td>
+                                  {{ assignment.request_decision_status }}
+                                </td>
                             </tr>
                         {% empty %}
                             <tr>

--- a/src/templates/admin/elements/review/add_reviewer_table_row.html
+++ b/src/templates/admin/elements/review/add_reviewer_table_row.html
@@ -7,3 +7,12 @@
 <td>{{ reviewer.reviewer.all.0.date_complete }}</td>
 <td>{% if reviewer.is_past_reviewer %}Yes{% else %}No{% endif %}</td>
 {% if journal_settings.general.enable_suggested_reviewers %}<td>{% if reviewer.is_suggested_reviewer %}Yes{% else %}No{% endif %}</td>{% endif %}
+<td>
+  <a
+      href="{% url 'core_user_history' reviewer.pk %}"
+      target="_blank"
+  >
+    View History
+    <span class="sr-only">(opens in new tab)</span>
+  </a>
+</td>

--- a/src/templates/admin/review/add_review_assignment.html
+++ b/src/templates/admin/review/add_review_assignment.html
@@ -57,6 +57,7 @@
                             <th>Last Review Completed</th>
                             <th>Has Reviewed Article</th>
                             {% if journal_settings.general.enable_suggested_reviewers %}<th>Suggested Reviewer</th>{% endif %}
+                            <th>History</th>
                         </tr>
                         </thead>
 


### PR DESCRIPTION
This PR adds a new completed reviews manager and tidies up the display of review information when assigning reviewers or looking a their histories.

Example:

![image](https://github.com/user-attachments/assets/e1147e67-6c55-450e-bead-dc3760a6e687)

Previously this user would have shown multiple active reviews and the review that was withdrawn would be the latest completed date/time.


Closes #4392 