### PR TITLE
Fix TOC generation to handle empty <a> tags and nested elements correctly

### DIFF
--- a/src/themes/OLH/assets/js/table_of_contents.js
+++ b/src/themes/OLH/assets/js/table_of_contents.js
@@ -1,19 +1,27 @@
-$( document ).ready(function() {
-    
+$(document).ready(function () {
+
     if (!$("#toc")) {
         return;
     }
-    
+
     var newLine, link, title, linkid, toc, iter, js;
 
     iter = 0;
     toc = '';
 
     $("#main_article h2, #main_article h3").each(function () {
-
         link = $(this);
-        link.find('a').contents().unwrap();
-        title = link.html();
+
+        var clonedLink = link.clone();
+        clonedLink.find('a').each(function () {
+            if (!$(this).text().trim()) {
+                $(this).remove();
+            } else {
+                $(this).contents().unwrap();
+            }
+        });
+
+        title = clonedLink.html();
 
         if (!link.attr("id")) {
             link.attr('id', 'heading' + iter.toString());
@@ -27,13 +35,11 @@ $( document ).ready(function() {
 
         toc += newLine;
         iter++;
-
     });
 
-    if(iter==0){
+    if (iter === 0) {
         $("#toc-section").remove();
-    }
-    else{
+    } else {
         $("#toc").append(toc);
     }
 });

--- a/src/themes/material/assets/toc.js
+++ b/src/themes/material/assets/toc.js
@@ -1,4 +1,4 @@
-$( document ).ready(function() {
+$(document).ready(function () {
 
     if (!$("#toc")) {
         return;
@@ -12,12 +12,23 @@ $( document ).ready(function() {
     $("#main_article h2").each(function () {
 
         link = $(this);
-        link.find('a').contents().unwrap();
-        title = link.html();
+
+        var clonedLink = link.clone();
+        clonedLink.find('a').each(function () {
+            if (!$(this).text().trim()) {
+                $(this).remove();
+            } else {
+                $(this).contents().unwrap();
+            }
+        });
+
+        clonedLink.find('sup').remove();
+
+        title = clonedLink.text().trim();
 
         if (!link.attr("id")) {
             link.attr('id', 'heading' + iter.toString());
-            link.addClass("section scrollspy")
+            link.addClass("section scrollspy");
         }
 
         linkid = "#" + link.attr("id");
@@ -31,10 +42,9 @@ $( document ).ready(function() {
 
     });
 
-    if(iter==0){
+    if (iter == 0) {
         $("#toc-section").remove();
-    }
-    else{
+    } else {
         $("#toc").append(toc);
     }
 });


### PR DESCRIPTION
Fixes TOC generation to ensure it leaves the tags alone.
Also fixes irritating edge case where a tag has an empty .