### PR TITLE
contact forms validate on server not browser

### DIFF
--- a/src/templates/admin/journal/contact.html
+++ b/src/templates/admin/journal/contact.html
@@ -30,7 +30,7 @@
                 </div>
                 <div class="large-8 columns">
                     <h3>{% trans "Contact" %}</h3>
-                    <form method="POST">
+                    <form method="POST" novalidate>
                         {% include "elements/forms/errors.html" with form=contact_form %}
                         {% csrf_token %}
                         <div class="row expanded">

--- a/src/themes/OLH/templates/journal/contact.html
+++ b/src/themes/OLH/templates/journal/contact.html
@@ -24,7 +24,7 @@
             </div>
             <div class="large-8 columns">
                 <h3>{% trans "Contact" %}</h3>
-                <form method="POST">
+                <form method="POST" novalidate>
                     {% include "elements/forms/errors.html" with form=contact_form %}
                     {% csrf_token %}
                     <label for="id_recipient">{% trans "Who would you like to contact?" %}</label>

--- a/src/themes/OLH/templates/press/journal/contact.html
+++ b/src/themes/OLH/templates/press/journal/contact.html
@@ -16,7 +16,7 @@
             </div>
             <div class="large-8 columns">
                 <h4>{% trans "Contact" %}</h4>
-                <form method="POST">
+                <form method="POST" novalidate>
                     {% include "elements/forms/errors.html" with form=contact_form %}
                     {% csrf_token %}
                     <label for="id_recipient">{% trans "Who would you like to contact?" %}</label>

--- a/src/themes/clean/templates/journal/contact.html
+++ b/src/themes/clean/templates/journal/contact.html
@@ -19,7 +19,7 @@
         </div>
         <div class="col-md-8">
             <h2>{% trans "Contact" %}</h2>
-            <form method="POST">
+            <form method="POST" novalidate>
                 {% include "elements/forms/errors.html" with form=contact_form %}
                 {% csrf_token %}
                 <div class="form-group">

--- a/src/themes/material/templates/journal/contact.html
+++ b/src/themes/material/templates/journal/contact.html
@@ -36,7 +36,7 @@
                     <span class="card-title">
                         {% trans "Contact" %}
                     </span>
-                    <form method="POST">
+                    <form method="POST" novalidate>
                         {% include "elements/forms/errors.html" with form=contact_form %}
                         {% csrf_token %}
 


### PR DESCRIPTION
closes #4268 

Note from @ajrbyers:

- Steph and I discussed the approach at length and did some reasearch around validation. We decided to disable HTML5 validation as recommended by the UK Gov Frontend team: https://design-system.service.gov.uk/patterns/validation/