### PR TITLE
Each theme (clean, material, OLH and admin) will now render favicons using a common template across all site types

### DIFF
--- a/src/core/templatetags/mimetype.py
+++ b/src/core/templatetags/mimetype.py
@@ -1,0 +1,19 @@
+from django import template
+
+from core.files import file_path_mime
+
+register = template.Library()
+
+
+@register.filter
+def get_mime(file_field):
+    """
+    Template tag to retrieve the MIME type of an ImageField or FileField.
+    If the field has no path attribute application/octet-stream is returned
+    as the default.
+
+    Usage: {{ request.press.favicon|get_mime }}
+    """
+    if file_field and hasattr(file_field, 'path'):
+        return file_path_mime(file_field.path)
+    return 'application/octet-stream'

--- a/src/templates/admin/core/base.html
+++ b/src/templates/admin/core/base.html
@@ -24,15 +24,7 @@
     } catch (e) {
     }</script>
     {% block css %}{% endblock %}
-
-    {% if journal.favicon %}
-        <link rel="icon" href="{{ journal.favicon.url }}" type="image/vnd.microsoft.icon"/>
-    {% elif request.repository.favicon %}
-        <link rel="icon" href="{{ request.repository.favicon.url }}" type="image/vnd.microsoft.icon"/>
-    {% elif press.favicon %}
-        <link rel="icon" href="{{ press.favicon.url }}" type="image/vnd.microsoft.icon"/>
-    {% endif %}
-
+    {% include "common/elements/favicons.html" %}
     <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
 </head>
 <body>

--- a/src/templates/common/elements/favicons.html
+++ b/src/templates/common/elements/favicons.html
@@ -1,0 +1,9 @@
+{% load mimetype %}
+
+{% if request.journal and request.journal.favicon %}
+  <link rel="icon" href="{{ request.journal.favicon.url }}" type="{{ request.journal.favicon|get_mime }}"/>
+{% elif request.repository and request.repository.favicon %}
+  <link rel="icon" href="{{ request.repository.favicon.url }}" type="{{ request.repository.favicon|get_mime }}"/>
+{% elif request.press and request.press.favicon %}
+  <link rel="icon" href="{{ request.press.favicon.url }}" type="{{ request.press.favicon|get_mime }}"/>
+{% endif %}

--- a/src/themes/OLH/templates/core/base.html
+++ b/src/themes/OLH/templates/core/base.html
@@ -42,13 +42,7 @@
         <link rel="alternate" type="application/rss+xml" title="Articles RSS Feed" href="{% url 'rss_articles' %}"/>
         <link  type="application/atom+xml" rel="alternate" title="News Feed for Journal" href="{% url 'rss_news' %}">
     {% endif %}
-
-    {% if request.journal and journal.favicon %}
-        <link rel="icon" href="{{ journal.favicon.url }}" type="image/vnd.microsoft.icon" />
-    {% elif request.press.favicon %}
-        <link rel="icon" href="{{ request.press.favicon.url }}" type="image/vnd.microsoft.icon" />
-    {% endif %}
-
+    {% include "common/elements/favicons.html" %}
 </head>
 <body>
 {% include "common/elements/skip_to_main_content.html" %}

--- a/src/themes/clean/templates/core/base.html
+++ b/src/themes/clean/templates/core/base.html
@@ -16,9 +16,7 @@
     <link href="{% journal_url 'rss_articles' %}" type="application/atom+xml" rel="alternate"
           title="Article Feed for Journal">
     <link href="{% journal_url 'rss_news' %}" type="application/atom+xml" rel="alternate" title="News Feed for Journal">
-    {% if journal.favicon %}
-        <link rel="icon" href="{{ journal.favicon.url }}" type="image/vnd.microsoft.icon"/>
-    {% endif %}
+    {% include "common/elements/favicons.html" %}
 
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">

--- a/src/themes/material/templates/core/base.html
+++ b/src/themes/material/templates/core/base.html
@@ -21,11 +21,7 @@
     <link href="{% journal_url 'rss_news' %}" type="application/atom+xml" rel="alternate"
           title="News Feed for Journal">
     {% endif %}
-    {% if request.journal.favicon %}
-        <link rel="icon" href="{{ journal.favicon.url }}" type="image/vnd.microsoft.icon"/>
-    {% elif request.repository.favicon %}
-        <link rel="icon" href="{{ request.repository.favicon.url }}" type="image/vnd.microsoft.icon"/>
-    {% endif %}
+    {% include "common/elements/favicons.html" %}
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Roboto" rel="stylesheet">
     <link


### PR DESCRIPTION
- Adds a new template tag that can be used to fetch the mimetype of a FileField or any of its children (eg ImageField).
    - `application/octet-stream` is used as the default when no mime can be worked out (https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types)
- Adds a common template for rendering favicons
- Closes #3997