### PR TITLE
#3965 adds text to the move_to_next modal.

### DIFF
--- a/src/templates/admin/elements/move_to_next_modal.html
+++ b/src/templates/admin/elements/move_to_next_modal.html
@@ -25,10 +25,10 @@
                 <input type="hidden" name="current_stage" value="{{ article.stage }}">
                 <div class="button-group expanded">
                     <button class="success button" type="submit">
-                        {% trans "Move to next stage" %}
+                        {% trans "Move to" %} {{ article.next_workflow_element|capfirst }}
                     </button>
                     <button class="alert button" data-close type="button">
-                        {% trans "Not right now" %}
+                        {% trans "Keep in" %} {{ article.current_workflow_element|capfirst }}
                     </button>
                 </div>
             </form>

--- a/src/templates/admin/elements/move_to_next_modal.html
+++ b/src/templates/admin/elements/move_to_next_modal.html
@@ -9,13 +9,10 @@
         <div class="card-section">
           <p>
             <span class="fa fa-info-circle"></span>
-            {% trans 'This article may need to be moved to the next workflow stage.' %}
-          </p>
-          <p>
-            This article is currently stalled in
+            This article is currently in the
             <strong>{{ article.current_workflow_element|capfirst }}
-              ({{ article.get_stage_display }})</strong> stage and needs to be
-            manually moved to the
+              ({{ article.get_stage_display }})</strong> stage and may need to
+            be manually moved to the
             <strong>{{ article.next_workflow_element|capfirst }}</strong>
             stage.
           </p>

--- a/src/templates/admin/elements/move_to_next_modal.html
+++ b/src/templates/admin/elements/move_to_next_modal.html
@@ -7,10 +7,20 @@
             <h4>{% trans "Workflow Info" %}</h4>
         </div>
         <div class="card-section">
-            <p>
-                <span class="fa fa-info-circle"></span>
-                {% trans 'This article may need to be moved to the next workflow stage.' %}
-            </p>
+          <p>
+            <span class="fa fa-info-circle"></span>
+            {% trans 'This article may need to be moved to the next workflow stage.' %}
+          </p>
+          <p>
+            This article is currently stalled in
+            <strong>{{ article.current_workflow_element|capfirst }}
+              ({{ article.get_stage_display }})</strong> stage and needs to be
+            manually moved to the
+            <strong>{{ article.next_workflow_element|capfirst }}</strong>
+            stage.
+          </p>
+
+
         </div>
         <div class="card-section">
             <form method="post" action="{% url 'move_to_next_workflow_element' article.pk %}">


### PR DESCRIPTION
- Adds text to explain the current stage and the stage the article will move to.

Closes #3965 

<img width="593" alt="Screenshot 2025-01-15 at 09 18 28" src="https://github.com/user-attachments/assets/71b757c8-3771-4006-8985-b24fc56807a0" />