### PR TITLE
fix annotated files if typesetting plugin is not installed

### DIFF
--- a/src/core/templatetags/files.py
+++ b/src/core/templatetags/files.py
@@ -71,8 +71,8 @@ def file_type(article, file):
             galleyproofing__round__article=article,
         )
     except FieldError:
-        annotated_files = models.File.objects.none(
-            proofingtask__round__article=article,
+        annotated_files = models.File.objects.filter(
+            proofingtask__round__assignment__article=article,
         )
 
     for galley in article.galley_set.all():


### PR DESCRIPTION
Clicking on Document Management causes an error since the recent addition of annotated_files to the file_type template tag if the typesetting plugin is not installed.
Suggested fix.