### PR TITLE
The clean theme carousel now includes a link bringing it in line with other themes

### DIFF
--- a/src/themes/clean/assets/css/clean.css
+++ b/src/themes/clean/assets/css/clean.css
@@ -245,7 +245,6 @@ main a:hover {
 
 .carousel-caption h2 a {
     color: white;
-    text-decoration: none;
 }
 
 .row-eq-height {

--- a/src/themes/clean/assets/css/clean.css
+++ b/src/themes/clean/assets/css/clean.css
@@ -243,6 +243,11 @@ main a:hover {
     background-color: rgba(55, 55, 55, .8);
 }
 
+.carousel-caption h2 a {
+    color: white;
+    text-decoration: none;
+}
+
 .row-eq-height {
     display: -webkit-box;
     display: -webkit-flex;

--- a/src/themes/clean/templates/journal/homepage_elements/carousel.html
+++ b/src/themes/clean/templates/journal/homepage_elements/carousel.html
@@ -21,8 +21,8 @@
                                 {% endif %}
                              alt="{{ carousel_item.carousel_title|striptags }}">
                         <div class="carousel-caption d-none d-md-block" style="min-width: 100%;">
-                             <p>{{ carousel_item.carousel_subtitle|safe }}</p>
-                             <h2>{{ carousel_item.carousel_title|truncatechars_html:200|safe }}</h2>
+                          <p>{{ carousel_item.carousel_subtitle|safe }}</p>
+                          <h2><a href="{{ carousel_item.url }}">{{ carousel_item.carousel_title|truncatechars_html:200|safe }}</a></h2>
                         </div>
                     </div>
                 {% endfor %}


### PR DESCRIPTION
Adds a link to the clean theme's carousel.

<img width="1128" alt="Screenshot 2024-10-28 at 10 25 51" src="https://github.com/user-attachments/assets/c7a7c706-d4dd-4eaa-aebc-99cf58ede45c">
