### PR TITLE
fix: disable URL for deprecated view #4495

### DIFF
--- a/src/journal/urls.py
+++ b/src/journal/urls.py
@@ -65,12 +65,6 @@ urlpatterns = [
         name='journal_articles',
     ),
 
-    re_path(
-        r'^funder_articles/(?P<funder_id>.+)$',
-        views.funder_articles,
-        name='funder_articles',
-    ),
-
     # Issues/Collections
     re_path(r'^issues/$', views.issues, name='journal_issues'),
     re_path(r'^issue/current/$', views.current_issue, name='current_issue'),


### PR DESCRIPTION
We do not link to this view anymore but is being hit  by bots and raising constant server errors/deprecation warnings.

I've kept the view as to preserve backwards compatibility but removed the URL entry

closes #4495 