### PR TITLE
Front of House table A11y updates

### DIFF
--- a/src/themes/OLH/templates/elements/section_block.html
+++ b/src/themes/OLH/templates/elements/section_block.html
@@ -1,50 +1,47 @@
 <h3>{% trans 'Sections' %}</h3>
+{# TableA11y superflous p tags, single row of headings, very ambiguous data -> single row and column headings and make icons screen-reader compatible #}
 <table>
     <thead>
         <tr>
-            <th>
-                <p>{% trans "Section or article type" %}</p>
-            </th>
-            <th>
-                <p>{% trans "Public Submissions" %}</p>
-            </th>
-            <th>
-                <p>{% trans "Peer Reviewed" %}</p>
-            </th>
-            <th>
-                <p>{% trans "Indexed" %}</p>
-            </th>
+            <th scope="col" >{% trans "Section or article type" %}</th>
+            <th scope="col" >{% trans "Public Submissions" %}</th>
+            <th scope="col" >{% trans "Peer Reviewed" %}</th>
+            <th scope="col" >{% trans "Indexed" %}</th>
     </thead>
     <tbody>
         {% for section in sections %}
         <tr>
-            <td>
-                <p>{{ section.name }}</p>
-            </td>
+            <th scope="row" >{{ section.name }}</th>
             <td>
                 <strong>
                     {% if section.public_submissions %}
-                        <i class="fa fa-check" title="{% trans 'yes' %}"></i>
+                        <i aria-hidden="true" class="fa fa-check"></i>
+                        <span class="sr-only">{% trans 'has public submissions' %}</span>
                     {% else %}
-                        <i class="fa fa-times" title="{% trans 'no' %}"></i>
+                        <i aria-hidden="true" class="fa fa-times"></i>
+                        <span class="sr-only">{% trans 'does not have public submissions' %}</span>
                     {% endif %}
                 </strong>
             </td>
             <td>
                 <strong>
                     {% if section.number_of_reviewers > 0 %}
-                        <i class="fa fa-check" title="{% trans 'yes' %}"></i>
+                        <i aria-hidden="true" class="fa fa-check"></i>
+                        <span class="sr-only">{% trans 'is peer reviewed' %}</span>
                     {% else %}
-                        <i class="fa fa-times" title="{% trans 'no' %}"></i>
+                        <i aria-hidden="true" class="fa fa-times"></i>
+                        <span class="sr-only">{% trans 'is not peer reviewed' %}</span>
                     {% endif %}
                 </strong>
             </td>
             <td>
                 <strong>
                     {% if section.indexing %}
-                        <i class="fa fa-check" title="{% trans 'yes' %}"></i>
+                        <i aria-hidden="true" class="fa fa-check"></i>
+                        <span class="sr-only">{% trans 'is indexed' %}</span>
                     {% else %}
-                        <i class="fa fa-times" title="{% trans 'no' %}"></i>
+                        <i aria-hidden="true" class="fa fa-times"></i>
+                        <span class="sr-only">{% trans 'is not indexed' %}</span>
                     {% endif %}
                 </strong>
             </td>

--- a/src/themes/OLH/templates/elements/section_block.html
+++ b/src/themes/OLH/templates/elements/section_block.html
@@ -1,5 +1,4 @@
 <h3>{% trans 'Sections' %}</h3>
-{# TableA11y superflous p tags, single row of headings, very ambiguous data -> single row and column headings and make icons screen-reader compatible #}
 <table>
     <thead>
         <tr>

--- a/src/themes/clean/templates/elements/sections_block.html
+++ b/src/themes/clean/templates/elements/sections_block.html
@@ -1,6 +1,5 @@
 <h2>{% trans 'Sections' %}</h2>
 
-{# TableA11y single row headings, but very ambiguous data, should be one row and one column headings #}
 <table class="table">
     <caption>{% trans 'Sections submission information' %}</caption>
     <thead>

--- a/src/themes/clean/templates/elements/sections_block.html
+++ b/src/themes/clean/templates/elements/sections_block.html
@@ -1,25 +1,26 @@
 <h2>{% trans 'Sections' %}</h2>
 
+{# TableA11y single row headings, but very ambiguous data, should be one row and one column headings #}
 <table class="table">
     <caption>{% trans 'Sections submission information' %}</caption>
     <thead>
     <tr>
-        <th>{% trans 'Section or article type' %}</th>
-        <th>{% trans 'Public Submissions' %}</th>
-        <th>{% trans 'Peer Reviewed' %}</th>
-        <th>{% trans 'Indexed' %}</th>
+        <th scope="col">{% trans 'Section or article type' %}</th>
+        <th scope="col">{% trans 'Public Submissions' %}</th>
+        <th scope="col">{% trans 'Peer Reviewed' %}</th>
+        <th scope="col">{% trans 'Indexed' %}</th>
     </tr>
     </thead>
     <tbody>
     {% for section in sections %}
         <tr>
-            <td>{{ section.name }}</td>
+            <th scope="row">{{ section.name }}</th>
             <td>{% if section.public_submissions %}<span class="fa fa-check"> {% trans 'Yes' %}</span>{% else %}
                 <span class="fa fa-times"> {% trans 'No' %}</span>{% endif %}</td>
             <td>{% if section.number_of_reviewers > 0 %}<span class="fa fa-check"> {% trans 'Yes' %}</span>{% else %}
                 <span class="fa fa-times"> {% trans 'No' %}</span>{% endif %}</td>
             <td>{% if section.indexing %}<span class="fa fa-check"> {% trans 'Yes' %}</span>{% else %}
-                <span class="fa fa-times"> {% trans 'No' %}}</span>{% endif %}</td>
+                <span class="fa fa-times"> {% trans 'No' %}</span>{% endif %}</td>
         </tr>
         {% empty %}
     {% endfor %}

--- a/src/themes/material/templates/elements/sections_display.html
+++ b/src/themes/material/templates/elements/sections_display.html
@@ -1,4 +1,3 @@
-{# TableA11y superfluous paragraph tags, single row headings, but very ambiguous data, should be one row and one column headings #}
 <table class="striped responsive-table">
     <thead>
         <tr>

--- a/src/themes/material/templates/elements/sections_display.html
+++ b/src/themes/material/templates/elements/sections_display.html
@@ -1,25 +1,16 @@
+{# TableA11y superfluous paragraph tags, single row headings, but very ambiguous data, should be one row and one column headings #}
 <table class="striped responsive-table">
     <thead>
         <tr>
-            <th>
-                <p>{% trans "Section or article type" %}</p>
-            </th>
-            <th>
-                <p>{% trans "Public Submissions" %}</p>
-            </th>
-            <th>
-                <p>{% trans "Peer Reviewed" %}</p>
-            </th>
-            <th>
-                <p>{% trans "Indexed" %}</p>
-            </th>
+            <th scope="col">{% trans "Section or article type" %}</th>
+            <th scope="col">{% trans "Public Submissions" %}</th>
+            <th scope="col">{% trans "Peer Reviewed" %}</th>
+            <th scope="col">{% trans "Indexed" %}</th>
     </thead>
     <tbody>
         {% for section in sections %}
         <tr>
-            <td>
-                <p>{{ section.name }}</p>
-            </td>
+            <th scope="row">{{ section.name }}</th>
             <td>
                 <strong>
                     {% if section.public_submissions %}

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -306,7 +306,6 @@
                     {% if article.has_publication_details %}
                     <div class="section">
                         <h4>{% trans "Publication details" %}</h4>
-                        {# TableA11y header cells in first column, ambiguous data #}
                         <table class="sidebar-table">
                             {% if article.page_range %}
                             <tr>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -306,52 +306,53 @@
                     {% if article.has_publication_details %}
                     <div class="section">
                         <h4>{% trans "Publication details" %}</h4>
+                        {# TableA11y header cells in first column, ambiguous data #}
                         <table class="sidebar-table">
                             {% if article.page_range %}
                             <tr>
-                                <th>{% trans "Pages" %}</th>
+                                <th scope="row" >{% trans "Pages" %}</th>
                                 <td>{{ article.page_range }}</td>
                             </tr>
                             {% endif %}
                             {% if article.article_number %}
                             <tr>
-                                <th>{% trans "Article No." %}</th>
+                                <th scope="row" >{% trans "Article No." %}</th>
                                 <td>{{ article.article_number }}</td>
                             </tr>
                             {% endif %}
                             {% if article.publisher_name %}
                             <tr>
-                                <th>{% trans "Publisher" %}</th>
+                                <th scope="row" >{% trans "Publisher" %}</th>
                                 <td>{{ article.publisher_name }}</td>
                             </tr>
                             {% endif %}
                             {% if article.publication_title %}
                             <tr>
-                                <th>{% trans "Publication" %}</th>
+                                <th scope="row" >{% trans "Publication" %}</th>
                                 <td>{{ article.publication_title }}</td>
                             </tr>
                             {% endif %}
                             {% if article.ISSN_override %}
                             <tr>
-                                <th>{% trans "Original ISSN" %}</th>
+                                <th scope="row" >{% trans "Original ISSN" %}</th>
                                 <td>{{ article.ISSN_override}}</td>
                             </tr>
                             {% endif %}
                             {% if journal_settings.article.display_date_submitted and article.date_submitted %}
                                 <tr>
-                                    <th>{% trans "Submitted on" %}</th>
+                                    <th scope="row" >{% trans "Submitted on" %}</th>
                                     <td>{{ article.date_submitted|date:"Y-m-d" }}</td>
                                 </tr>
                             {% endif %}
                             {% if journal_settings.article.display_date_accepted and article.date_accepted %}
                                 <tr>
-                                    <th>{% trans "Accepted on" %}</th>
+                                    <th scope="row" >{% trans "Accepted on" %}</th>
                                     <td>{{ article.date_accepted|date:"Y-m-d" }}</td>
                                 </tr>
                             {% endif %}
                             {% if article.date_published or proofing %}
                             <tr>
-                                <th>{% trans "Published on" %}</th>
+                                <th scope="row" >{% trans "Published on" %}</th>
                                 <td id="article_date_published">
                                     {{ article.date_published|date:"Y-m-d" }}
                                 </td>


### PR DESCRIPTION
tables identified via a search for 'table' in the templates within the themes directory.

first commit includes a comment above each table stating what needed fixing, these comments are then removed for the final commit. 

For the OLH theme, there were icons that needed updating within the table (as per #4215) which convey information that is relevant to their position within the table, so I updated those too.

closes #4055