### PR TITLE
Adds pytz as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ python-crontab==2.2.3
 python-dateutil==2.8.1
 python-docx==0.8.11
 python-magic==0.4.13
+pytz==2024.1
 requests==2.31.0
 six==1.14.0
 sqlparse==0.4.4


### PR DESCRIPTION
When doing a clean install pytz is missing.

```python
  File "/var/www/vermont/src/cms/models.py", line 17, in <module>
    from utils.logic import build_url_for_request
  File "/var/www/vermont/src/utils/logic.py", line 12, in <module>
    from core.middleware import GlobalRequestMiddleware
  File "/var/www/vermont/src/core/middleware.py", line 9, in <module>
    import pytz
ModuleNotFoundError: No module named 'pytz'
```

It may previously have been loaded automatically but another dependency but now adding it on its own.