### PR TITLE
Ensures that when an article and preprint are linked the preprint is only displayed if it is published.

### DIFF
--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -475,7 +475,7 @@
                         </div>
                         {% endfor %}
 
-                        {% if article.preprint %}
+                        {% if article.preprint and article.preprint.is_published %}
                         <div class="section hide-for-small-only">
                             <h3>{{ article.preprint.repository.object_name }}</h3>
                             <p>This article is linked to a {{ article.preprint.repository.object_name }} in {{ article.preprint.repository.name }}.</p>

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -330,6 +330,15 @@
                         </a>
                         <br/>
                     </div>
+                    {% if article.preprint and article.preprint.is_published %}
+                      <h2>{{ article.preprint.repository.object_name }}</h2>
+                      <p>This article is linked to
+                        a {{ article.preprint.repository.object_name }}
+                        in {{ article.preprint.repository.name }}.</p>
+                      <p>
+                        <a href="{{ article.preprint.url }}">{{ article.preprint.title }}</a>
+                      </p>
+                    {% endif %}
                     <h2>{% trans 'File Checksums' %}</h2> (MD5)
                     {% if galleys %}
                         <ul>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -472,6 +472,16 @@
                         </div>
                     {% endif %}
 
+                    {% if article.preprint and article.preprint.is_published %}
+                      <h4>{{ article.preprint.repository.object_name }}</h4>
+                      <p>This article is linked to
+                        a {{ article.preprint.repository.object_name }}
+                        in {{ article.preprint.repository.name }}.</p>
+                      <p>
+                        <a href="{{ article.preprint.url }}">{{ article.preprint.title }}</a>
+                      </p>
+                    {% endif %}
+
                     {% if article.is_published or proofing %}
                         <h4>
                             {% trans "File Checksums" %} (MD5)


### PR DESCRIPTION
- Adds a check to OLH template to ensure preprint is published
- Extends this feature to clean and material as it was not present there

Closes #3996 

**Note**: I'm aware that this PR contains bad use of header tags but they follow the current pattern and will be fixed as detailed in site structure issues.