### PR TITLE
Fixes two issues related to prepublication author and reviewer notifications

### DIFF
--- a/src/journal/logic.py
+++ b/src/journal/logic.py
@@ -250,7 +250,7 @@ def handle_unassign_issue(request, article, issues):
 
 def get_initial_for_prepub_notifications(request, article):
     author_initial = {}
-    author_initial['to'] = article.correspondence_author.email
+    author_initial['to'] = article.correspondence_author.email if article.correspondence_author else  None
     cc = [au.email for au in article.non_correspondence_authors()]
     notify_section_editors = request.journal.get_setting(
         'general',
@@ -265,7 +265,7 @@ def get_initial_for_prepub_notifications(request, article):
         'notify_peer_reviewers_of_publication',
     )
 
-    if not notify_peer_reviewers:
+    if not notify_peer_reviewers or not article.peer_reviewers():
         return [author_initial]
     else:
         peer_reviewer_initial = {}

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1121,7 +1121,7 @@ class Article(AbstractLastModifiedModel):
         if self.correspondence_author:
             return self.authors.exclude(pk=self.correspondence_author.pk)
         else:
-            return self.authors
+            return self.authors.all()
 
     def is_accepted(self):
         if self.date_published:

--- a/src/templates/admin/elements/publish/warnings.html
+++ b/src/templates/admin/elements/publish/warnings.html
@@ -1,0 +1,71 @@
+<ul>
+  {% if journal_settings.general.abstract_required and not article.abstract %}
+  <li>
+    This journal requires article to have an abstract - this article does not
+    have one
+    <a
+      target="_blank"
+      href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}"
+      >[change]<span class="show-for-sr"> Opens in new tab</span></a
+    >
+  </li>
+  {% endif %}
+  <li>
+    This article has been marked as {% if not article.peer_reviewed %}not {% endif %}peer reviewed
+    <a
+      target="_blank"
+      href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}"
+      >[change]<span class="show-for-sr"> Opens in new tab</span></a
+    >
+    {% if not article.get_doi %}
+  </li>
+  <li>
+    No DOI has been assigned
+    <a target="_blank" href="{% url 'edit_identifiers' article.pk %}"
+      >[change]<span class="show-for-sr"> Opens in new tab</span></a
+    >
+  </li>
+  {% endif %} {% if not article.keywords.count > 0 %}
+  <li>
+    No keywords have been set
+    <a
+      target="_blank"
+      href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}"
+      >[change]<span class="show-for-sr"> Opens in new tab</span></a
+    >
+  </li>
+  {% endif %} {% if not article.issues_list.count > 0 %}
+  <li>
+    This article has not been assigned to an Issue yet{% if article.projected_issue %}
+    It was projected to be in {{ article.projected_issue }}{% endif %}
+    <a href="?m=issue">[change]</a>
+  </li>
+  {% endif %} {% if not article.license %}
+  <li>
+    No license has been set
+    <a
+      target="_blank"
+      href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}"
+      >[change]<span class="show-for-sr"> Opens in new tab</span></a
+    >.
+  </li>
+  {% endif %} {% if article.license and not article.license.url %}
+  <li>
+    The set license has no URL
+    <a
+      target="_blank"
+      href="{% url 'submission_licenses_id' article.license.pk %}"
+      >[edit license]<span class="show-for-sr"> Opens in new tab</span></a
+    >.
+  </li>
+  {% endif %} {% if not article.correspondence_author %}
+  <li>
+    No correspondence author has been set
+    <a
+      target="_blank"
+      href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}#edit-metadata-authors"
+      >[change]<span class="show-for-sr"> Opens in new tab</span></a
+    >.
+  </li>
+  {% endif %}
+</ul>

--- a/src/templates/admin/journal/publish_article.html
+++ b/src/templates/admin/journal/publish_article.html
@@ -224,16 +224,7 @@
 
             <div class="bs-callout bs-callout-danger">
                 <p><strong><span class="fa fa-warning"> </span> Warnings</strong></p>
-                <ul>
-                    {% if journal_settings.general.abstract_required and not article.abstract %}
-                        <li>This journal requires article to have an abstract - this article does not have one <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="show-for-sr"> Opens in new tab</span></a></li>{% endif %}
-                    <li>This article has been marked as {% if not article.peer_reviewed %}not {% endif %}peer reviewed <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="show-for-sr"> Opens in new tab</span></a>
-                    {% if not article.get_doi %}<li>No DOI has been assigned <a target="_blank" href="{% url 'edit_identifiers' article.pk %}">[change]<span class="show-for-sr"> Opens in new tab</span></a></li>{% endif %}
-                    {% if not article.keywords.count > 0 %}<li>No keywords have been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="show-for-sr"> Opens in new tab</span></a></li>{% endif %}
-                    {% if not article.issues_list.count > 0 %}<li>This article has not been assigned to an Issue yet{% if article.projected_issue %} It was projected to be in {{ article.projected_issue }}{% endif %} <a href="?m=issue">[change]</a></li>{% endif %}
-                    {% if not article.license %}<li>No license has been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="show-for-sr"> Opens in new tab</span></a>.</li>{% endif %}
-                    {% if article.license and not article.license.url %}<li>The set license has no URL <a target="_blank" href="{% url 'submission_licenses_id' article.license.pk %}">[edit license]<span class="show-for-sr"> Opens in new tab</span></a>.</li>{% endif %}
-                </ul>
+                {% include "admin/elements/publish/warnings.html" %}
             </div>
         </div>
     </div>

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -21,7 +21,7 @@
         <div class="row expanded">
             <form method="POST"{% if journal_settings.general.abstract_required %} novalidate{% endif %}>
                 <div class="title-area">
-                    <h2>Edit Metadata</h2>
+                    <h2 id="edit-metadata">Edit Metadata</h2>
                     <a class="button" href="{{ return }}"><i class="fa fa-arrow-left"></i>Back</a>
                 </div>
                 <div class="content">
@@ -122,7 +122,7 @@
             </form>
         </div>
         <div class="title-area">
-            <h2>Authors</h2>
+            <h2 id="edit-metadata-authors">Authors</h2>
             {% if frozen_author %}
                 <a href="{% url 'edit_metadata' article.pk %}?modal=author&return={{ return }}" class="button">Add Author</a>
             {% else %}
@@ -177,7 +177,7 @@
             </form>
         </div>
         <div class="title-area">
-             <h2>Funding</h2>
+             <h2 id="edit-metadata-funding">Funding</h2>
         </div>
         <div class="content submission-content">
             <div class="row expanded">
@@ -221,7 +221,7 @@
         </div>
 
         <div class="title-area">
-            <h2>Current Funders</h2>
+            <h2 id="edit-metadata-currnt-funders">Current Funders</h2>
         </div>
 
         <div class="row expanded">

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -221,7 +221,7 @@
         </div>
 
         <div class="title-area">
-            <h2 id="edit-metadata-currnt-funders">Current Funders</h2>
+            <h2 id="edit-metadata-current-funders">Current Funders</h2>
         </div>
 
         <div class="row expanded">


### PR DESCRIPTION
- If no corresp author is present adds this as a warning
- When no corresp author is found set `author_initial['to']` to None, form validation will handle it being empty
- The change above surfaced a bug with in `article.non_correspondence_authors` also fixed by this PR
- The notification template had additional protection as it checked whether the given article had peer reviews, this was not present in the logic file so posting this form would error due to the second form not being present. This check is now also present in the logic.
- Shifts prepub warnings into their own file and inseted with an include.
- Closes #4477 