### PR TITLE
Make display of funding info clearer on article page

### DIFF
--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -133,16 +133,15 @@ def serve_journal_cover(request):
 
 @has_journal
 def funder_articles(request, funder_id):
-    # NOTE: This view is not usable currently because
-    # it is visually indistinguishable from the main Article search page.
-    # There is a filter applied to the queryset by the funder,
-    # but that is not represented in the filters, and the main heading
-    # just says "Articles".
-    """ Renders the list of articles in the journal.
+    """ Deprecated. Renders the list of articles in the journal.
 
         :param request: the request associated with this call
         :return: a rendered template of all articles
         """
+    raise DeprecationWarning(
+        'This view is deprecated.'
+    )
+
     if request.POST and 'clear' in request.POST:
         return logic.unset_article_session_variables(request)
 

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -133,6 +133,11 @@ def serve_journal_cover(request):
 
 @has_journal
 def funder_articles(request, funder_id):
+    # NOTE: This view is not usable currently because
+    # it is visually indistinguishable from the main Article search page.
+    # There is a filter applied to the queryset by the funder,
+    # but that is not represented in the filters, and the main heading
+    # just says "Articles".
     """ Renders the list of articles in the journal.
 
         :param request: the request associated with this call

--- a/src/templates/common/elements/funder_info_for_readers.html
+++ b/src/templates/common/elements/funder_info_for_readers.html
@@ -1,0 +1,30 @@
+{% if article.funders.all %}
+  <div class="callout primary">
+    <h2>{% trans "Funding" %}</h2>
+    {% trans "Name" as name_label %}
+    {% trans "FundRef ID" as fundref_id_label %}
+    {% trans "Funding ID" as funding_id_label %}
+    {% trans "Funding Statement" as statement_label %}
+    {% for funder in article.funders.all %}
+      <dl>
+        {% include "elements/layout/key_value_above.html" with key=name_label value=funder.name %}
+        {% if funder.fundref_id %}
+          {% include "elements/layout/key_value_above.html" with key=fundref_id_label value=funder.fundref_id %}
+        {% endif %}
+        {% if funder.funding_id %}
+          {% include "elements/layout/key_value_above.html" with key=funding_id_label value=funder.funding_id %}
+        {% endif %}
+        {% if funder.funding_statement %}
+          {% include "elements/layout/key_value_above.html" with key=statement_label value=funder.funding_statement|safe render_line_breaks=True %}
+        {% endif %}
+      </dl>
+      {% if funder.fundref_id %}
+        <p>
+          <a href="{% url "funder_articles" funder.fundref_id %}">
+            {% trans "Browse all articles funded by" %} {{ funder.name }}
+          </a>
+        </p>
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endif %}

--- a/src/templates/common/elements/funder_info_for_readers.html
+++ b/src/templates/common/elements/funder_info_for_readers.html
@@ -18,13 +18,6 @@
           {% include "elements/layout/key_value_above.html" with key=statement_label value=funder.funding_statement|safe render_line_breaks=True %}
         {% endif %}
       </dl>
-      {% if funder.fundref_id %}
-        <p>
-          <a href="{% url "funder_articles" funder.fundref_id %}">
-            {% trans "Browse all articles funded by" %} {{ funder.name }}
-          </a>
-        </p>
-      {% endif %}
     {% endfor %}
   </div>
 {% endif %}

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -228,31 +228,7 @@
                                     {% endif %}
                                 </div>
                             {% endif %}
-
-                            {% if article.funders.all %}
-                                <h2>{% trans "Funding" %}</h2>
-
-                                {% for funder in article.funders.all %}
-                                    <p>
-                                        {% if funder.fundref_id %}
-                                            <a href="{% url "funder_articles" funder.fundref_id %}">{{ funder.name }}</a>
-                                        {% else %}
-                                            {{ funder.name }}
-                                        {% endif %}
-                                        {% if funder.funding_id %}
-                                            {% blocktranslate with id=funder.funding_id %}
-                                                ({{ id }})
-                                            {% endblocktranslate %}
-                                        {% endif %}
-                                        {% if funder.funding_statement %}
-                                            <br/>
-                                            {{ funder.funding_statement|safe|linebreaksbr }}
-                                        {% endif %}
-                                    </p>
-                                {% endfor %}
-
-                            {% endif %}
-
+                            {% include "elements/funder_info_for_readers.html" %}
                             <div class="summary">
                                 {% if article.is_published or proofing %}
                                     {% if not request.journal.disable_metrics_display %}

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -121,27 +121,9 @@
                         </p>
                     </div>
                 {% endif %}
-                {% if article.funders.all %}
-                    <strong>{% trans "Funding" %}</strong>
-                    {% for funder in article.funders.all %}
-                        <p>
-                            {% if funder.fundref_id %}
-                                <a href="{% url "funder_articles" funder.fundref_id %}">{{ funder.name }}</a>
-                            {% else %}
-                                {{ funder.name }}
-                            {% endif %}
-                            {% if funder.funding_id %}
-                                {% blocktranslate with id=funder.funding_id %}
-                                    ({{ id }})
-                                {% endblocktranslate %}
-                            {% endif %}
-                            {% if funder.funding_statement %}
-                                <br/>
-                                {{ funder.funding_statement|safe|linebreaksbr }}
-                            {% endif %}
-                        </p>
-                    {% endfor %}
-                {% endif %}
+
+                {% include "elements/funder_info_for_readers.html" %}
+
                 {% if article.publisher_notes.all %}
                     <div class="callout primary">
                         <h2>{% trans "Publisher Notes" %}</h2>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -147,30 +147,7 @@
                             </div>
                         </div>
                     {% endif %}
-
-                    {% if article.funders.all %}
-                        <div class="callout primary">
-                            <h2>{% trans "Funding" %}</h2>
-                            {% for funder in article.funders.all %}
-                                <p>
-                                    {% if funder.fundref_id %}
-                                        <a href="{% url "funder_articles" funder.fundref_id %}">{{ funder.name }}</a>
-                                    {% else %}
-                                        {{ funder.name }}
-                                    {% endif %}
-                                    {% if funder.funding_id %}
-                                        {% blocktranslate with id=funder.funding_id %}
-                                            ({{ id }})
-                                        {% endblocktranslate %}
-                                    {% endif %}
-                                    {% if funder.funding_statement %}
-                                        <br/>
-                                        {{ funder.funding_statement|safe|linebreaksbr }}
-                                    {% endif %}
-                                </p>
-                            {% endfor %}
-                        </div>
-                    {% endif %}
+                    {% include "elements/funder_info_for_readers.html" %}
                 </div>
             </div>
             <div class="row">


### PR DESCRIPTION
Fixes #4461.

See my comment on the original issue for a diagnosis: https://github.com/openlibhums/janeway/issues/4461#issuecomment-2437595887

To make the behavior clear and still display the various IDs for metadata purposes, I have laid out the data using a definition list. I have opted to use the `key_value_above` template from the back office as it is agnostic of styling. If crossing between the themes in this way is undesirable, I can move `key_value_above` to common templates.

![image](https://github.com/user-attachments/assets/65b7e411-04e3-4abc-976c-d7c59ba80cd2)

![image](https://github.com/user-attachments/assets/5f8eb0f5-89e1-4e91-84a0-87ad478fda09)

![image](https://github.com/user-attachments/assets/455b957d-c370-481f-8c01-498b229a8463)
