### PR TITLE
Translation file changes for v1.8

### DIFF
--- a/src/core/locales/cy/LC_MESSAGES/django.po
+++ b/src/core/locales/cy/LC_MESSAGES/django.po
@@ -2,72 +2,79 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Janeway\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-12 16:34+0000\n"
+"POT-Creation-Date: 2024-12-05 10:48+0000\n"
 "Language: cy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: src/comms/models.py:94
+#: src/comms/models.py:119
 #, fuzzy, python-brace-format
 #| msgid "Posted by"
 msgid "Posted by {byline}"
 msgstr "Postiwyd gan"
 
-#: src/comms/models.py:95
+#: src/comms/models.py:120
 #, fuzzy, python-brace-format
 #| msgid "Posted by"
 msgid "Posted by  {byline}"
 msgstr "Postiwyd gan"
 
-#: src/copyediting/forms.py:16
+#: src/copyediting/forms.py:17
 msgid "Are you sure you want to create a copyediting assignment?"
 msgstr ""
 
-#: src/copyediting/forms.py:99
+#: src/copyediting/forms.py:104
 msgid "Are you sure you want to ask the author to review copyedits?"
 msgstr ""
 
-#: src/copyediting/forms.py:146
+#: src/copyediting/forms.py:151
 msgid "Are you sure you want to complete the copyedit task?"
 msgstr ""
 
-#: src/core/forms/forms.py:110
-msgid "Password 1"
-msgstr "Cyfrinair 1"
-
-#: src/core/forms/forms.py:111
-msgid "Password 2"
-msgstr "Cyfrinair 2"
-
-#: src/core/forms/forms.py:129
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/core/forms/forms.py:114 src/core/forms/forms.py:162
+#: src/templates/admin/core/accounts/orcid_registration.html:29
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
 #: src/themes/OLH/templates/press/core/login.html:33
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:24
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:28
 #: src/themes/clean/templates/core/login.html:34
+#: src/themes/hourglass/templates/custom/orcid-registration.html:32
 msgid "Password"
 msgstr "Cyfrinair"
 
-#: src/core/forms/forms.py:130
+#: src/core/forms/forms.py:123 src/core/forms/forms.py:170
 msgid "Repeat Password"
 msgstr "Ailadrodd Cyfrinair"
 
-#: src/core/forms/forms.py:133
+#: src/core/forms/forms.py:148 src/core/models.py:235
+#: src/templates/admin/core/accounts/orcid_registration.html:25
+#: src/templates/admin/repository/article.html:213
+#: src/templates/admin/repository/author_article.html:92
+#: src/templates/admin/repository/submit/authors.html:77
+#: src/templates/admin/submission/submit_authors.html:70
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:33
+#: src/themes/OLH/templates/press/core/login.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:25
+#: src/themes/hourglass/templates/custom/orcid-registration.html:28
+msgid "Email"
+msgstr "Ebost"
+
+#: src/core/forms/forms.py:179
 msgid ""
 "Check this box if you would like to receive notifications of new articles "
 "published in this journal"
 msgstr ""
 
-#: src/core/forms/forms.py:495
+#: src/core/forms/forms.py:578
 msgid "E-mail"
 msgstr "Ebost"
 
-#: src/core/forms/forms.py:694
+#: src/core/forms/forms.py:783
 msgid "Are you sure?"
 msgstr ""
 
-#: src/core/forms/forms.py:725
+#: src/core/forms/forms.py:814
 #, python-format
 msgid ""
 "The account belonging to %(email)s has not yet been activated, so the "
@@ -112,241 +119,233 @@ msgstr ""
 msgid "Issues and Collections"
 msgstr "Gweld y Casgliad"
 
-#: src/core/janeway_global_settings.py:252
+#: src/core/janeway_global_settings.py:254
 #, fuzzy
 #| msgid "English"
 msgid "English"
 msgstr "Saesneg"
 
-#: src/core/janeway_global_settings.py:253
+#: src/core/janeway_global_settings.py:255
 #, fuzzy
 #| msgid "English"
 msgid "English (US)"
 msgstr "Saesneg"
 
-#: src/core/janeway_global_settings.py:254
+#: src/core/janeway_global_settings.py:256
 msgid "French"
 msgstr "Ffrangeg"
 
-#: src/core/janeway_global_settings.py:255
+#: src/core/janeway_global_settings.py:257
 msgid "German"
 msgstr "Almaeneg "
 
-#: src/core/janeway_global_settings.py:256
+#: src/core/janeway_global_settings.py:258
 msgid "Dutch"
 msgstr ""
 
-#: src/core/janeway_global_settings.py:257
+#: src/core/janeway_global_settings.py:259
 msgid "Welsh"
 msgstr "Cymraeg "
 
-#: src/core/logic.py:810
+#: src/core/logic.py:833
 msgid "Your password must be {} characters long"
 msgstr ""
 
-#: src/core/logic.py:814
+#: src/core/logic.py:837
 msgid "An uppercase character is required"
 msgstr ""
 
-#: src/core/logic.py:817
+#: src/core/logic.py:840
 msgid "A number is required"
 msgstr ""
 
-#: src/core/models.py:69
+#: src/core/models.py:77
 msgid "Miss"
 msgstr ""
 
-#: src/core/models.py:70
+#: src/core/models.py:78
 msgid "Ms"
 msgstr ""
 
-#: src/core/models.py:71
+#: src/core/models.py:79
 #, fuzzy
 #| msgid "Metrics"
 msgid "Mrs"
 msgstr "Metrigau "
 
-#: src/core/models.py:72
+#: src/core/models.py:80
 msgid "Mr"
 msgstr ""
 
-#: src/core/models.py:73
+#: src/core/models.py:81
 msgid "Mx"
 msgstr ""
 
-#: src/core/models.py:74
+#: src/core/models.py:82
 msgid "Dr"
 msgstr ""
 
-#: src/core/models.py:75
+#: src/core/models.py:83
 #, fuzzy
 #| msgid "Profile"
 msgid "Prof."
 msgstr "Proffil"
 
-#: src/core/models.py:208 src/templates/admin/repository/article.html:213
-#: src/templates/admin/repository/author_article.html:92
-#: src/templates/admin/repository/submit/authors.html:80
-#: src/templates/admin/submission/submit_authors.html:65
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:26
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:29
-#: src/themes/OLH/templates/press/core/login.html:30
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:16
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:18
-msgid "Email"
-msgstr "Ebost"
-
-#: src/core/models.py:209
+#: src/core/models.py:236
 msgid "Username"
 msgstr "Enw Defnyddiwr"
 
-#: src/core/models.py:211
+#: src/core/models.py:242
 msgid "First name"
 msgstr "Enw Cyntaf"
 
-#: src/core/models.py:212 src/submission/forms.py:271
+#: src/core/models.py:248 src/submission/forms.py:286
 msgid "Middle name"
 msgstr "Enw Canol"
 
-#: src/core/models.py:213 src/submission/forms.py:272
+#: src/core/models.py:254 src/submission/forms.py:287
 msgid "Last name"
 msgstr "Cyfenw"
 
-#: src/core/models.py:217
+#: src/core/models.py:263
 msgid "Salutation"
 msgstr "Cyfarchiad "
 
-#: src/core/models.py:222
+#: src/core/models.py:269
 msgid "Name suffix"
 msgstr ""
 
-#: src/core/models.py:224
-#: src/themes/OLH/templates/core/accounts/public_profile.html:19
-#: src/themes/clean/templates/core/accounts/public_profile.html:19
-#: src/themes/material/templates/core/accounts/public_profile.html:19
+#: src/core/models.py:274
+#: src/themes/OLH/templates/core/accounts/public_profile.html:50
+#: src/themes/clean/templates/core/accounts/public_profile.html:23
+#: src/themes/material/templates/core/accounts/public_profile.html:23
 msgid "Biography"
 msgstr "Bywgraffiad "
 
-#: src/core/models.py:225 src/submission/models.py:1943
+#: src/core/models.py:276 src/submission/models.py:2014
 msgid "ORCiD"
 msgstr "ORCiD"
 
-#: src/core/models.py:226 src/submission/forms.py:275
+#: src/core/models.py:280 src/submission/forms.py:290
 msgid "Institution"
 msgstr "Sefydliad"
 
-#: src/core/models.py:227 src/submission/forms.py:276
+#: src/core/models.py:286 src/submission/forms.py:291
 msgid "Department"
 msgstr "Adran"
 
-#: src/core/models.py:228
+#: src/core/models.py:289
 #, fuzzy
 #| msgid "Twitter"
 msgid "Twitter Handle"
 msgstr "Twitter"
 
-#: src/core/models.py:229
+#: src/core/models.py:290
 #, fuzzy
 #| msgid "Facebook"
 msgid "Facebook Handle"
 msgstr "Facebook"
 
-#: src/core/models.py:230
+#: src/core/models.py:291
 #, fuzzy
 #| msgid "Edit Profile"
 msgid "Linkedin Profile"
 msgstr "Golygu Proffeil"
 
-#: src/core/models.py:231
+#: src/core/models.py:292
 #: src/themes/OLH/templates/elements/journal/editorial_social_content.html:3
 #: src/themes/clean/templates/elements/journal/editorial_social_content.html:3
 msgid "Website"
 msgstr "Gwefan "
 
-#: src/core/models.py:232
+#: src/core/models.py:293
 #, fuzzy
 #| msgid "Username"
 msgid "Github Username"
 msgstr "Enw Defnyddiwr"
 
-#: src/core/models.py:236
+#: src/core/models.py:297
 #, fuzzy
 #| msgid "Information"
 msgid "Confirmation Code"
 msgstr "Gwybodaeth"
 
-#: src/core/models.py:237
+#: src/core/models.py:300
 msgid "Signature"
 msgstr ""
 
-#: src/core/models.py:243
-#: src/themes/OLH/templates/core/accounts/public_profile.html:15
-#: src/themes/clean/templates/core/accounts/public_profile.html:15
-#: src/themes/material/templates/core/accounts/public_profile.html:15
+#: src/core/models.py:307
+#: src/themes/OLH/templates/core/accounts/public_profile.html:45
+#: src/themes/clean/templates/core/accounts/public_profile.html:19
+#: src/themes/material/templates/core/accounts/public_profile.html:19
 msgid "Country"
 msgstr "Gwlad"
 
-#: src/core/models.py:246
+#: src/core/models.py:314
 msgid "Preferred Timezone"
 msgstr ""
 
-#: src/core/models.py:254
+#: src/core/models.py:323
 msgid "Enable Digest"
 msgstr ""
 
-#: src/core/models.py:259
+#: src/core/models.py:328
 msgid "If enabled, your basic profile will be available to the public."
 msgstr ""
 
-#: src/core/models.py:261
+#: src/core/models.py:330
 msgid "Enable public profile"
 msgstr ""
 
-#: src/core/models.py:566 src/core/models.py:578
+#: src/core/models.py:639 src/core/models.py:651
 msgid "Expires on"
 msgstr ""
 
-#: src/core/models.py:840 src/core/models.py:1118
+#: src/core/models.py:915 src/core/models.py:1193
 #, fuzzy
 #| msgid "Article"
 msgid "Article PK"
 msgstr "Erthygl"
 
-#: src/core/models.py:845 src/core/models.py:1123 src/repository/models.py:838
-#: src/templates/admin/elements/submit/file.html:24
-#: src/templates/admin/submission/submit_files.html:40
-#: src/templates/admin/submission/submit_files.html:80
-#: src/templates/admin/submission/submit_review.html:120
+#: src/core/models.py:920 src/core/models.py:1198 src/repository/models.py:848
+#: src/templates/admin/submission/submit_files.html:46
+#: src/templates/admin/submission/submit_files.html:86
+#: src/templates/admin/submission/submit_review.html:136
 msgid "Label"
 msgstr "Label"
 
-#: src/core/models.py:846 src/core/models.py:1124
-#: src/templates/admin/elements/submit/file.html:31
+#: src/core/models.py:921 src/core/models.py:1199
 msgid "Description"
 msgstr "Disgrifiad"
 
-#: src/core/models.py:857
+#: src/core/models.py:932
 msgid "Remote URL of file"
 msgstr ""
 
-#: src/core/models.py:1150
+#: src/core/models.py:1225
 msgid "Other"
 msgstr ""
 
-#: src/core/models.py:1151
+#: src/core/models.py:1226
 msgid "Image"
 msgstr ""
 
-#: src/core/models.py:1493
+#: src/core/models.py:1594 src/templates/admin/journal/contact.html:38
+#: src/themes/OLH/templates/journal/contact.html:30
+#: src/themes/OLH/templates/press/journal/contact.html:22
+#: src/themes/clean/templates/journal/contact.html:27
+msgid "Who would you like to contact?"
+msgstr "Pwy hoffech gysylltu â nhw?"
+
+#: src/core/models.py:1595
 msgid "Your contact email address"
 msgstr "Eich cyfeiriad ebost cyswllt "
 
-#: src/core/models.py:1494
+#: src/core/models.py:1596
 msgid "Subject"
 msgstr "Pwnc"
 
-#: src/core/models.py:1495
+#: src/core/models.py:1597
 msgid "Your message"
 msgstr "Eich neges"
 
@@ -367,153 +366,165 @@ msgstr ""
 "Nid yw math MIME {mimetype} yn ddilys. Y mathau dilys yw: {validator."
 "mimetypes}"
 
-#: src/core/views.py:78
+#: src/core/views.py:80
 msgid "You have been banned from logging in due to failed attempts."
 msgstr ""
 
-#: src/core/views.py:122
+#: src/core/views.py:124
 msgid ""
 "Password reset process has been initiated, please check your inbox for a "
 "reset request link."
 msgstr ""
 
-#: src/core/views.py:132
+#: src/core/views.py:134
 msgid ""
 "Wrong email/password combination or your email address has not been "
 "confirmed yet."
 msgstr ""
 
-#: src/core/views.py:219
+#: src/core/views.py:226
 msgid "You have been logged out."
 msgstr ""
 
-#: src/core/views.py:236
+#: src/core/views.py:249
 msgid "If your account was found, an email has been sent to you."
 msgstr ""
 
-#: src/core/views.py:355
+#: src/core/views.py:377
 msgid ""
 "Your account has been created. Please follow the instructions in the email "
 "that has been sent to you."
 msgstr ""
 
-#: src/core/views.py:400
+#: src/core/views.py:420
 #, fuzzy
 #| msgid "Account"
 msgid "Account activated"
 msgstr "Cyfrif"
 
-#: src/core/views.py:442
+#: src/core/views.py:469
 msgid "An account with that email address already exists."
 msgstr ""
 
-#: src/core/views.py:448
+#: src/core/views.py:475
 #, fuzzy
 #| msgid "Email Address"
 msgid "Email address is not valid."
 msgstr "Cyfeiriad ebost"
 
-#: src/core/views.py:463
+#: src/core/views.py:490
 #, fuzzy
 #| msgid "Password Guide"
 msgid "Password updated."
 msgstr "Canllaw Cyfrinair "
 
-#: src/core/views.py:467
+#: src/core/views.py:494
 msgid "Passwords do not match"
 msgstr ""
 
-#: src/core/views.py:470
+#: src/core/views.py:497
 msgid "Old password is not correct."
 msgstr ""
 
-#: src/core/views.py:480
+#: src/core/views.py:507
 #, fuzzy
 #| msgid "Register for"
 msgid "Successfully subscribed to article notifications."
 msgstr "Cofrestru ar gyfer"
 
-#: src/core/views.py:491
+#: src/core/views.py:518
 msgid "Successfully unsubscribed from article notifications."
 msgstr ""
 
-#: src/core/views.py:1943
+#: src/core/views.py:2079
 msgid ""
 "You cannot remove a section that contains articles. Remove articles from the "
 "section if you want to delete it."
 msgstr ""
+
+#: src/core/views.py:2711 src/journal/forms.py:24 src/journal/views.py:2866
+msgid "Newest"
+msgstr ""
+
+#: src/core/views.py:2712 src/journal/forms.py:25 src/journal/views.py:2867
+msgid "Oldest"
+msgstr ""
+
+#: src/core/views.py:2713
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name A-Z"
+msgstr "Cyfenw"
+
+#: src/core/views.py:2714
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name Z-A"
+msgstr "Cyfenw"
 
 #: src/discussion/models.py:27
 msgid "Max. 300 characters."
 msgstr ""
 
 #. Translators: Search order options
-#: src/journal/forms.py:20
+#: src/journal/forms.py:21
 msgid "Relevance"
 msgstr ""
 
-#: src/journal/forms.py:21 src/journal/views.py:2629
+#: src/journal/forms.py:22 src/journal/views.py:2868
 #, fuzzy
 #| msgid "Title"
 msgid "Titles A-Z"
 msgstr "Teitl"
 
-#: src/journal/forms.py:22 src/journal/views.py:2630
+#: src/journal/forms.py:23 src/journal/views.py:2869
 #, fuzzy
 #| msgid "Title"
 msgid "Titles Z-A"
 msgstr "Teitl"
 
-#: src/journal/forms.py:23 src/journal/views.py:2627
-msgid "Newest"
-msgstr ""
-
-#: src/journal/forms.py:24 src/journal/views.py:2628
-msgid "Oldest"
-msgstr ""
-
-#: src/journal/forms.py:97
+#: src/journal/forms.py:98
 #: src/themes/clean/templates/core/homepage_elements/search_bar.html:20
 #, fuzzy
 #| msgid "Search"
 msgid "Search term"
 msgstr "Chwilio"
 
-#: src/journal/forms.py:98
+#: src/journal/forms.py:99
 #, fuzzy
 #| msgid "Search preprints"
 msgid "Search Titles"
 msgstr "Chwilio rhagargraffiadau"
 
-#: src/journal/forms.py:99
+#: src/journal/forms.py:100
 #, fuzzy
 #| msgid "Abstract"
 msgid "Search Abstract"
 msgstr "Crynodeb"
 
-#: src/journal/forms.py:100
+#: src/journal/forms.py:101
 #, fuzzy
 #| msgid "Search for Existing Authors"
 msgid "Search Authors"
 msgstr "Chwilio am Awduron"
 
-#: src/journal/forms.py:101
+#: src/journal/forms.py:102
 #, fuzzy
 #| msgid "Keywords"
 msgid "Search Keywords"
 msgstr "Geiriau Allweddol"
 
-#: src/journal/forms.py:102
+#: src/journal/forms.py:103
 msgid "Search Full Text"
 msgstr ""
 
-#: src/journal/forms.py:103
+#: src/journal/forms.py:104
 #, fuzzy
 #| msgid "Search"
 msgid "Search ORCIDs"
 msgstr "Chwilio"
 
-#: src/journal/forms.py:104 src/templates/common/elements/sorting.html:16
+#: src/journal/forms.py:105 src/templates/common/elements/sorting.html:16
 #: src/themes/clean/templates/elements/sorting.html:17
 #: src/themes/material/templates/elements/sorting.html:31
 #, fuzzy
@@ -521,171 +532,193 @@ msgstr "Chwilio"
 msgid "Sort results by"
 msgstr "Teitl eich erthygl"
 
-#: src/journal/logic.py:212
+#: src/journal/logic.py:216
 msgid "Articles without a section cannot be added to an issue."
 msgstr "Ni ellir ychwanegu erthyglau heb adran i rifyn."
 
-#: src/journal/models.py:80
+#: src/journal/models.py:101
 msgid ""
 "Short acronym for the journal. Used as part of the journal URLin path mode "
 "and to uniquely identify the journal"
 msgstr ""
 
-#: src/journal/models.py:98
+#: src/journal/models.py:119
 msgid ""
 "The default thumbnail for articles, not to be confused with 'Default cover "
 "image'."
 msgstr ""
 
-#: src/journal/models.py:106
+#: src/journal/models.py:127
 msgid "Replaces the press logo in the footer."
 msgstr ""
 
-#: src/journal/models.py:113
+#: src/journal/models.py:134
 msgid ""
 "The default cover image for journal issues and for the journal's listing on "
 "the press-level website."
 msgstr ""
 
-#: src/journal/models.py:121
+#: src/journal/models.py:142
 #, fuzzy
 #| msgid "The default language of articles when lang is hidden"
 msgid "The default background image for article openers and carousel items."
 msgstr "Iaith ddiofyn yr erthyglau pan fydd yr iaith ynghudd "
 
-#: src/journal/models.py:129
+#: src/journal/models.py:150
 msgid ""
 "The logo-sized image at the top of all pages, typically used for journal "
 "logos."
 msgstr ""
 
-#: src/journal/models.py:137
+#: src/journal/models.py:158
 msgid ""
 "The tiny round or square image appearing in browser tabs before the webpage "
 "title"
 msgstr ""
 
-#: src/journal/models.py:148
+#: src/journal/models.py:166
+msgid ""
+"A default image displayed on the profile and editorial team pages when the "
+"user has no set profile image."
+msgstr ""
+
+#: src/journal/models.py:183
 #, fuzzy
 #| msgid "This article has been peer reviewed."
 msgid "This field has been deprecated in v1.4.3"
 msgstr "Mae’r erthygl hon wedi’i chymheirio"
 
-#: src/journal/models.py:158
+#: src/journal/models.py:193
 msgid "When enabled, the journal is marked as not hosted in Janeway."
 msgstr ""
 
-#: src/journal/models.py:169
+#: src/journal/models.py:204
 msgid "If the journal is remote you can link to its submission page."
 msgstr ""
 
-#: src/journal/models.py:174
+#: src/journal/models.py:209
 msgid "If the journal is remote you can link to its home page."
 msgstr ""
 
-#: src/journal/models.py:178
+#: src/journal/models.py:213
 msgid "Enables a \"View PDF\" link on article pages."
 msgstr ""
 
-#: src/journal/models.py:220
+#: src/journal/models.py:255
 msgid ""
 "Whether to display article numbers. Article numbers are distinct from "
 "article ID and can be set in Edit Metadata."
 msgstr ""
 
-#: src/journal/models.py:532
+#: src/journal/models.py:600
 msgid "Please add as much detail as you can."
 msgstr ""
 
-#: src/journal/models.py:573
+#: src/journal/models.py:724
 #, fuzzy
 #| msgid "Subtitle of the article display format; Title: Subtitle"
 msgid "Autogenerated cache of the display format of an issue title"
 msgstr "Fformat arddangos isdeitl yr erthygl; Teitl: Isdeitl "
 
-#: src/journal/models.py:588
+#: src/journal/models.py:739
 msgid "Image representing the cover of a printed issue or volume"
 msgstr ""
 
-#: src/journal/models.py:594
+#: src/journal/models.py:745
 msgid "landscape hero image used in the carousel and issue page"
 msgstr ""
 
-#: src/journal/models.py:613
+#: src/journal/models.py:764
 msgid ""
 "An optional alphanumeric code (Slug) used to generate a verbose  url for "
 "this issue. e.g: 'winter-special-issue'."
 msgstr ""
 
-#: src/journal/models.py:635
+#: src/journal/models.py:786
 msgid ""
 "An ISBN is relevant for non-serial collections such as conference proceedings"
 msgstr ""
 
-#: src/journal/models.py:676
+#: src/journal/models.py:827
 #: src/themes/OLH/templates/press/press_journals.html:71
 #: src/themes/clean/templates/press/press_journals.html:42
 #: src/themes/material/templates/press/press_journals.html:46
 msgid "Current Issue"
 msgstr "Rhifyn Cyfredol"
 
-#: src/journal/models.py:734
+#: src/journal/models.py:885
 msgid "pages"
 msgstr ""
 
-#: src/journal/models.py:736
+#: src/journal/models.py:887
 msgid "page"
 msgstr ""
 
-#: src/journal/views.py:751
+#: src/journal/views.py:771
 msgid "No file uploaded"
 msgstr "Dim ffeil wedi’i huwchlwytho"
 
-#: src/journal/views.py:1009
+#: src/journal/views.py:1097
 msgid "Issue not in this journal’s issue list."
 msgstr ""
 
-#: src/journal/views.py:1129
+#: src/journal/views.py:1143
+msgid ""
+"Publication date set to { article.date_published.strftime(\"%Y-%m-%d %H:%M "
+"%Z\") } "
+msgstr ""
+
+#: src/journal/views.py:1150
+#, fuzzy
+#| msgid "Publication Fees"
+msgid "Publication date unset"
+msgstr "Ffioedd Cyhoeddi"
+
+#: src/journal/views.py:1156
+msgid "Something went wrong when trying to save the form. "
+msgstr ""
+
+#: src/journal/views.py:1241
 msgid "Article set for publication."
 msgstr "Erthygl wedi’i gosod ar gyfer cyhoeddi."
 
-#: src/journal/views.py:1401
+#: src/journal/views.py:1516
 msgid "You cannot move the first section up the order list"
 msgstr "Ni allwch symud yr adran gyntaf i fyny’r rhestr "
 
-#: src/journal/views.py:1433
+#: src/journal/views.py:1548
 msgid "You cannot move the last section down the order list"
 msgstr "Ni allwch symud yr adran olaf i lawr y rhestr "
 
-#: src/journal/views.py:1440
+#: src/journal/views.py:1555
 msgid "This page accepts post requests only."
 msgstr "Mae’r dudalen hon yn derbyn ceisiadau post yn unig."
 
-#: src/journal/views.py:1511
+#: src/journal/views.py:1626
 msgid "User is already a guest editor."
 msgstr "Mae’r defnyddiwr eisoes yn olygydd gwadd."
 
-#: src/journal/views.py:1517
+#: src/journal/views.py:1632
 msgid "This user is not a member of this journal."
 msgstr "Nid yw’r defnyddiwr hwn yn aelod o’r cyfnodolyn hwn."
 
-#: src/journal/views.py:1570
+#: src/journal/views.py:1685
 msgid "Editor removed from Issue."
 msgstr "Tynnwyd y Golygydd o’r Rhifyn."
 
-#: src/journal/views.py:1576
+#: src/journal/views.py:1691
 msgid "Issue Editor not found."
 msgstr "Ni chanfuwyd Golygydd y Rhifyn."
 
-#: src/journal/views.py:1582
+#: src/journal/views.py:1697
 msgid "No Issue Editor ID supplied."
 msgstr "Ni chyflenwyd ID Golygydd y Rhifyn."
 
-#: src/journal/views.py:1729
+#: src/journal/views.py:1851
 msgid "Uploaded file is not UTF-8 encoded"
 msgstr "Nid yw’r ffeil a uwchlwythwyd wedi amgodio UTF-8 "
 
-#: src/journal/views.py:1823
+#: src/journal/views.py:1945
 msgid ""
 "You must login before you can become a reviewer. Click the button below to "
 "login."
@@ -693,7 +726,7 @@ msgstr ""
 "Rhaid mewngofnodi cyn gallu dod yn adolygydd. Cliciwch y botwm isod i "
 "fewngofnodi."
 
-#: src/journal/views.py:1828
+#: src/journal/views.py:1950
 msgid ""
 "You are not yet a reviewer for this journal. Click the button below to "
 "become a reviewer."
@@ -701,111 +734,104 @@ msgstr ""
 "Nid ydych yn un o adolygwyr y cyfnodolyn hwn eto. Cliciwch y botwm isod i "
 "ddod yn adolygydd."
 
-#: src/journal/views.py:1833
+#: src/journal/views.py:1955
 msgid "You are already a reviewer."
 msgstr "Rydych eisoes yn adolygydd."
 
-#: src/journal/views.py:1840
+#: src/journal/views.py:1962
 msgid "You are now a reviewer"
 msgstr "Rydych bellach yn adolygydd"
 
-#: src/journal/views.py:1879
+#: src/journal/views.py:2001
 msgid "Your message has been sent."
 msgstr "Anfonwyd eich neges."
 
-#: src/journal/views.py:2313 src/journal/views.py:2330
-#: src/journal/views.py:2340
+#: src/journal/views.py:2478
+#, fuzzy
+#| msgid "Production file uploaded."
+msgid "Manuscript file uploaded."
+msgstr "Uwchlwythwyd y ffeil cynhyrchu."
+
+#: src/journal/views.py:2495
+#, fuzzy
+#| msgid "Proofing file uploaded."
+msgid "Data/figure file uploaded."
+msgstr "Uwchlwythwyd y ffeil prawf ddarllen"
+
+#: src/journal/views.py:2506
 msgid "Production file uploaded."
 msgstr "Uwchlwythwyd y ffeil cynhyrchu."
 
-#: src/journal/views.py:2350
+#: src/journal/views.py:2516
+#, fuzzy
+#| msgid "No file uploaded"
+msgid "Galley file uploaded."
+msgstr "Dim ffeil wedi’i huwchlwytho"
+
+#: src/journal/views.py:2552
 msgid "Proofing file uploaded."
 msgstr "Uwchlwythwyd y ffeil prawf ddarllen"
 
-#: src/journal/views.py:2603
+#: src/journal/views.py:2558
+#, fuzzy
+#| msgid "Upload files"
+msgid "Saved file."
+msgstr "Uwchlwytho ffeiliau"
+
+#: src/journal/views.py:2568
+#, fuzzy
+#| msgid "Supplementary Files"
+msgid "Supplementary file uploaded."
+msgstr "Ffeiliau Atodol"
+
+#: src/journal/views.py:2578
+#, fuzzy
+#| msgid "Proofing file uploaded."
+msgid "Typesetting source file uploaded."
+msgstr "Uwchlwythwyd y ffeil prawf ddarllen"
+
+#: src/journal/views.py:2849
 #, fuzzy
 #| msgid "Published"
 msgid "Published after"
 msgstr "Cyhoeddwyd"
 
-#: src/journal/views.py:2607
+#: src/journal/views.py:2853
 #, fuzzy
 #| msgid "Published on"
 msgid "Published before"
 msgstr "Cyhoeddwyd ar"
 
-#: src/journal/views.py:2612
-#: src/templates/admin/submission/submit_review.html:70
+#: src/journal/views.py:2858
+#: src/templates/admin/submission/submit_review.html:75
 msgid "Section"
 msgstr "Adran"
 
-#: src/journal/views.py:2631 src/themes/OLH/templates/repository/list.html:77
+#: src/journal/views.py:2870 src/themes/OLH/templates/repository/list.html:77
 #: src/themes/material/templates/preprints/list.html:80
 #: src/themes/material/templates/repository/list.html:61
 msgid "Author Name"
 msgstr "Enw Awdur "
 
-#: src/journal/views.py:2632
+#: src/journal/views.py:2871
 msgid "Volume"
 msgstr ""
 
-#: src/plugins_bak/typesetting/forms.py:16
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to create a typesetting assignment?"
-msgstr "Nodwch eich cyfrinair newydd ddwywaith i gwblhau’r broses ailosod "
-
-#: src/plugins_bak/typesetting/forms.py:90
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to create a proofreading assignment?"
-msgstr "Nodwch eich cyfrinair newydd ddwywaith i gwblhau’r broses ailosod "
-
-#: src/plugins_bak/typesetting/forms.py:160
-msgid "Text to show as the download link on the article page"
-msgstr ""
-
-#: src/plugins_bak/typesetting/forms.py:199
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to complete the proofreading task?"
-msgstr "Nodwch eich cyfrinair newydd ddwywaith i gwblhau’r broses ailosod "
-
-#: src/plugins_bak/typesetting/forms.py:224
-msgid "You have not proofed some galleys:"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:164
-msgid "Article has no typeset files"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:165
-msgid "One or more typeset files are missing images"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:167
-msgid "One or more typesetting or proofing tasks haven't been completed"
-msgstr ""
-
-#: src/plugins_bak/typesetting/templates/typesetting/typesetting_proofreading_assignment.html:116
-msgid "Mark Task as Complete"
-msgstr ""
-
-#: src/press/views.py:406
+#: src/press/views.py:405
 #, fuzzy
 #| msgid "Description"
 msgid "Description deleted."
 msgstr "Disgrifiad"
 
-#: src/press/views.py:419
+#: src/press/views.py:418
 #, fuzzy
 #| msgid "Description"
 msgid "Description saved."
 msgstr "Disgrifiad"
 
-#: src/repository/forms.py:44 src/submission/forms.py:75
+#: src/repository/forms.py:42 src/submission/forms.py:87
 #: src/templates/admin/core/manager/sections/section_articles.html:30
-#: src/templates/admin/submission/submit_review.html:46
+#: src/templates/admin/submission/submit_review.html:51
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:21
 #: src/themes/OLH/templates/repository/list.html:75
 #: src/themes/clean/templates/journal/articles.html:65
@@ -815,7 +841,7 @@ msgstr "Disgrifiad"
 msgid "Title"
 msgstr "Teitl"
 
-#: src/repository/forms.py:47 src/submission/forms.py:79
+#: src/repository/forms.py:45
 msgid "Enter your article's abstract here"
 msgstr "Rhowch grynodeb eich erthygl yma "
 
@@ -835,98 +861,88 @@ msgid ""
 "files."
 msgstr ""
 
-#: src/repository/models.py:350
+#: src/repository/models.py:375
 msgid ""
 "If this field is to be output as a dc metadata field you can addthe type "
 "here."
 msgstr ""
 
-#: src/repository/models.py:396 src/repository/models.py:983
-#: src/repository/models.py:1140 src/submission/models.py:632
+#: src/repository/models.py:421 src/repository/models.py:993
+#: src/repository/models.py:1144 src/submission/models.py:622
 msgid "Your article title"
 msgstr "Teitl eich erthygl"
 
-#: src/repository/models.py:403 src/submission/models.py:645
-msgid "Copying and pasting from word processors is supported."
-msgstr ""
-
-#: src/repository/models.py:949
-#: src/templates/admin/submission/submit_review.html:101
+#: src/repository/models.py:959
+#: src/templates/admin/submission/submit_review.html:117
 msgid "ORCID"
 msgstr ""
 
-#: src/repository/models.py:990 src/repository/models.py:1146
-msgid ""
-"Please avoid pasting content from word processors as they can add unwanted "
-"styling to the abstract. You can retype the abstract here or copy and paste "
-"it into notepad/a plain text editor before pasting here."
-msgstr ""
-"Osgowch ludo cynnwys o broseswyr geiriau gan eu bod yn gallu ychwanegu gwedd "
-"ddieisiau i’r crynodeb. Gallwch aildeipio’r crynodeb yma neu ei ludo i "
-"notepad/golygydd testun plaen cyn gludo yma."
-
-#: src/repository/models.py:1209
+#: src/repository/models.py:1206
 msgid "Approved"
 msgstr ""
 
-#: src/repository/models.py:1211
+#: src/repository/models.py:1208
 #, fuzzy
 #| msgid "Peer Review"
 msgid "Under Review"
 msgstr "Adolygiadau Cymheiriaid"
 
-#: src/repository/models.py:1213 src/templates/admin/review/view_review.html:64
+#: src/repository/models.py:1210 src/templates/admin/review/view_review.html:64
 #, fuzzy
 #| msgid "Disciplines"
 msgid "Declined"
 msgstr "Disgyblaethau"
 
-#: src/repository/views.py:1076
+#: src/repository/views.py:1097
 #, fuzzy
 #| msgid "Author Information"
 msgid "Author information saved"
 msgstr "Gwybodaeth Awdur "
 
-#: src/review/forms.py:237
+#: src/review/forms.py:242
 msgid "Are you sure you want to request revisions?"
 msgstr ""
 
-#: src/review/forms.py:281
+#: src/review/forms.py:292
 #, fuzzy
 #| msgid "Enter your new password twice to complete the reset process"
 msgid "Are you sure you want to complete the revision request?"
 msgstr "Nodwch eich cyfrinair newydd ddwywaith i gwblhau’r broses ailosod "
 
-#: src/review/forms.py:406
+#: src/review/forms.py:415
 msgid "Author can access this review"
 msgstr ""
 
-#: src/review/forms.py:407
+#: src/review/forms.py:416
 msgid "Author can access review file"
 msgstr ""
 
-#: src/review/forms.py:427
+#: src/review/forms.py:436
 #, python-format
 msgid "Author can see ‘%(name)s’"
 msgstr ""
 
-#: src/review/models.py:195
+#: src/review/models.py:198
 msgid "Anonymity"
 msgstr ""
 
-#: src/review/models.py:331
+#: src/review/models.py:334
 msgid "available for the author to access"
 msgstr ""
 
-#: src/review/models.py:332
+#: src/review/models.py:335
 msgid "not available for the author to access"
 msgstr ""
 
-#: src/review/views.py:1605
+#: src/review/views.py:1664
 #, fuzzy
 #| msgid "This article has been peer reviewed."
 msgid "This article has already been accepted or declined."
 msgstr "Mae’r erthygl hon wedi’i chymheirio"
+
+#: src/security/templatetags/securitytags.py:102
+msgid "[Anonymised data]"
+msgstr ""
 
 #: src/submission/decorators.py:22
 msgid "This page can only be accessed on Journals."
@@ -936,104 +952,108 @@ msgstr "Dim ond ar ‘Cyfnodolion’ y gellir cyrchu’r dudalen hon."
 msgid "Submission is disabled for this journal."
 msgstr "Analluogwyd cyflwyno i’r cyfnodolyn hwn."
 
-#: src/submission/forms.py:76
-#: src/templates/admin/submission/submit_review.html:48
+#: src/submission/forms.py:88
+#: src/templates/admin/submission/submit_review.html:53
 msgid "Subtitle"
 msgstr "Isdeitl"
 
-#: src/submission/forms.py:274
+#: src/submission/forms.py:289
 msgid "Enter biography here"
 msgstr ""
 
-#: src/submission/forms.py:277
+#: src/submission/forms.py:292
 #, fuzzy
 #| msgid "Twitter"
 msgid "Twitter handle"
 msgstr "Twitter"
 
-#: src/submission/forms.py:278
+#: src/submission/forms.py:293
 #, fuzzy
 #| msgid "Edit Profile"
 msgid "LinkedIn profile"
 msgstr "Golygu Proffeil"
 
-#: src/submission/forms.py:279
+#: src/submission/forms.py:294
 msgid "ImpactStory profile"
 msgstr ""
 
-#: src/submission/forms.py:280
+#: src/submission/forms.py:295
 msgid "ORCID ID"
 msgstr ""
 
-#: src/submission/forms.py:281
+#: src/submission/forms.py:296
 #, fuzzy
 #| msgid "Email Address"
 msgid "Email address"
 msgstr "Cyfeiriad ebost"
 
-#: src/submission/forms.py:338
+#: src/submission/forms.py:352
 #, python-format
 msgid "Currently linked to %s, leave blank to use this address"
 msgstr ""
 
-#: src/submission/forms.py:343
+#: src/submission/forms.py:357
 #, python-format
 msgid "If left blank, the account ORCiD will be used (%s)"
 msgstr ""
 
-#: src/submission/logic.py:98
+#: src/submission/logic.py:99
 msgid "You must upload a file that is either a Doc, Docx, RTF or ODT."
 msgstr ""
 
-#: src/submission/models.py:639
+#: src/submission/models.py:347
+msgid "Additional information regarding this funding entry"
+msgstr ""
+
+#: src/submission/models.py:629
 msgid "Do not use--deprecated in version 1.4.1 and later."
 msgstr ""
 
-#: src/submission/models.py:654
+#: src/submission/models.py:644
 msgid "The primary language of the article"
 msgstr "Prif iaith yr erthygl"
 
-#: src/submission/models.py:715
+#: src/submission/models.py:719
 msgid "Custom page range. e.g.: 'I-VII' or 1-3,4-8"
 msgstr ""
 
-#: src/submission/models.py:738
+#: src/submission/models.py:742
 msgid "Add any comments you'd like the editor to consider here."
 msgstr ""
 
-#: src/submission/models.py:761
+#: src/submission/models.py:765
 msgid ""
 "Custom 'how to cite' text. To be used only if the block generated by Janeway "
 "is not suitable."
 msgstr ""
 
-#: src/submission/models.py:767 src/submission/models.py:774
+#: src/submission/models.py:771 src/submission/models.py:778
 msgid ""
 "Name of the publisher who published this article Only relevant to migrated "
 "articles from a different publisher"
 msgstr ""
 
-#: src/submission/models.py:780
+#: src/submission/models.py:784
 msgid ""
 "Original ISSN of this article's journal when published Only relevant for "
 "back content published under a different title"
 msgstr ""
 
-#: src/submission/models.py:1898
+#: src/submission/models.py:1948
 msgid "Optional name prefix (e.g: Prof or Dr)"
 msgstr ""
 
-#: src/submission/models.py:1903
+#: src/submission/models.py:1954
 msgid "Optional name suffix (e.g.: Jr or III)"
 msgstr ""
 
-#: src/submission/models.py:1914
+#: src/submission/models.py:1985
 #, fuzzy
 #| msgid "Biography"
 msgid "Frozen Biography"
 msgstr "Bywgraffiad "
 
-#: src/submission/models.py:1915
+#: src/submission/models.py:1986
 msgid ""
 "The author's biography at the time they published the linked article. For "
 "this article only, it overrides any main biography attached to the author's "
@@ -1041,103 +1061,103 @@ msgid ""
 "account will be populated instead."
 msgstr ""
 
-#: src/submission/models.py:1939
+#: src/submission/models.py:2009
 #, fuzzy
 #| msgid "Author Name"
 msgid "Author Email"
 msgstr "Enw Awdur "
 
-#: src/submission/models.py:1944
+#: src/submission/models.py:2015
 msgid ""
 "ORCiD to be displayed when no account is associated with this author. It "
 "should be introduced in code format (e.g: 0000-0000-0000-000X)"
 msgstr ""
 
-#: src/submission/models.py:1951
+#: src/submission/models.py:2022
 msgid ""
 "If checked, this authors email address link will be displayed on the article "
 "page."
 msgstr ""
 
-#: src/submission/models.py:2311
-#: src/templates/admin/submission/submit_files.html:69
+#: src/submission/models.py:2387
+#: src/templates/admin/submission/submit_files.html:75
 msgid "Figures and Data Files"
 msgstr "Ffeiliau Ffigurau a Data "
 
-#: src/submission/models.py:2318
+#: src/submission/models.py:2394
 msgid "The default license applied when no option is presented"
 msgstr "Defnyddir y drwydded ddiofyn pan na chyflwynir opsiwn "
 
-#: src/submission/models.py:2326
+#: src/submission/models.py:2402
 msgid "The default language of articles when lang is hidden"
 msgstr "Iaith ddiofyn yr erthyglau pan fydd yr iaith ynghudd "
 
-#: src/submission/models.py:2332
+#: src/submission/models.py:2408
 msgid "The default section of articles when no option is presented"
 msgstr "Adran ddiofyn yr erthyglau pan na chyflwynir opsiwn "
 
-#: src/submission/views.py:260 src/submission/views.py:295
-#: src/submission/views.py:320
+#: src/submission/views.py:284 src/submission/views.py:319
+#: src/submission/views.py:344
 #, python-brace-format
 msgid "{author_name} added to the article."
 msgstr "Ychwanegwyd {author_name} at yr erthygl."
 
-#: src/submission/views.py:288
+#: src/submission/views.py:312
 msgid "Errors found in the new author form"
 msgstr "Canfuwyd gwallau yn y ffurflen awdur newydd "
 
-#: src/submission/views.py:309
+#: src/submission/views.py:333
 msgid "An empty search is not allowed."
 msgstr "Ni chaniateir chwiliad gwag."
 
-#: src/submission/views.py:327
+#: src/submission/views.py:351
 msgid "No author found with those details."
 msgstr "Ni chanfuwyd awdur gyda’r manylion hyn."
 
-#: src/submission/views.py:337
+#: src/submission/views.py:361
 msgid "You must select a main author."
 msgstr "Rhaid dewis prif awdur."
 
-#: src/submission/views.py:447
+#: src/submission/views.py:569
 msgid "File deleted"
 msgstr "Dilëwyd y ffeil"
 
-#: src/submission/views.py:501
+#: src/submission/views.py:624
 msgid "You must upload a manuscript file."
 msgstr ""
 
-#: src/submission/views.py:564
+#: src/submission/views.py:692
 #, python-brace-format
 msgid "Article {title} submitted"
 msgstr "Cyflwynwyd erthygl {title} "
 
-#: src/submission/views.py:661
+#: src/submission/views.py:791
 msgid "Metadata updated."
 msgstr "Diweddarwyd metadata."
 
-#: src/submission/views.py:673
+#: src/submission/views.py:803
 msgid "Primary author set."
 msgstr ""
 
-#: src/submission/views.py:690
+#: src/submission/views.py:820
 #, python-brace-format
 msgid "Author {author_name} updated."
 msgstr "Diweddarwyd awdur {author_name}."
 
-#: src/submission/views.py:708
+#: src/submission/views.py:838
 msgid "Frozen Author deleted."
 msgstr "Dilëwyd Awdur rhewedig."
 
-#: src/submission/views.py:823
+#: src/submission/views.py:953
 msgid "License saved."
 msgstr "Trwydded wedi’i chadw."
 
-#: src/submission/views.py:868
+#: src/submission/views.py:998
 #, python-brace-format
 msgid "License {license_name} deleted."
 msgstr "Dilëwyd trwydded {license_name}."
 
-#: src/submission/views.py:904
+#: src/submission/views.py:1034
 msgid "Configuration updated."
 msgstr "Diweddarwyd ffurfweddiad."
 
@@ -1170,6 +1190,428 @@ msgstr ""
 #: src/templates/admin/copyediting/author_review.html:92
 msgid "Complete Copyedit Task"
 msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:5
+#: src/templates/admin/core/accounts/activate_account.html:10
+#: src/templates/admin/core/accounts/activate_account.html:15
+#: src/templates/admin/core/accounts/activate_account.html:29
+#: src/themes/OLH/templates/core/accounts/activate_account.html:9
+#: src/themes/OLH/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:30
+#: src/themes/clean/templates/core/accounts/activate_account.html:9
+#: src/themes/clean/templates/core/accounts/activate_account.html:17
+#: src/themes/clean/templates/core/accounts/activate_account.html:21
+#: src/themes/hourglass/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:18
+#: src/themes/material/templates/core/accounts/activate_account.html:23
+msgid "Activate Account"
+msgstr "Actifadu’r Cyfrif"
+
+#: src/templates/admin/core/accounts/activate_account.html:17
+#, fuzzy
+#| msgid "Account"
+msgid "No account to activate"
+msgstr "Cyfrif"
+
+#: src/templates/admin/core/accounts/activate_account.html:24
+#, fuzzy
+#| msgid ""
+#| "You can complete the activation process by clicking the button below."
+msgid ""
+"\n"
+"      You can complete the activation process by clicking the button\n"
+"      below.\n"
+"    "
+msgstr "Gallwch gwblhau’r broses actifadu drwy glicio’r botwm isod."
+
+#: src/templates/admin/core/accounts/activate_account.html:32
+msgid ""
+"\n"
+"      Sorry, we could not find an account to activate, or your account is "
+"active\n"
+"      already. You can check if it is active by attempting to log in.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:38
+#: src/templates/admin/core/accounts/login.html:5
+#: src/templates/admin/core/accounts/login.html:13
+#: src/templates/admin/core/accounts/orcid_registration.html:38
+#: src/themes/OLH/templates/core/login.html:43
+#: src/themes/clean/templates/core/login.html:40
+msgid "Log in"
+msgstr "Mewngofnodi"
+
+#: src/templates/admin/core/accounts/edit_profile.html:9
+#: src/templates/admin/core/accounts/edit_profile.html:17
+#: src/themes/OLH/templates/core/accounts/edit_profile.html:8
+#: src/themes/clean/templates/core/accounts/edit_profile.html:9
+#: src/themes/hourglass/templates/core/accounts/edit_profile.html:11
+#: src/themes/material/templates/core/accounts/edit_profile.html:8
+msgid "Edit Profile"
+msgstr "Golygu Proffeil"
+
+#: src/templates/admin/core/accounts/edit_profile.html:26
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
+msgid "Change Your Email Address"
+msgstr "Newid eich cyfeiriad ebost"
+
+#: src/templates/admin/core/accounts/edit_profile.html:28
+#, fuzzy
+#| msgid ""
+#| "If you want to change your email address you may do so below, however, "
+#| "you will be logged out and your account will be marked as inactive until "
+#| "you follow the instructions in the verification email."
+msgid ""
+"\n"
+"          <p>If you want to change your email address you may do so below,\n"
+"          however, you will be logged out and your\n"
+"          account will be marked as inactive until you follow the\n"
+"          instructions in the verification email. <strong>Note: </strong>\n"
+"          Changing your email address will also change your username as "
+"these\n"
+"          are one and the same.</p>\n"
+"        "
+msgstr ""
+"Os ydych chi’n dymuno newid eich cyfeiriad ebost gallwch wneud hynny isod, "
+"ond cewch eich allgofnodi a bydd eich cyfrif yn cael ei farcio’n segur tan i "
+"chi ddilyn y cyfarwyddiadau yn yr ebost dilysu. Nodwch: Bydd newid eich "
+"cyfeiriad ebost hefyd yn newid eich enw defnyddiwr gan fod y rhain yr un "
+"fath â’i gilydd."
+
+#: src/templates/admin/core/accounts/edit_profile.html:36
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
+#, fuzzy
+#| msgid "Email Address"
+msgid "Current Email Address"
+msgstr "Cyfeiriad ebost"
+
+#: src/templates/admin/core/accounts/edit_profile.html:43
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
+#, fuzzy
+#| msgid "Email Address"
+msgid "New Email Address"
+msgstr "Cyfeiriad ebost"
+
+#: src/templates/admin/core/accounts/edit_profile.html:50
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
+msgid "Update Email Address"
+msgstr "Diweddaru Cyfeiriad Ebost"
+
+#: src/templates/admin/core/accounts/edit_profile.html:58
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
+#, fuzzy
+#| msgid "Register for"
+msgid "Register for Article Notifications"
+msgstr "Cofrestru ar gyfer"
+
+#: src/templates/admin/core/accounts/edit_profile.html:61
+msgid ""
+"\n"
+"              Use the button below to register to receive notifications of "
+"new articles\n"
+"              published in this journal.\n"
+"            "
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:68
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
+msgid "Unsubscribe from Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:72
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
+msgid "Subscribe to Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:80
+#: src/templates/admin/core/accounts/edit_profile.html:115
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
+msgid "Update Password"
+msgstr "Diweddaru Cyfrinair"
+
+#: src/templates/admin/core/accounts/edit_profile.html:82
+#, fuzzy
+#| msgid ""
+#| "You can update your password by entering your existing password plus your "
+#| "new password."
+msgid ""
+"\n"
+"          You can update your password by entering your existing\n"
+"          password plus your new password.\n"
+"        "
+msgstr ""
+"Gallwch ddiweddaru eich cyfrinair drwy nodi eich cyfrinair presennol a’ch "
+"cyfrinair newydd."
+
+#: src/templates/admin/core/accounts/edit_profile.html:91
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
+msgid "Current Password"
+msgstr "Cyfrinair Presennol"
+
+#: src/templates/admin/core/accounts/edit_profile.html:98
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
+msgid "New Password"
+msgstr "Cyfrinair Newydd"
+
+#: src/templates/admin/core/accounts/edit_profile.html:105
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
+msgid "Enter Password Again"
+msgstr "Nodwch y Cyfrinair Eto"
+
+#: src/templates/admin/core/accounts/edit_profile.html:122
+#, fuzzy
+#| msgid "Profile Image"
+msgid "Profile Details"
+msgstr "Delwedd Proffil"
+
+#: src/templates/admin/core/accounts/edit_profile.html:132
+#: src/templates/admin/core/accounts/reset_password.html:31
+#: src/templates/admin/press/edit_press_journal_description.html:24
+#: src/templates/admin/review/view_review.html:168
+#: src/templates/admin/review/view_review.html:189
+msgid "Save"
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:5
+#: src/templates/admin/core/accounts/get_reset_token.html:10
+#: src/templates/admin/core/accounts/get_reset_token.html:14
+#, fuzzy
+#| msgid "Reset Password"
+msgid "Reset password"
+msgstr "Ailosod Cyfrinair"
+
+#: src/templates/admin/core/accounts/get_reset_token.html:20
+msgid ""
+"\n"
+"      Enter your email address and then follow the link sent to you by "
+"email.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:27
+#, fuzzy
+#| msgid "Request Token"
+msgid "Request link"
+msgstr "Tocyn Cais"
+
+#: src/templates/admin/core/accounts/login.html:24
+#: src/themes/OLH/templates/core/login.html:28
+#: src/themes/clean/templates/core/login.html:16
+#: src/themes/material/templates/core/login.html:18
+msgid "Log in with ORCiD"
+msgstr "Mewngofnodi gydag ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:33
+#, fuzzy
+#| msgid "Login with ORCiD"
+msgid "Log in with"
+msgstr "Mewngofnodi gydag ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:45
+#: src/themes/OLH/templates/core/login.html:27
+#: src/themes/OLH/templates/press/core/login.html:25
+#: src/themes/clean/templates/core/login.html:14
+msgid "Log in with your account"
+msgstr "Mewngofnodi gyda’ch cyfrif"
+
+#: src/templates/admin/core/accounts/login.html:50
+#: src/templates/admin/core/accounts/orcid_registration.html:43
+#: src/themes/OLH/templates/core/login.html:44
+#: src/themes/clean/templates/core/login.html:44
+msgid "Forgotten your password?"
+msgstr "Wedi anghofio eich cyfrinair?"
+
+#: src/templates/admin/core/accounts/login.html:55
+#: src/templates/admin/core/accounts/orcid_registration.html:48
+#: src/themes/OLH/templates/core/login.html:45
+#: src/themes/clean/templates/core/login.html:48
+msgid "Register a new account"
+msgstr "Cofrestru cyfrif newydd"
+
+#: src/templates/admin/core/accounts/orcid_registration.html:5
+#: src/templates/admin/core/accounts/orcid_registration.html:10
+#: src/templates/admin/core/accounts/orcid_registration.html:14
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:9
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:23
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:8
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:13
+msgid "Unregistered ORCiD"
+msgstr "Dadgofrestru ORCiD"
+
+#: src/templates/admin/core/accounts/orcid_registration.html:19
+#, fuzzy
+#| msgid ""
+#| "The ORCiD you logged in with is not currently linked with an account in "
+#| "our system. You can either register a new account, or login with an "
+#| "existing account to link your ORCiD for future use."
+msgid ""
+"\n"
+"    The ORCiD you logged in with is not currently linked with an\n"
+"    account in our system. You can either register a new account, or login "
+"with\n"
+"    an existing account to link your ORCiD for future use.\n"
+"  "
+msgstr ""
+"Nid yw’r ORCiD y defnyddioch i fewngofnodi ar hyn o bryd yn gysylltiedig â "
+"chyfrif yn ein system. Gallwch naill ai gofrestru cyfrif newydd, neu "
+"fewngofnodi gyda chyfrif sy’n bodoli eisoes i gysylltu eich ORCiD i’w "
+"ddefnyddio yn y dyfodol."
+
+#: src/templates/admin/core/accounts/password_guide.html:11
+#: src/themes/OLH/templates/core/accounts/register.html:110
+#: src/themes/OLH/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/register.html:54
+#: src/themes/clean/templates/core/accounts/reset_password.html:47
+#: src/themes/material/templates/core/accounts/register.html:53
+#: src/themes/material/templates/core/accounts/reset_password.html:43
+msgid "Password Guide"
+msgstr "Canllaw Cyfrinair "
+
+#: src/templates/admin/core/accounts/password_guide.html:15
+#, fuzzy
+#| msgid "When it comes to passwords, length is better than complexity."
+msgid ""
+"\n"
+"        When it comes to passwords, length is better than complexity.\n"
+"      "
+msgstr "Pan ddaw’n fater o gyfrineiriau, mae hyd yn well na chymhlethdod."
+
+#: src/templates/admin/core/accounts/password_guide.html:18
+#, fuzzy
+#| msgid ""
+#| "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
+#| "secure than a long and uncomplicated password (our awesome moon base "
+#| "rocks)."
+msgid ""
+"\n"
+"        Its a common myth that a short and complex password\n"
+"        (Jfjfy&65^87) is more secure than a long and uncomplicated password\n"
+"        (our awesome moon base rocks).\n"
+"      "
+msgstr ""
+"Mae’n goel gyffredin fod cyfrinair byr a chymhleth (Jfjfy&65^87) yn fwy "
+"diogel na chyfrinair hir llai cymhleth (gwinllan a roddwyd i’n gofal)."
+
+#: src/templates/admin/core/accounts/password_guide.html:23
+#, fuzzy
+#| msgid ""
+#| "We recommend selecting a long, but easy to remember password such as our "
+#| "awesome moon base rocks which would take an estimated septillion years to "
+#| "crack as opposed to a complex one like Jfjfy&65^87 which would take just "
+#| "over 600 years on a standard computer."
+msgid ""
+"\n"
+"        We recommend selecting a long, but easy to remember\n"
+"        password such as our awesome moon base rocks which would take an\n"
+"        estimated septillion years to crack as opposed to a complex one "
+"like\n"
+"        Jfjfy&65^87 which would take just over 600 years on a standard\n"
+"        computer.\n"
+"      "
+msgstr ""
+"Rydym yn argymell dewis cyfrinair hir ond hawdd ei gofio fel ‘our awesome "
+"moon base rocks’, yr amcangyfrifir y byddai’n cymryd setptiliwn o "
+"flynyddoedd i’w ddatrys yn hytrach na chyfrinair cymhleth fel Jfjfy&65^87 a "
+"fyddai’n cymryd ychydig dros 600 o flynyddoedd ar gyfrifiadur safonol."
+
+#: src/templates/admin/core/accounts/register.html:5
+#: src/templates/admin/core/accounts/register.html:10
+#: src/templates/admin/core/accounts/register.html:14
+#, fuzzy
+#| msgid "Register for"
+msgid "Register for an account"
+msgstr "Cofrestru ar gyfer cyfrif gyda"
+
+#: src/templates/admin/core/accounts/register.html:39
+#: src/templates/admin/core/accounts/reset_password.html:19
+#: src/themes/OLH/templates/core/accounts/register.html:31
+#: src/themes/OLH/templates/core/accounts/reset_password.html:31
+#: src/themes/clean/templates/core/accounts/register.html:22
+#: src/themes/clean/templates/core/accounts/reset_password.html:21
+#: src/themes/material/templates/core/accounts/register.html:24
+#: src/themes/material/templates/core/accounts/reset_password.html:21
+#, fuzzy
+#| msgid "Password Guide"
+msgid "Password Rules"
+msgstr "Canllaw Cyfrinair "
+
+#: src/templates/admin/core/accounts/register.html:43
+#: src/templates/admin/core/accounts/reset_password.html:23
+msgid ""
+"\n"
+"    For more information read our <a href=\"#\"\n"
+"    data-open=\"password-modal\">password guide</a>.\n"
+"  "
+msgstr ""
+
+#: src/templates/admin/core/accounts/register.html:55
+#: src/themes/OLH/templates/core/accounts/register.html:91
+#: src/themes/clean/templates/core/accounts/register.html:31
+#: src/themes/hourglass/templates/custom/register.html:24
+#: src/themes/material/templates/core/accounts/register.html:37
+msgid "By registering an account you agree to our"
+msgstr "Drwy gofrestru cyfrif rydych yn cytuno i’r"
+
+#: src/templates/admin/core/accounts/register.html:63
+#: src/templates/admin/journal/submissions.html:35
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:52
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:54
+#: src/themes/OLH/templates/core/accounts/register.html:9
+#: src/themes/OLH/templates/core/accounts/register.html:100
+#: src/themes/OLH/templates/core/base.html:142
+#: src/themes/OLH/templates/core/nav.html:76
+#: src/themes/OLH/templates/journal/submissions.html:30
+#: src/themes/OLH/templates/press/nav.html:58
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:45
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:47
+#: src/themes/clean/templates/core/accounts/register.html:9
+#: src/themes/clean/templates/core/accounts/register.html:39
+#: src/themes/clean/templates/core/nav.html:104
+#: src/themes/clean/templates/journal/submissions.html:17
+#: src/themes/clean/templates/press/nav.html:79
+#: src/themes/hourglass/templates/core/accounts/register.html:11
+#: src/themes/material/templates/core/accounts/register.html:10
+#: src/themes/material/templates/core/accounts/register.html:44
+#: src/themes/material/templates/core/nav.html:79
+#: src/themes/material/templates/core/nav.html:134
+#: src/themes/material/templates/journal/submissions.html:33
+#: src/themes/material/templates/press/nav.html:67
+#: src/themes/material/templates/press/nav.html:115
+#: src/themes/material/templates/repository/nav.html:60
+msgid "Register"
+msgstr "Cofrestru "
+
+#: src/templates/admin/core/accounts/reset_password.html:5
+#: src/templates/admin/core/accounts/reset_password.html:10
+#: src/templates/admin/core/accounts/reset_password.html:14
+#, fuzzy
+#| msgid "Enter New Password"
+msgid "Enter your new password"
+msgstr "Nodwch y Cyfrinair Newydd"
 
 #: src/templates/admin/core/manager/sections/manage_section.html:15
 #: src/templates/admin/core/manager/sections/manage_section.html:22
@@ -1310,6 +1752,30 @@ msgid ""
 "the section if you want to delete it."
 msgstr ""
 
+#: src/templates/admin/core/manager/users/list.html:16
+#, fuzzy
+#| msgid "Journals"
+msgid "Journal Users"
+msgstr "Cyfnodolion "
+
+#: src/templates/admin/core/manager/users/list.html:18
+#, fuzzy
+#| msgid "All Preprints"
+msgid "All Users"
+msgstr "Pob Rhagargraffiad"
+
+#: src/templates/admin/core/manager/users/list.html:40
+#, fuzzy
+#| msgid "Username"
+msgid "Users"
+msgstr "Enw Defnyddiwr"
+
+#: src/templates/admin/core/manager/users/list.html:70
+#, fuzzy
+#| msgid "No articles to display."
+msgid "No accounts to display."
+msgstr "Dim erthyglau i’w dangos."
+
 #: src/templates/admin/core/request_submission_access.html:14
 msgid "requires that you request permission to make a submission."
 msgstr ""
@@ -1325,44 +1791,64 @@ msgid "You have an active access request that was submitted on: "
 msgstr ""
 
 #: src/templates/admin/elements/accounts/user_form.html:4
-#: src/themes/OLH/templates/elements/accounts/user_form.html:5
-#: src/themes/clean/templates/elements/accounts/user_form.html:5
-#: src/themes/material/templates/elements/accounts/user_form.html:6
-msgid "Core Data"
-msgstr "Data Craidd"
+#: src/templates/admin/repository/article.html:212
+#: src/templates/admin/repository/author_article.html:91
+#: src/templates/admin/repository/submit/authors.html:76
+#: src/templates/admin/submission/submit_authors.html:69
+#: src/templates/admin/submission/submit_funding.html:72
+#: src/templates/common/elements/funder_info_for_readers.html:4
+msgid "Name"
+msgstr "Enw"
 
-#: src/templates/admin/elements/accounts/user_form.html:61
+#: src/templates/admin/elements/accounts/user_form.html:13
+#, fuzzy
+#| msgid "Affiliation"
+msgid "Affiliations"
+msgstr "Cyswllt"
+
+#: src/templates/admin/elements/accounts/user_form.html:20
+#: src/themes/OLH/templates/elements/accounts/user_form.html:41
+#: src/themes/clean/templates/elements/accounts/user_form.html:38
+#: src/themes/material/templates/elements/accounts/user_form.html:39
+msgid "Social Media and Accounts"
+msgstr "Cyfryngau Cymdeithasol a Chyfrifon "
+
+#: src/templates/admin/elements/accounts/user_form.html:30
 #: src/themes/OLH/templates/elements/accounts/user_form.html:65
 #: src/themes/clean/templates/elements/accounts/user_form.html:62
 #: src/themes/material/templates/elements/accounts/user_form.html:63
 msgid "Biography and Signature"
 msgstr "Bywgraffiad a Llofnod"
 
-#: src/templates/admin/elements/accounts/user_form.html:70
+#: src/templates/admin/elements/accounts/user_form.html:40
+#: src/templates/admin/elements/accounts/user_form.html:43
 #: src/themes/OLH/templates/elements/accounts/user_form.html:74
 #: src/themes/clean/templates/elements/accounts/user_form.html:71
 #: src/themes/material/templates/elements/accounts/user_form.html:72
 msgid "Review Interests"
 msgstr "Adolygu Diddordebau"
 
-#: src/templates/admin/elements/accounts/user_form.html:71
+#: src/templates/admin/elements/accounts/user_form.html:50
 #: src/themes/OLH/templates/elements/accounts/user_form.html:75
 #: src/themes/clean/templates/elements/accounts/user_form.html:72
 #: src/themes/material/templates/elements/accounts/user_form.html:73
 msgid "Hit Enter to add a new interest"
 msgstr "Pwyswch Enter i ychwanegu diddordeb newydd"
 
-#: src/templates/admin/elements/accounts/user_form.html:75
+#: src/templates/admin/elements/accounts/user_form.html:53
 #: src/themes/OLH/templates/elements/accounts/user_form.html:79
 #: src/themes/clean/templates/elements/accounts/user_form.html:76
 #: src/themes/material/templates/elements/accounts/user_form.html:77
 msgid "Profile Image"
 msgstr "Delwedd Proffil"
 
-#: src/templates/admin/elements/accounts/user_form.html:91
-#, fuzzy
-#| msgid "Options"
-msgid "Email Options"
+#: src/templates/admin/elements/accounts/user_form.html:69
+#: src/themes/OLH/templates/elements/accounts/user_form.html:95
+#: src/themes/OLH/templates/journal/article.html:107
+#: src/themes/OLH/templates/journal/article.html:108
+#: src/themes/clean/templates/elements/accounts/user_form.html:92
+#: src/themes/material/templates/elements/accounts/user_form.html:93
+msgid "Options"
 msgstr "Opsiynau "
 
 #: src/templates/admin/elements/confirm_modal.html:7
@@ -1386,7 +1872,7 @@ msgstr ""
 msgid "No, go back"
 msgstr ""
 
-#: src/templates/admin/elements/forms/field.html:7
+#: src/templates/admin/elements/forms/field.html:13
 msgid "translatable"
 msgstr ""
 
@@ -1403,6 +1889,10 @@ msgstr ""
 msgid ""
 "If you don't want to display metrics you can disable them all, or you can "
 "disable the display of citation metrics below"
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_article.html:37
+msgid "Enable the display of the dates an article was submitted and accepted."
 msgstr ""
 
 #: src/templates/admin/elements/forms/group_journal.html:32
@@ -1437,7 +1927,7 @@ msgstr "Allforio "
 msgid "How should editors and staff members get help with Janeway?"
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_journal_images.html:10
+#: src/templates/admin/elements/forms/group_journal_images.html:11
 msgid ""
 "For details about where each image appears, see the Janeway documentation: "
 msgstr ""
@@ -1456,15 +1946,15 @@ msgstr ""
 msgid "Review Form manager"
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_review.html:29
+#: src/templates/admin/elements/forms/group_review.html:28
 msgid "Settings here determine the review form experience."
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_review.html:41
+#: src/templates/admin/elements/forms/group_review.html:40
 msgid "Settings here determine the review experience for editors."
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_review.html:49
+#: src/templates/admin/elements/forms/group_review.html:48
 msgid "Settings here determine the review experience for authors."
 msgstr ""
 
@@ -1478,15 +1968,31 @@ msgid ""
 "Agreement that authors accept."
 msgstr ""
 
-#: src/templates/admin/elements/fundref/fundref.html:24
+#: src/templates/admin/elements/forms/messages_in_callout.html:11
+msgid "Problems processing the form"
+msgstr ""
+
+#: src/templates/admin/elements/fundref/fundref.html:22
 msgid "Funder"
 msgstr "Cyllidwr "
 
-#: src/templates/admin/elements/fundref/fundref.html:61
-#: src/templates/admin/elements/fundref/fundref.html:82
-#: src/templates/admin/elements/fundref/fundref.html:166
-#: src/templates/admin/submission/submit_funding.html:85
-#: src/templates/admin/submission/submit_funding.html:108
+#: src/templates/admin/elements/fundref/fundref.html:23
+#: src/templates/admin/submission/submit_funding.html:73
+#: src/templates/common/elements/funder_info_for_readers.html:5
+#, fuzzy
+#| msgid "Funder DOI"
+msgid "FundRef ID"
+msgstr "DOI Cyllidwr"
+
+#: src/templates/admin/elements/fundref/fundref.html:24
+#, fuzzy
+#| msgid "Add funder"
+msgid "Add Funder"
+msgstr "Ychwanegu cyllidwr"
+
+#: src/templates/admin/elements/fundref/fundref.html:39
+#: src/templates/admin/submission/submit_funding.html:121
+#: src/templates/admin/submission/submit_funding.html:128
 msgid "Add funder"
 msgstr "Ychwanegu cyllidwr"
 
@@ -1506,6 +2012,34 @@ msgstr ""
 #| msgid "Your article title"
 msgid "Sort Articles"
 msgstr "Teitl eich erthygl"
+
+#: src/templates/admin/elements/list_filters.html:7
+#, fuzzy
+#| msgid "Sort and Filter"
+msgid "Search and filter"
+msgstr "Trefnu a Hidlo"
+
+#: src/templates/admin/elements/list_filters.html:28
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
+msgid "Apply"
+msgstr ""
+
+#: src/templates/admin/elements/list_filters.html:32
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:10
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:11
+#: src/themes/material/templates/elements/journal/article_list_filters.html:15
+#, fuzzy
+#| msgid "Clear Filters"
+msgid "Clear all"
+msgstr "Clirio Hidlyddion"
+
+#: src/templates/admin/elements/metadata.html:143
+#: src/templates/admin/submission/edit/metadata.html:244
+#: src/templates/admin/submission/submit_funding.html:75
+#: src/templates/common/elements/funder_info_for_readers.html:7
+msgid "Funding Statement"
+msgstr ""
 
 #: src/templates/admin/elements/move_to_next_modal.html:7
 msgid "Workflow Info"
@@ -1542,7 +2076,7 @@ msgid "Save Publisher Note"
 msgstr "Cadw Nodyn Cyhoeddwr"
 
 #: src/templates/admin/elements/repository/metadata_form.html:39
-#: src/templates/admin/repository/submit/start.html:73 src/utils/forms.py:55
+#: src/templates/admin/repository/submit/start.html:71 src/utils/forms.py:60
 msgid "Hit Enter to add a new keyword."
 msgstr "Pwyswch Enter i ychwanegu gair allweddol newydd."
 
@@ -1552,10 +2086,10 @@ msgid "Additional Fields"
 msgstr "Meysydd Ychwanegol "
 
 #: src/templates/admin/elements/submit/author.html:8
-#: src/templates/admin/repository/submit/authors.html:65
-#: src/templates/admin/repository/submit/authors.html:116
-#: src/templates/admin/repository/submit/authors.html:123
-#: src/templates/admin/submission/submit_authors.html:49
+#: src/templates/admin/repository/submit/authors.html:62
+#: src/templates/admin/repository/submit/authors.html:113
+#: src/templates/admin/repository/submit/authors.html:120
+#: src/templates/admin/submission/submit_authors.html:54
 #: src/themes/OLH/templates/elements/submit/author.html:8
 msgid "Add New Author"
 msgstr "Ychwanegu Awdur Newydd"
@@ -1565,14 +2099,13 @@ msgstr "Ychwanegu Awdur Newydd"
 msgid "Add Author"
 msgstr "Ychwanegu Awdur"
 
-#: src/templates/admin/elements/submit/file.html:7
+#: src/templates/admin/elements/submit/file.html:9
 #: src/themes/OLH/templates/elements/submit/file.html:6
 #: src/themes/OLH/templates/elements/submit/preprint_file.html:6
 msgid "Add New File"
 msgstr "Ychwanegu Ffeil Newydd"
 
-#: src/templates/admin/elements/submit/file.html:35
-#: src/templates/admin/elements/submit/file.html:51
+#: src/templates/admin/elements/submit/file.html:33
 #: src/themes/OLH/templates/elements/submit/file.html:25
 #: src/themes/OLH/templates/elements/submit/preprint_file.html:25
 msgid "Add File"
@@ -1624,6 +2157,7 @@ msgstr "Manylion Cyswllt"
 #: src/themes/clean/templates/journal/contact.html:5
 #: src/themes/clean/templates/journal/contact.html:21
 #: src/themes/clean/templates/press/nav.html:53
+#: src/themes/hourglass/templates/press/contact.html:4
 #: src/themes/material/templates/core/nav.html:42
 #: src/themes/material/templates/core/nav.html:103
 #: src/themes/material/templates/journal/contact.html:5
@@ -1633,14 +2167,6 @@ msgstr "Manylion Cyswllt"
 msgid "Contact"
 msgstr "Cysylltu"
 
-#: src/core/models.py:1492
-#: src/templates/admin/journal/contact.html:38
-#: src/themes/OLH/templates/journal/contact.html:30
-#: src/themes/OLH/templates/press/journal/contact.html:22
-#: src/themes/clean/templates/journal/contact.html:27
-msgid "Who would you like to contact?"
-msgstr "Pwy hoffech gysylltu â nhw?"
-
 #: src/templates/admin/journal/contact.html:52
 #: src/themes/OLH/templates/journal/contact.html:39
 #: src/themes/OLH/templates/press/journal/contact.html:30
@@ -1649,39 +2175,39 @@ msgstr "Pwy hoffech gysylltu â nhw?"
 msgid "Send Message"
 msgstr "Anfon Neges"
 
-#: src/templates/admin/journal/manage/archive_article.html:24
+#: src/templates/admin/journal/manage/archive_article.html:25
 #, fuzzy
 #| msgid "Edit Article"
 msgid "Edit Article Images"
 msgstr "Golygu Erthygl"
 
-#: src/templates/admin/journal/manage/archive_article.html:26
+#: src/templates/admin/journal/manage/archive_article.html:27
 #, fuzzy
 #| msgid "Publications"
 msgid "Edit Publication Info"
 msgstr "Cyhoeddiadau"
 
-#: src/templates/admin/journal/manage/archive_article.html:28
+#: src/templates/admin/journal/manage/archive_article.html:29
 #, fuzzy
 #| msgid "Latest Articles & News"
 msgid "Remote Article View"
 msgstr "Erthyglau a Newyddion Diweddaraf"
 
-#: src/templates/admin/journal/manage/archive_article.html:178
+#: src/templates/admin/journal/manage/archive_article.html:179
 msgid "Undo Article Rejection"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:182
+#: src/templates/admin/journal/manage/archive_article.html:183
 msgid "Review"
 msgstr "Adolygu"
 
-#: src/templates/admin/journal/manage/archive_article.html:184
+#: src/templates/admin/journal/manage/archive_article.html:185
 #, fuzzy
 #| msgid "Assign"
 msgid "Unassigned"
 msgstr "Neilltuo"
 
-#: src/templates/admin/journal/manage/archive_article.html:186
+#: src/templates/admin/journal/manage/archive_article.html:187
 #, python-format
 msgid ""
 "You will have the opportunity to send an email to the author, and then the "
@@ -1706,52 +2232,26 @@ msgid ""
 "                 "
 msgstr ""
 
-#: src/templates/admin/journal/submissions.html:35
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:48
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:50
-#: src/themes/OLH/templates/core/accounts/register.html:5
-#: src/themes/OLH/templates/core/accounts/register.html:96
-#: src/themes/OLH/templates/core/base.html:141
-#: src/themes/OLH/templates/core/nav.html:77
-#: src/themes/OLH/templates/journal/submissions.html:30
-#: src/themes/OLH/templates/press/nav.html:58
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:41
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:43
-#: src/themes/clean/templates/core/accounts/register.html:5
-#: src/themes/clean/templates/core/accounts/register.html:39
-#: src/themes/clean/templates/core/nav.html:104
-#: src/themes/clean/templates/journal/submissions.html:17
-#: src/themes/clean/templates/press/nav.html:79
-#: src/themes/material/templates/core/accounts/register.html:6
-#: src/themes/material/templates/core/accounts/register.html:44
-#: src/themes/material/templates/core/nav.html:79
-#: src/themes/material/templates/core/nav.html:134
-#: src/themes/material/templates/journal/submissions.html:33
-#: src/themes/material/templates/press/nav.html:67
-#: src/themes/material/templates/press/nav.html:115
-#: src/themes/material/templates/repository/nav.html:60
-msgid "Register"
-msgstr "Cofrestru "
-
 #: src/templates/admin/journal/submissions.html:36
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:28
-#: src/themes/OLH/templates/core/base.html:141
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/themes/OLH/templates/core/base.html:142
 #: src/themes/OLH/templates/core/login.html:6
-#: src/themes/OLH/templates/core/nav.html:76
+#: src/themes/OLH/templates/core/nav.html:75
 #: src/themes/OLH/templates/elements/journal_footer.html:30
 #: src/themes/OLH/templates/journal/become_reviewer.html:16
 #: src/themes/OLH/templates/journal/submissions.html:31
 #: src/themes/OLH/templates/press/core/login.html:5
 #: src/themes/OLH/templates/press/elements/press_footer.html:15
 #: src/themes/OLH/templates/press/nav.html:57
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:19
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:23
 #: src/themes/clean/templates/core/login.html:5
 #: src/themes/clean/templates/core/nav.html:103
-#: src/themes/clean/templates/elements/journal_footer.html:41
+#: src/themes/clean/templates/elements/journal_footer.html:43
 #: src/themes/clean/templates/elements/press_footer.html:19
 #: src/themes/clean/templates/journal/become_reviewer.html:13
 #: src/themes/clean/templates/journal/submissions.html:18
 #: src/themes/clean/templates/press/nav.html:77
+#: src/themes/hourglass/templates/core/accounts/login.html:11
 #: src/themes/material/templates/core/login.html:5
 #: src/themes/material/templates/core/login.html:42
 #: src/themes/material/templates/core/nav.html:78
@@ -1765,7 +2265,7 @@ msgid "Login"
 msgstr "Mewngofnodi"
 
 #: src/templates/admin/journal/submissions.html:38
-#: src/templates/admin/submission/start.html:72
+#: src/templates/admin/submission/start.html:77
 #: src/themes/OLH/templates/core/nav.html:43
 #: src/themes/OLH/templates/journal/submissions.html:32
 #: src/themes/clean/templates/core/nav.html:71
@@ -1786,10 +2286,13 @@ msgid "Licences"
 msgstr "Trwyddedau"
 
 #: src/templates/admin/journal/submissions.html:48
+#: src/templates/admin/submission/submit_info.html:109
 #: src/themes/OLH/templates/journal/submissions.html:40
 #: src/themes/clean/templates/journal/submissions.html:27
 #: src/themes/material/templates/journal/submissions.html:46
-msgid "allows the following licences for submission"
+#, fuzzy
+#| msgid "allows the following licences for submission"
+msgid "The following licences are allowed:"
 msgstr "yn caniatáu’r trwyddedau canlynol i’r cyflwyniad"
 
 #: src/templates/admin/press/edit_press_journal_description.html:5
@@ -1800,8 +2303,9 @@ msgstr ""
 #: src/templates/admin/press/edit_press_journal_description.html:11
 #: src/templates/admin/press/edit_press_journal_description.html:17
 #: src/templates/admin/repository/article.html:215
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 #: src/templates/admin/review/view_review.html:112
+#: src/templates/admin/submission/submit_funding.html:76
 #: src/themes/OLH/templates/elements/edit_author.html:4
 msgid "Edit"
 msgstr "Golygu"
@@ -1818,12 +2322,6 @@ msgid ""
 "description is used."
 msgstr ""
 
-#: src/templates/admin/press/edit_press_journal_description.html:24
-#: src/templates/admin/review/view_review.html:168
-#: src/templates/admin/review/view_review.html:189
-msgid "Save"
-msgstr ""
-
 #: src/templates/admin/press/edit_press_journal_description.html:25
 #, fuzzy
 #| msgid "Description"
@@ -1838,31 +2336,24 @@ msgstr "Cyfyngir pob cylch prawfddarllen i"
 msgid "proofreaders"
 msgstr "prawfddarllenwyr"
 
-#: src/templates/admin/repository/article.html:212
-#: src/templates/admin/repository/author_article.html:91
-#: src/templates/admin/repository/submit/authors.html:79
-#: src/templates/admin/submission/submit_authors.html:64
-#: src/templates/admin/submission/submit_funding.html:49
-msgid "Name"
-msgstr "Enw"
-
 #: src/templates/admin/repository/article.html:214
 #: src/templates/admin/repository/author_article.html:93
-#: src/templates/admin/repository/submit/authors.html:81
-#: src/templates/admin/submission/submit_review.html:102
-#: src/themes/OLH/templates/core/accounts/public_profile.html:14
-#: src/themes/clean/templates/core/accounts/public_profile.html:14
-#: src/themes/material/templates/core/accounts/public_profile.html:14
+#: src/templates/admin/repository/submit/authors.html:78
+#: src/templates/admin/submission/submit_review.html:118
+#: src/themes/OLH/templates/core/accounts/public_profile.html:42
+#: src/themes/clean/templates/core/accounts/public_profile.html:18
+#: src/themes/material/templates/core/accounts/public_profile.html:18
 msgid "Affiliation"
 msgstr "Cyswllt"
 
 #: src/templates/admin/repository/article.html:216
-#: src/templates/admin/repository/submit/authors.html:82
+#: src/templates/admin/repository/submit/authors.html:79
+#: src/templates/admin/submission/submit_funding.html:77
 msgid "Delete"
 msgstr ""
 
 #: src/templates/admin/repository/article.html:239
-#: src/templates/admin/repository/submit/authors.html:97
+#: src/templates/admin/repository/submit/authors.html:94
 #, fuzzy
 #| msgid "No funders added."
 msgid "No authors added."
@@ -1884,37 +2375,37 @@ msgstr ""
 msgid "Add Authors to"
 msgstr "Ychwanegu awduron at"
 
-#: src/templates/admin/repository/submit/authors.html:23
-#: src/themes/clean/templates/journal/article.html:217
+#: src/templates/admin/repository/submit/authors.html:20
+#: src/themes/clean/templates/journal/article.html:219
 msgid "Information"
 msgstr "Gwybodaeth"
 
-#: src/templates/admin/repository/submit/authors.html:27
+#: src/templates/admin/repository/submit/authors.html:24
 msgid ""
 "You can add yourself as an author using the button below. This will copy "
 "metadata from your profile to create a"
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:27
+#: src/templates/admin/repository/submit/authors.html:24
 msgid "author record."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:28
+#: src/templates/admin/repository/submit/authors.html:25
 msgid ""
 "You can search the database of existing authors and add them as authors."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:29
+#: src/templates/admin/repository/submit/authors.html:26
 msgid "You can create a new record for an author using the form below."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:34
-#: src/templates/admin/submission/submit_authors.html:46
+#: src/templates/admin/repository/submit/authors.html:31
+#: src/templates/admin/submission/submit_authors.html:51
 msgid "Add Self as Author"
 msgstr "Ychwanegu Eich Hun fel Awdur"
 
-#: src/templates/admin/repository/submit/authors.html:37
-#: src/templates/admin/submission/submit_authors.html:44
+#: src/templates/admin/repository/submit/authors.html:34
+#: src/templates/admin/submission/submit_authors.html:49
 msgid ""
 "By default, your account is the owner of this submission, but is not an "
 "Author on record. You can add yourself using the button below."
@@ -1922,26 +2413,26 @@ msgstr ""
 "Eich cyfrif chi yw perchennog y cyflwyniad hwn yn ddiofyn, ond nid yw’n "
 "Awdur ar gofnod. Gallwch ychwanegu eich hun yn defnyddio’r botwm isod."
 
-#: src/templates/admin/repository/submit/authors.html:45
+#: src/templates/admin/repository/submit/authors.html:42
 #, fuzzy
 #| msgid "Search for Existing Authors"
 msgid "Search for an Author"
 msgstr "Chwilio am Awduron"
 
-#: src/templates/admin/repository/submit/authors.html:48
+#: src/templates/admin/repository/submit/authors.html:45
 msgid ""
 "You can search by email or ORCiD. eg. person@example.com or "
 "0000-0003-2126-266X."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/repository/submit/authors.html:58
 #, fuzzy
 #| msgid "Add Author"
 msgid "Add an Author"
 msgstr "Ychwanegu Awdur"
 
-#: src/templates/admin/repository/submit/authors.html:64
-#: src/templates/admin/submission/submit_authors.html:48
+#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/submission/submit_authors.html:53
 msgid ""
 "If you cannot find the author record by searching, and you are not the only "
 "author, you can add one by clicking the button below. This will open a popup "
@@ -1951,40 +2442,40 @@ msgstr ""
 "awdur, gallwch ychwanegu un drwy glicio’r botwm isod. Bydd hyn yn agor modal "
 "popup i chi allu cwblhau eu manylion."
 
-#: src/templates/admin/repository/submit/authors.html:70
+#: src/templates/admin/repository/submit/authors.html:67
 #: src/themes/OLH/templates/journal/article.html:27
 #: src/themes/OLH/templates/journal/article.html:63
-#: src/themes/OLH/templates/journal/article.html:158
-#: src/themes/OLH/templates/journal/article.html:332
+#: src/themes/OLH/templates/journal/article.html:161
+#: src/themes/OLH/templates/journal/article.html:313
 #: src/themes/OLH/templates/journal/authors.html:4
 #: src/themes/OLH/templates/journal/authors.html:5
 #: src/themes/OLH/templates/journal/authors.html:11
 #: src/themes/OLH/templates/journal/print.html:15
 #: src/themes/OLH/templates/repository/preprint.html:33
 #: src/themes/clean/templates/journal/article.html:37
-#: src/themes/clean/templates/journal/article.html:167
+#: src/themes/clean/templates/journal/article.html:153
 #: src/themes/clean/templates/journal/authors.html:9
 #: src/themes/clean/templates/journal/print.html:15
-#: src/themes/material/templates/journal/article.html:269
+#: src/themes/material/templates/journal/article.html:250
 #: src/themes/material/templates/journal/authors.html:5
 #: src/themes/material/templates/journal/authors.html:6
 #: src/themes/material/templates/journal/authors.html:10
 #: src/themes/material/templates/preprints/article.html:28
-#: src/themes/material/templates/repository/preprint.html:149
+#: src/themes/material/templates/repository/preprint.html:147
 msgid "Authors"
 msgstr "Awduron"
 
-#: src/templates/admin/repository/submit/authors.html:73
+#: src/templates/admin/repository/submit/authors.html:70
 msgid ""
 "You can reorder the authors by dragging and dropping rows in the table below."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:103
+#: src/templates/admin/repository/submit/authors.html:100
 msgid "Once you have added all of your authors you can complete this stage."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:106
-msgid "Complete Step 2 of 3"
+#: src/templates/admin/repository/submit/authors.html:103
+msgid "Complete Step 2 of 4"
 msgstr ""
 
 #: src/templates/admin/repository/submit/files.html:8
@@ -1993,65 +2484,59 @@ msgstr ""
 msgid "Upload Files for"
 msgstr "Uwchlwytho ffeiliau"
 
-#: src/templates/admin/repository/submit/files.html:29
+#: src/templates/admin/repository/submit/files.html:25
 msgid "You can use the form below to select and upload your manuscript file."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:43
 #, fuzzy
 #| msgid "Supplementary Files"
 msgid "Supplementary files"
 msgstr "Ffeiliau Atodol"
 
-#: src/templates/admin/repository/submit/files.html:50
+#: src/templates/admin/repository/submit/files.html:46
 msgid "Optional links to externaly hosted supplementary files."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:51
-#: src/templates/admin/repository/submit/files.html:101
-#: src/templates/admin/repository/submit/files.html:108
+#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:97
+#: src/templates/admin/repository/submit/files.html:104
 #: src/templates/admin/repository/supp_files_body.html:53
 #, fuzzy
 #| msgid "Supplementary Files"
 msgid "Add New Supplementary File"
 msgstr "Ffeiliau Atodol"
 
-#: src/templates/admin/repository/submit/files.html:60
+#: src/templates/admin/repository/submit/files.html:56
 msgid ""
 "If you want to change this file you can upload a new one and it will be "
 "overwritten."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:93
-msgid "Complete Step 3 of 3"
+#: src/templates/admin/repository/submit/files.html:89
+msgid "Complete Step 3 of 4"
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:120
+#: src/templates/admin/repository/submit/files.html:116
 #, fuzzy
 #| msgid "Sections submission information"
 msgid "Submission Information"
 msgstr "Gwybodaeth cyflwyno adrannau "
 
-#: src/templates/admin/repository/submit/review.html:8
-#, fuzzy
-#| msgid "Submission Checklist"
-msgid "Submission Complete"
-msgstr "Rhestr Wirio Cyflwyniad"
-
-#: src/templates/admin/repository/submit/start.html:26
+#: src/templates/admin/repository/submit/start.html:24
 #, fuzzy
 #| msgid "Submission Started"
 msgid "Submission Agreement"
 msgstr "Cyflwyniad wedi Dechrau"
 
-#: src/templates/admin/repository/submit/start.html:38
+#: src/templates/admin/repository/submit/start.html:36
 #: src/themes/OLH/templates/repository/preprint.html:122
 #: src/themes/material/templates/preprints/article.html:121
 msgid "Metadata"
 msgstr "Metadata"
 
-#: src/templates/admin/repository/submit/start.html:94
-msgid "Complete Step 1 of 3"
+#: src/templates/admin/repository/submit/start.html:92
+msgid "Complete Step 1 of 4"
 msgstr ""
 
 #: src/templates/admin/repository/version_queue.html:19
@@ -2063,17 +2548,25 @@ msgstr ""
 #: src/templates/admin/review/add_review_assignment.html:27
 msgid ""
 "\n"
-"                        You can select a reviewer using the radio buttons in "
-"the first column and complete the section under \"Set Options\".\n"
-"                        If you cannot find the reviewer you want in this "
-"list you can use \"Enroll Existing User\" to search the database and give "
-"users the Reviewer role, or \"Add New Reviewer\" to create a new account for "
-"a reviewer (this process is silent, they will not receive an account "
-"creation email).\n"
-"                        "
+"                                You can select a reviewer using the radio\n"
+"                                buttons in the first column and complete "
+"the\n"
+"                                section under 'Set Options'.\n"
+"                                If you cannot find the reviewer you want in\n"
+"                                this list you can use 'Enroll Existing User' "
+"to\n"
+"                                search the database and give users the "
+"Reviewer\n"
+"                                role, or 'Add New Reviewer' to create a new\n"
+"                                account for a reviewer (this process is "
+"silent,\n"
+"                                so they will not receive an account "
+"creation\n"
+"                                email).\n"
+"                            "
 msgstr ""
 
-#: src/templates/admin/review/decision.html:44
+#: src/templates/admin/review/decision.html:57
 msgid ""
 "Note: This article has completed reviews that have not been made available "
 "to the author:"
@@ -2092,33 +2585,33 @@ msgstr ""
 msgid "No"
 msgstr "Nodwch"
 
-#: src/templates/admin/review/in_review.html:25
+#: src/templates/admin/review/in_review.html:23
 #, fuzzy
 #| msgid "This article has not been peer reviewed."
 msgid "This article is not yet in the review stage"
 msgstr "Nid yw’r erthygl hon wedi’i chymheirio."
 
-#: src/templates/admin/review/in_review.html:27
+#: src/templates/admin/review/in_review.html:25
 msgid "Before you can move this paper into review you need to"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:28
+#: src/templates/admin/review/in_review.html:26
 msgid "assign an editor"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
 msgid ""
 "This paper has not had an automatic plagiarism check. If you wish to do so "
 "you can run a"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
 msgid "Similarity Check via iThenticate"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:68
+#: src/templates/admin/review/in_review.html:66
 #, python-format
 msgid ""
 "\n"
@@ -2127,7 +2620,7 @@ msgid ""
 "                                            "
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:217
+#: src/templates/admin/review/in_review.html:215
 msgid ""
 "\n"
 "                                The latest manuscript and figure files for "
@@ -2136,19 +2629,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:287
+#: src/templates/admin/review/in_review.html:285
 msgid "Move to Next Stage"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:20
+#: src/templates/admin/review/projected_issue.html:27
 msgid "Save Projected Issue"
 msgstr "Cadw Rhifyn a Ragamcanir"
 
-#: src/templates/admin/review/projected_issue.html:30
+#: src/templates/admin/review/projected_issue.html:37
 msgid "What is this for?"
 msgstr "Beth yw diben hwn?"
 
-#: src/templates/admin/review/projected_issue.html:31
+#: src/templates/admin/review/projected_issue.html:38
 msgid ""
 "The projected issue field can be used internally to keep track of plans and "
 "communicate with typesetters, without affecting issue assignment or "
@@ -2156,21 +2649,21 @@ msgid ""
 "to issues on a rolling basis and publish them individually."
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:32
+#: src/templates/admin/review/projected_issue.html:39
 msgid ""
 "You can assign articles directly to issues in the prepublication stage or "
 "through "
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:32
+#: src/templates/admin/review/projected_issue.html:39
 msgid "issue management"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:33
+#: src/templates/admin/review/projected_issue.html:40
 msgid "How does it work?"
 msgstr "Sut mae’n gweithio?"
 
-#: src/templates/admin/review/projected_issue.html:34
+#: src/templates/admin/review/projected_issue.html:41
 #, fuzzy
 #| msgid ""
 #| "Select an issue from the drop down on the left and press save, this "
@@ -2182,11 +2675,11 @@ msgstr ""
 "Dewiswch rifyn o’r gwymplen ar y chwith a phwyso cadw, bydd y rhifyn a "
 "ragamcanir ar gyfer yr erthygl nawr wedi’i osod."
 
-#: src/templates/admin/review/projected_issue.html:35
+#: src/templates/admin/review/projected_issue.html:42
 msgid "Can I unset a projected issue?"
 msgstr "A allaf ddadosod rhifyn a ragamcanir?"
 
-#: src/templates/admin/review/projected_issue.html:36
+#: src/templates/admin/review/projected_issue.html:43
 #, fuzzy
 #| msgid "Yes, simply select the blank option (-------) from the drop down."
 msgid "Yes, you can select the blank option (-------) from the dropdown."
@@ -2200,24 +2693,24 @@ msgid ""
 "revisions once you click 'Submit Revisions'"
 msgstr ""
 
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 msgid "Assign"
 msgstr "Neilltuo"
 
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 msgid "Projected Issue"
 msgstr "Rhifyn a Ragamcanir"
 
-#: src/templates/admin/review/unassigned_article.html:122
+#: src/templates/admin/review/unassigned_article.html:125
 msgid "This article is projected to be published as part of"
 msgstr "Rhagamcanir y caiff yr erthygl hon ei chyhoeddi fel rhan o "
 
-#: src/templates/admin/review/unassigned_article.html:124
+#: src/templates/admin/review/unassigned_article.html:127
 msgid "This article is not projected to be published as part of any issue."
 msgstr ""
 "Ni ragamcanir y caiff yr erthygl hon ei chyhoeddi fel rhan o unrhyw rifyn."
 
-#: src/templates/admin/review/unassigned_article.html:137
+#: src/templates/admin/review/unassigned_article.html:140
 msgid ""
 "To check an article for possible plagiarism, you can send an article for an "
 "automated Similarity Check via iThenticate by clicking Send below. The "
@@ -2302,7 +2795,6 @@ msgid "Withdrawn"
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:63
-#: src/themes/material/templates/journal/article.html:394
 msgid "Accepted"
 msgstr "Derbyniwyd"
 
@@ -2382,7 +2874,7 @@ msgstr ""
 msgid "Suggested Reviewers"
 msgstr "Cymheiriwyd"
 
-#: src/templates/admin/submission/edit/metadata.html:178
+#: src/templates/admin/submission/edit/metadata.html:195
 msgid ""
 "\n"
 "                            You can search the <a href=\"https://www."
@@ -2392,7 +2884,7 @@ msgid ""
 "                        "
 msgstr ""
 
-#: src/templates/admin/submission/manager/delete_license.html:26
+#: src/templates/admin/submission/manager/delete_license.html:25
 msgid ""
 "This license is currently used by the following articles. If you delete it "
 "these articles will no longer have a license listed."
@@ -2401,9 +2893,13 @@ msgstr ""
 "bryd. Os byddwch yn ei dileu ni fydd gan yr erthyglau hyn drwydded wedi’i "
 "rhestru bellach."
 
-#: src/templates/admin/submission/manager/delete_license.html:27
+#: src/templates/admin/submission/manager/delete_license.html:26
+#, fuzzy
+#| msgid ""
+#| "You should only delete this license if you are absolutley sure you want "
+#| "to remove it."
 msgid ""
-"You should only delete this license if you are absolutley sure you want to "
+"You should only delete this license if you are absolutely sure you want to "
 "remove it."
 msgstr ""
 "Dim ond os ydych chi’n gwbl siŵr eich bod am ei thynnu y dylech ddileu’r "
@@ -2422,43 +2918,43 @@ msgid ""
 "Please carefully read through the statements below before checking items"
 msgstr "Darllenwch y datganiadau isod yn ofalus cyn gwirio’r eitemau"
 
-#: src/templates/admin/submission/start.html:24
+#: src/templates/admin/submission/start.html:29
 msgid ""
 "All authors must agree to the below statements in order to submit an article "
 "to"
 msgstr ""
 
-#: src/templates/admin/submission/start.html:24
+#: src/templates/admin/submission/start.html:29
 msgid ""
 "If you do not agree with these terms you will be unable to proceed with your "
 "submission."
 msgstr ""
 
-#: src/templates/admin/submission/start.html:29
+#: src/templates/admin/submission/start.html:34
 msgid "Publication Fees"
 msgstr "Ffioedd Cyhoeddi"
 
-#: src/templates/admin/submission/start.html:36
+#: src/templates/admin/submission/start.html:41
 msgid "Author(s) agrees to the above statement"
 msgstr "Mae’r awdur(on) yn cytuno â’r datganiad uchod"
 
-#: src/templates/admin/submission/start.html:42
+#: src/templates/admin/submission/start.html:47
 msgid "Submission Checklist"
 msgstr "Rhestr Wirio Cyflwyniad"
 
-#: src/templates/admin/submission/start.html:48
+#: src/templates/admin/submission/start.html:53
 msgid "Author(s) confirms that this article adheres to the above requirements"
 msgstr ""
 "Mae’r awdur(on) yn cadarnhau bod yr erthygl hon yn cadw at y gofynion uchod "
 
-#: src/templates/admin/submission/start.html:54
+#: src/templates/admin/submission/start.html:59
 msgid "Copyright Notice"
 msgstr "Hysbysiad Hawlfraint"
 
-#: src/templates/admin/submission/start.html:66
-#: src/themes/OLH/templates/journal/article.html:428
-#: src/themes/clean/templates/journal/article.html:255
-#: src/themes/material/templates/journal/article.html:424
+#: src/templates/admin/submission/start.html:71
+#: src/themes/OLH/templates/journal/article.html:419
+#: src/themes/clean/templates/journal/article.html:265
+#: src/themes/material/templates/journal/article.html:400
 msgid "Competing Interests"
 msgstr "Buddiannau sy’n Gwrthdaro"
 
@@ -2468,11 +2964,11 @@ msgstr "Buddiannau sy’n Gwrthdaro"
 msgid "Author Information"
 msgstr "Gwybodaeth Awdur "
 
-#: src/templates/admin/submission/submit_authors.html:18
+#: src/templates/admin/submission/submit_authors.html:23
 msgid "Search for Existing Authors"
 msgstr "Chwilio am Awduron"
 
-#: src/templates/admin/submission/submit_authors.html:25
+#: src/templates/admin/submission/submit_authors.html:30
 msgid ""
 "Search for a user using email address or ORCiD. If a user is matched, they "
 "will be automatically added as an author. This search only returns exact "
@@ -2482,12 +2978,12 @@ msgstr ""
 "defnyddiwr ei ganfod, caiff ei ychwanegu’n awtomatig fel awdur. Dim ond "
 "achosion o gydweddu’n union y bydd y chwiliad hwn yn eu canfod."
 
-#: src/templates/admin/submission/submit_authors.html:31
+#: src/templates/admin/submission/submit_authors.html:36
 msgid "Search by email address or ORCiD"
 msgstr "Chwilio yn ôl ebost neu ORCiD"
 
-#: src/templates/admin/submission/submit_authors.html:35
-#: src/themes/OLH/templates/core/base.html:153
+#: src/templates/admin/submission/submit_authors.html:40
+#: src/themes/OLH/templates/core/base.html:154
 #: src/themes/OLH/templates/journal/full-text-search.html:8
 #: src/themes/OLH/templates/journal/full-text-search.html:10
 #: src/themes/OLH/templates/journal/full-text-search.html:70
@@ -2510,23 +3006,23 @@ msgstr "Chwilio yn ôl ebost neu ORCiD"
 msgid "Search"
 msgstr "Chwilio"
 
-#: src/templates/admin/submission/submit_authors.html:40
+#: src/templates/admin/submission/submit_authors.html:45
 msgid "Add Authors"
 msgstr "Ychwanegu Awduron"
 
-#: src/templates/admin/submission/submit_authors.html:55
+#: src/templates/admin/submission/submit_authors.html:60
 msgid "Current Authors"
 msgstr "Awduron Cyfredol"
 
-#: src/templates/admin/submission/submit_authors.html:57
+#: src/templates/admin/submission/submit_authors.html:62
 msgid "Drag and drop an author to re-order them."
 msgstr "Llusgwch a gollwng awdur i’w ail-archebu."
 
-#: src/templates/admin/submission/submit_authors.html:81
+#: src/templates/admin/submission/submit_authors.html:86
 msgid "No authors yet, add one!"
 msgstr "Dim awduron eto, ychwanegwch un!"
 
-#: src/templates/admin/submission/submit_authors.html:88
+#: src/templates/admin/submission/submit_authors.html:93
 msgid ""
 "You are required to select a main author, this author will receive the "
 "communications regarding your articles process through our systems. This "
@@ -2536,14 +3032,14 @@ msgstr ""
 "yn ymwneud â chynnydd eich erthygl drwy’n systemau. Dyw hi ddim yn ofynnol "
 "mai chi yw hwn."
 
-#: src/templates/admin/submission/submit_authors.html:89
+#: src/templates/admin/submission/submit_authors.html:94
 msgid "Select main author"
 msgstr "Dewis prif awdur"
 
-#: src/templates/admin/submission/submit_authors.html:99
-#: src/templates/admin/submission/submit_files.html:112
-#: src/templates/admin/submission/submit_funding.html:75
-#: src/templates/admin/submission/submit_info.html:83
+#: src/templates/admin/submission/submit_authors.html:104
+#: src/templates/admin/submission/submit_files.html:118
+#: src/templates/admin/submission/submit_funding.html:111
+#: src/templates/admin/submission/submit_info.html:93
 msgid "Save and Continue"
 msgstr "Cadw a Pharhau"
 
@@ -2551,77 +3047,90 @@ msgstr "Cadw a Pharhau"
 msgid "Upload files"
 msgstr "Uwchlwytho ffeiliau"
 
-#: src/templates/admin/submission/submit_files.html:33
-#: src/templates/admin/submission/submit_files.html:74
+#: src/templates/admin/submission/submit_files.html:39
+#: src/templates/admin/submission/submit_files.html:80
 msgid "Upload"
 msgstr "Uwchlwytho "
 
-#: src/templates/admin/submission/submit_files.html:41
-#: src/templates/admin/submission/submit_files.html:81
-#: src/templates/admin/submission/submit_review.html:121
+#: src/templates/admin/submission/submit_files.html:47
+#: src/templates/admin/submission/submit_files.html:87
+#: src/templates/admin/submission/submit_review.html:137
 msgid "File Name"
 msgstr "Enw’r Ffeil"
 
-#: src/templates/admin/submission/submit_files.html:59
-#: src/templates/admin/submission/submit_files.html:97
+#: src/templates/admin/submission/submit_files.html:65
+#: src/templates/admin/submission/submit_files.html:103
 msgid "No files uploaded"
 msgstr "Dim ffeiliau wedi’u huwchlwytho"
 
 #: src/templates/admin/submission/submit_funding.html:7
-#: src/templates/admin/submission/submit_info.html:6
-#: src/templates/admin/submission/submit_review.html:43
-msgid "Article Info"
-msgstr "Gwybodaeth am yr Erthygl"
+#, fuzzy
+#| msgid "License Information"
+msgid "Funding Information"
+msgstr "Gwybodaeth y Drwydded"
 
-#: src/templates/admin/submission/submit_funding.html:16
+#: src/templates/admin/submission/submit_funding.html:25
 #: src/templates/admin/submission/timeline.html:36
 #: src/templates/admin/submission/timeline.html:37
-#: src/themes/OLH/templates/journal/article.html:229
-#: src/themes/clean/templates/journal/article.html:123
-#: src/themes/material/templates/journal/article.html:151
+#: src/templates/common/elements/funder_info_for_readers.html:3
 msgid "Funding"
 msgstr "Cyllido"
 
-#: src/templates/admin/submission/submit_funding.html:20
+#: src/templates/admin/submission/submit_funding.html:30
+msgid ""
+"\n"
+"                         Here you can search the FundRef database to add "
+"grant IDs to your article's metadata. If you can't find a specific funder, "
+"you can manually enter the details. You can also edit or delete entries as "
+"necessary.\n"
+"                    "
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:36
 msgid "Add Funding Source"
 msgstr "Ychwanegu Ffynhonnell Cyllido"
 
-#: src/templates/admin/submission/submit_funding.html:27
+#: src/templates/admin/submission/submit_funding.html:47
 msgid "Search for funder"
 msgstr "Chwilio am gyllidwr"
 
-#: src/templates/admin/submission/submit_funding.html:31
+#: src/templates/admin/submission/submit_funding.html:53
 msgid "Add funder manually"
 msgstr "Ychwanegu cyllidwr â llaw"
 
-#: src/templates/admin/submission/submit_funding.html:41
+#: src/templates/admin/submission/submit_funding.html:64
 msgid "Current Funders"
 msgstr "Cyllidwyr Cyfredol"
 
-#: src/templates/admin/submission/submit_funding.html:50
+#: src/templates/admin/submission/submit_funding.html:74
 msgid "Grant Number"
 msgstr "Rhif Grant"
 
-#: src/templates/admin/submission/submit_funding.html:65
+#: src/templates/admin/submission/submit_funding.html:100
 msgid "No funders added."
 msgstr "Dim cyllidwyr wedi’u hychwanegu"
 
-#: src/templates/admin/submission/submit_info.html:16
+#: src/templates/admin/submission/submit_info.html:6
+#: src/templates/admin/submission/submit_review.html:48
+msgid "Article Info"
+msgstr "Gwybodaeth am yr Erthygl"
+
+#: src/templates/admin/submission/submit_info.html:26
 msgid "This article is a preprint"
 msgstr "Rhagargraffiad yw’r erthygl hon"
 
-#: src/templates/admin/submission/submit_info.html:21
+#: src/templates/admin/submission/submit_info.html:31
 #, fuzzy
 #| msgid "Information"
 msgid "Basic Information"
 msgstr "Gwybodaeth"
 
-#: src/templates/admin/submission/submit_info.html:58
+#: src/templates/admin/submission/submit_info.html:68
 msgid "View license information"
 msgstr "Gweld gwybodaeth y drwydded"
 
-#: src/templates/admin/submission/submit_info.html:67
-#: src/themes/OLH/templates/journal/article.html:178
+#: src/templates/admin/submission/submit_info.html:77
+#: src/themes/OLH/templates/journal/article.html:181
 #: src/themes/OLH/templates/journal/keywords.html:6
 #: src/themes/OLH/templates/journal/keywords.html:12
 #: src/themes/OLH/templates/journal/print.html:33
@@ -2641,17 +3150,13 @@ msgstr "Gweld gwybodaeth y drwydded"
 #: src/themes/material/templates/journal/search.html:50
 #: src/themes/material/templates/preprints/list.html:79
 #: src/themes/material/templates/repository/list.html:60
-#: src/themes/material/templates/repository/preprint.html:172
+#: src/themes/material/templates/repository/preprint.html:170
 msgid "Keywords"
 msgstr "Geiriau Allweddol"
 
-#: src/templates/admin/submission/submit_info.html:96
+#: src/templates/admin/submission/submit_info.html:106
 msgid "License Information"
 msgstr "Gwybodaeth y Drwydded"
-
-#: src/templates/admin/submission/submit_info.html:99
-msgid "allows the following licenses for submission"
-msgstr "caniatáu'r trwyddedau canlynol ar gyfer cyflwyno  "
 
 #: src/templates/admin/submission/submit_review.html:7
 #: src/templates/admin/submission/timeline.html:43
@@ -2663,7 +3168,7 @@ msgstr "caniatáu'r trwyddedau canlynol ar gyfer cyflwyno  "
 msgid "Review your submission"
 msgstr "Adolygu Cyflwyniad Rhagargraffiad "
 
-#: src/templates/admin/submission/submit_review.html:21
+#: src/templates/admin/submission/submit_review.html:26
 msgid ""
 "Please review your submission use the details below. If you need to make "
 "changes use the links above to move back along the submission steps. You "
@@ -2672,120 +3177,120 @@ msgid ""
 "receipt email. "
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:25
+#: src/templates/admin/submission/submit_review.html:30
 #, fuzzy
 #| msgid "Author Agreement"
 msgid "Agreements"
 msgstr "Cytundeb Awdur "
 
-#: src/templates/admin/submission/submit_review.html:29
+#: src/templates/admin/submission/submit_review.html:34
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Agreed to Publication Fees statement"
 msgstr "Ffioedd Cyhoeddi"
 
-#: src/templates/admin/submission/submit_review.html:33
+#: src/templates/admin/submission/submit_review.html:38
 #, fuzzy
 #| msgid "Submission Checklist"
 msgid "Agreed to Submission Checklist"
 msgstr "Rhestr Wirio Cyflwyniad"
 
-#: src/templates/admin/submission/submit_review.html:37
+#: src/templates/admin/submission/submit_review.html:42
 msgid "Agreed to Copyright statement"
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:59
-#: src/themes/OLH/templates/journal/article.html:175
+#: src/templates/admin/submission/submit_review.html:64
+#: src/themes/OLH/templates/journal/article.html:178
 #: src/themes/OLH/templates/journal/print.html:30
 #: src/themes/OLH/templates/repository/preprint.html:45
 #: src/themes/clean/templates/journal/article.html:78
 #: src/themes/clean/templates/journal/print.html:30
 #: src/themes/material/templates/journal/article.html:73
 #: src/themes/material/templates/preprints/article.html:43
-#: src/themes/material/templates/repository/preprint.html:157
+#: src/themes/material/templates/repository/preprint.html:155
 msgid "Abstract"
 msgstr "Crynodeb"
 
-#: src/templates/admin/submission/submit_review.html:68
+#: src/templates/admin/submission/submit_review.html:73
 msgid "Language"
 msgstr "Iaith"
 
-#: src/templates/admin/submission/submit_review.html:72
-#: src/themes/material/templates/journal/article.html:413
+#: src/templates/admin/submission/submit_review.html:77
+#: src/themes/material/templates/journal/article.html:389
 msgid "Licence"
 msgstr "Trwydded"
 
-#: src/templates/admin/submission/submit_review.html:94
+#: src/templates/admin/submission/submit_review.html:110
 msgid "Author Info"
 msgstr "Gwybodaeth Awdur"
 
-#: src/templates/admin/submission/submit_review.html:97
+#: src/templates/admin/submission/submit_review.html:113
 #, fuzzy
 #| msgid "First name"
 msgid "First Name"
 msgstr "Enw Cyntaf"
 
-#: src/templates/admin/submission/submit_review.html:98
+#: src/templates/admin/submission/submit_review.html:114
 #, fuzzy
 #| msgid "Middle name"
 msgid "Middle Name"
 msgstr "Enw Canol"
 
-#: src/templates/admin/submission/submit_review.html:99
+#: src/templates/admin/submission/submit_review.html:115
 #, fuzzy
 #| msgid "Last name"
 msgid "Last Name"
 msgstr "Cyfenw"
 
-#: src/templates/admin/submission/submit_review.html:100
+#: src/templates/admin/submission/submit_review.html:116
 #, fuzzy
 #| msgid "Email Address"
 msgid "Email Address"
 msgstr "Cyfeiriad ebost"
 
-#: src/templates/admin/submission/submit_review.html:110
+#: src/templates/admin/submission/submit_review.html:126
 #, fuzzy
 #| msgid "No Issue Editor ID supplied."
 msgid "No ORCID supplied"
 msgstr "Ni chyflenwyd ID Golygydd y Rhifyn."
 
-#: src/templates/admin/submission/submit_review.html:117
+#: src/templates/admin/submission/submit_review.html:133
 #: src/templates/admin/submission/timeline.html:28
 #: src/templates/admin/submission/timeline.html:29
 msgid "Article Files"
 msgstr "Ffeiliau Erthygl"
 
-#: src/templates/admin/submission/submit_review.html:122
+#: src/templates/admin/submission/submit_review.html:138
 #, fuzzy
 #| msgid "File Name"
 msgid "File Type"
 msgstr "Enw’r Ffeil"
 
-#: src/templates/admin/submission/submit_review.html:128
+#: src/templates/admin/submission/submit_review.html:144
 #, fuzzy
 #| msgid "Manuscript File"
 msgid "Manuscript"
 msgstr "Ffeil Llawysgrif"
 
-#: src/templates/admin/submission/submit_review.html:136
+#: src/templates/admin/submission/submit_review.html:152
 msgid "Figure/Data"
 msgstr "Ffigur/Data"
 
-#: src/templates/admin/submission/submit_review.html:146
+#: src/templates/admin/submission/submit_review.html:162
 msgid "Comments to the Editor"
 msgstr "Sylwadau i’r Golygydd"
 
-#: src/templates/admin/submission/submit_review.html:149
+#: src/templates/admin/submission/submit_review.html:165
 msgid ""
 "Before submitting you have the option to add additional comments for the "
 "editor using the field below. Only the editor will see anything you add here."
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:155
+#: src/templates/admin/submission/submit_review.html:171
 msgid "Complete"
 msgstr "Cwblhawyd "
 
-#: src/templates/admin/submission/submit_review.html:155
+#: src/templates/admin/submission/submit_review.html:171
 #: src/themes/OLH/templates/core/nav.html:40
 #: src/themes/clean/templates/core/nav.html:47
 #: src/themes/material/templates/core/nav.html:39
@@ -2802,15 +3307,38 @@ msgstr "Cyflwyniad wedi Dechrau"
 msgid "Article Information"
 msgstr "Gwybodaeth am yr Erthygl"
 
+#: src/templates/common/accounts/register_privacy_policy.html:3
+#: src/templates/common/accounts/register_privacy_policy.html:7
+#: src/templates/common/accounts/register_privacy_policy.html:11
+#: src/themes/OLH/templates/elements/journal_footer.html:25
+#: src/themes/OLH/templates/elements/journal_footer.html:27
+#: src/themes/OLH/templates/press/elements/press_footer.html:9
+#: src/themes/OLH/templates/press/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/journal_footer.html:33
+#: src/themes/clean/templates/elements/journal_footer.html:37
+#: src/themes/clean/templates/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/press_footer.html:14
+#: src/themes/hourglass/templates/custom/register.html:29
+#: src/themes/hourglass/templates/custom/register.html:35
+#: src/themes/material/templates/elements/journal_footer.html:28
+msgid "Privacy Policy"
+msgstr "Polisi Preifatrwydd"
+
+#: src/templates/common/elements/funder_info_for_readers.html:6
+#, fuzzy
+#| msgid "Funding"
+msgid "Funding ID"
+msgstr "Cyllido"
+
 #: src/templates/common/elements/journal/article_issue_list.html:4
 #: src/themes/OLH/templates/core/nav.html:25
+#: src/themes/OLH/templates/journal/issues.html:5
 #: src/themes/OLH/templates/journal/issues.html:7
-#: src/themes/OLH/templates/journal/issues.html:9
 #: src/themes/clean/templates/core/nav.html:24
 #: src/themes/clean/templates/journal/issues.html:6
 #: src/themes/material/templates/core/nav.html:33
 #: src/themes/material/templates/core/nav.html:94
-#: src/themes/material/templates/journal/issues.html:6
+#: src/themes/material/templates/journal/issues.html:5
 msgid "Issues"
 msgstr "Rhifynnau "
 
@@ -2830,6 +3358,30 @@ msgstr ""
 #: src/templates/common/elements/journal/article_issue_list.html:21
 msgid "This article is not a part of any issues"
 msgstr "Nid yw’r erthygl hon yn rhan o unrhyw rifynnau"
+
+#: src/templates/common/elements/orcid_registration.html:16
+#, fuzzy
+#| msgid "Login with ORCiD"
+msgid "Register with ORCiD"
+msgstr "Mewngofnodi gydag ORCiD"
+
+#: src/templates/common/elements/password_rules.html:2
+#, python-format
+msgid "Your password should be %(password_length)s characters long."
+msgstr ""
+
+#: src/templates/common/elements/password_rules.html:6
+msgid "Your password should contain at least one upper case letter."
+msgstr ""
+
+#: src/templates/common/elements/password_rules.html:11
+msgid "Your password should contain at least one number."
+msgstr ""
+
+#: src/templates/common/elements/skip_to_main_content.html:3
+#: src/themes/clean/templates/500.html:21
+msgid "Skip to main content"
+msgstr ""
 
 #: src/templates/common/elements/sorting.html:7
 #: src/themes/clean/templates/elements/sorting.html:7
@@ -2877,31 +3429,28 @@ msgstr "Gwall Gweinydd "
 msgid "A server error has occurred"
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:5
-#: src/themes/OLH/templates/core/accounts/activate_account.html:22
-#: src/themes/OLH/templates/core/accounts/activate_account.html:26
-#: src/themes/clean/templates/core/accounts/activate_account.html:5
-#: src/themes/clean/templates/core/accounts/activate_account.html:13
-#: src/themes/clean/templates/core/accounts/activate_account.html:17
-#: src/themes/material/templates/core/accounts/activate_account.html:5
-#: src/themes/material/templates/core/accounts/activate_account.html:14
-#: src/themes/material/templates/core/accounts/activate_account.html:19
-msgid "Activate Account"
-msgstr "Actifadu’r Cyfrif"
-
-#: src/themes/OLH/templates/core/accounts/activate_account.html:25
-#: src/themes/clean/templates/core/accounts/activate_account.html:16
-#: src/themes/material/templates/core/accounts/activate_account.html:17
-msgid "You can complete the activation process by clicking the button below."
-msgstr "Gallwch gwblhau’r broses actifadu drwy glicio’r botwm isod."
+#: src/themes/OLH/templates/cms/page.html:22
+#: src/themes/clean/templates/cms/page.html:19
+#: src/themes/clean/templates/journal/article.html:340
+#: src/themes/material/templates/cms/page.html:25
+#: src/themes/material/templates/journal/article.html:484
+#: src/themes/material/templates/journal/submissions.html:72
+msgid "Table of Contents"
+msgstr "Tabl Cynnwys"
 
 #: src/themes/OLH/templates/core/accounts/activate_account.html:29
 #: src/themes/clean/templates/core/accounts/activate_account.html:20
-#: src/themes/material/templates/core/accounts/activate_account.html:23
+#: src/themes/material/templates/core/accounts/activate_account.html:21
+msgid "You can complete the activation process by clicking the button below."
+msgstr "Gallwch gwblhau’r broses actifadu drwy glicio’r botwm isod."
+
+#: src/themes/OLH/templates/core/accounts/activate_account.html:33
+#: src/themes/clean/templates/core/accounts/activate_account.html:24
+#: src/themes/material/templates/core/accounts/activate_account.html:27
 msgid "Error"
 msgstr "Gwall"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:31
+#: src/themes/OLH/templates/core/accounts/activate_account.html:35
 msgid ""
 "There was no inactive account with this activation code found. It is "
 "possible that your account is already active, you can check by attempting to"
@@ -2909,49 +3458,32 @@ msgstr ""
 "Ni chanfuwyd cyfrif segur gyda’r cod actifadu hwn. Mae’n bosibl fod eich "
 "cyfrif eisoes yn weithredol, gallwch wirio drwy geisio "
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:32
-#: src/themes/clean/templates/core/accounts/activate_account.html:22
-#: src/themes/material/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:36
+#: src/themes/clean/templates/core/accounts/activate_account.html:26
+#: src/themes/material/templates/core/accounts/activate_account.html:30
 msgid "login"
 msgstr "mewngofnodi"
 
-#: src/themes/OLH/templates/core/accounts/edit_profile.html:4
-#: src/themes/clean/templates/core/accounts/edit_profile.html:5
-#: src/themes/material/templates/core/accounts/edit_profile.html:4
-msgid "Edit Profile"
-msgstr "Golygu Proffeil"
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:5
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:9
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:86
 #: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:105
 #: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:100
 msgid "Update"
 msgstr "Diweddaru"
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:25
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:15
-#: src/themes/material/templates/core/accounts/get_reset_token.html:14
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:20
+#: src/themes/material/templates/core/accounts/get_reset_token.html:20
 msgid "Enter your email address to begin the reset process"
 msgstr "Nodwch eich cyfeiriad ebost i ddechrau’r broses ailosod "
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:27
-msgid "somebody"
-msgstr "rhywun"
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:21
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:31
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:24
+#: src/themes/material/templates/core/accounts/get_reset_token.html:25
 msgid "Request Token"
 msgstr "Tocyn Cais"
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:5
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:19
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:4
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:9
-msgid "Unregistered ORCiD"
-msgstr "Dadgofrestru ORCiD"
-
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:20
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:24
 msgid ""
 "The ORCiD you logged in with is not currently linked with an account in our "
 "system. You can either register a new account, or login with an existing "
@@ -2962,27 +3494,27 @@ msgstr ""
 "fewngofnodi gyda chyfrif sy’n bodoli eisoes i gysylltu eich ORCiD i’w "
 "ddefnyddio yn y dyfodol."
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:40
 #: src/themes/OLH/templates/press/core/login.html:36
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:29
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:33
 msgid "Log In"
 msgstr "Mewngofnodi"
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:37
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:41
 #: src/themes/OLH/templates/press/core/login.html:37
 msgid "Forgot your password?"
 msgstr "Wedi anghofio eich cyfrinair?"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:5
-#: src/themes/OLH/templates/core/nav.html:73
+#: src/themes/OLH/templates/core/accounts/public_profile.html:9
+#: src/themes/OLH/templates/core/nav.html:72
 #: src/themes/OLH/templates/elements/right_hand_menu.html:38
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:12
 #: src/themes/OLH/templates/press/nav.html:54
 #: src/themes/OLH/templates/repository/elements/right_hand_menu.html:10
-#: src/themes/clean/templates/core/accounts/public_profile.html:4
+#: src/themes/clean/templates/core/accounts/public_profile.html:8
 #: src/themes/clean/templates/core/nav.html:98
 #: src/themes/clean/templates/press/nav.html:71
-#: src/themes/material/templates/core/accounts/public_profile.html:5
+#: src/themes/material/templates/core/accounts/public_profile.html:9
 #: src/themes/material/templates/core/nav.html:165
 #: src/themes/material/templates/core/nav.html:200
 #: src/themes/material/templates/press/nav.html:135
@@ -2990,123 +3522,55 @@ msgstr "Wedi anghofio eich cyfrinair?"
 msgid "Profile"
 msgstr "Proffil"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:13
-#: src/themes/clean/templates/core/accounts/public_profile.html:13
-#: src/themes/material/templates/core/accounts/public_profile.html:13
+#: src/themes/OLH/templates/core/accounts/public_profile.html:19
+#: src/themes/clean/templates/core/accounts/public_profile.html:17
+#: src/themes/material/templates/core/accounts/public_profile.html:17
 msgid "Roles"
 msgstr "Rolau "
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:25
-#: src/themes/clean/templates/core/accounts/public_profile.html:25
-#: src/themes/material/templates/core/accounts/public_profile.html:25
+#: src/themes/OLH/templates/core/accounts/public_profile.html:27
+#, fuzzy
+#| msgid "Editorial Team"
+msgid "Editorial groups"
+msgstr "Tîm Golygyddol"
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:35
+msgid "Staff roles"
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:56
+#: src/themes/clean/templates/core/accounts/public_profile.html:29
+#: src/themes/material/templates/core/accounts/public_profile.html:29
 msgid "Publications"
 msgstr "Cyhoeddiadau"
 
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
+#: src/themes/OLH/templates/core/accounts/register.html:29
+#: src/themes/clean/templates/core/accounts/register.html:21
+#: src/themes/material/templates/core/accounts/register.html:19
 #, fuzzy
 #| msgid "Register for"
 msgid "Register for an account with"
 msgstr "Cofrestru ar gyfer cyfrif gyda"
 
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
-#, fuzzy
-#| msgid "Account"
-msgid "account"
-msgstr "Cyfrif"
-
-#: src/themes/OLH/templates/core/accounts/register.html:26
-#: src/themes/OLH/templates/core/accounts/reset_password.html:27
-#: src/themes/clean/templates/core/accounts/register.html:18
-#: src/themes/clean/templates/core/accounts/reset_password.html:17
-#: src/themes/material/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/reset_password.html:17
-#, fuzzy
-#| msgid "Password Guide"
-msgid "Password Rules"
-msgstr "Canllaw Cyfrinair "
-
-#: src/themes/OLH/templates/core/accounts/register.html:28
-#: src/themes/clean/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/register.html:22
-#: src/themes/material/templates/core/accounts/reset_password.html:19
-#, python-format
-msgid "Your password should be %(password_length)s characters long."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:29
-#: src/themes/OLH/templates/core/accounts/reset_password.html:30
-#: src/themes/clean/templates/core/accounts/register.html:21
-#: src/themes/clean/templates/core/accounts/reset_password.html:20
-#: src/themes/material/templates/core/accounts/register.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:20
-msgid "Your password should contain at least one upper case letter.\""
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:30
-#: src/themes/OLH/templates/core/accounts/reset_password.html:31
-#: src/themes/clean/templates/core/accounts/register.html:22
-#: src/themes/clean/templates/core/accounts/reset_password.html:21
-#: src/themes/material/templates/core/accounts/register.html:24
-#: src/themes/material/templates/core/accounts/reset_password.html:21
-#, python-format
-msgid "Your password should contain at least one number.\" %%}"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:32
+#: src/themes/OLH/templates/core/accounts/register.html:35
+#: src/themes/OLH/templates/core/accounts/reset_password.html:36
 msgid ""
-"For more information read our <a href=\"#\" data-open=\"password-modal"
-"\">password guide</a>."
+"For more information read our <a href=\"#\" data-open=\"password-"
+"modal\">password guide</a>."
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/register.html:83
-#: src/themes/clean/templates/core/accounts/register.html:27
-#: src/themes/material/templates/core/accounts/register.html:33
-msgid "By registering an account you agree to our"
-msgstr "Drwy gofrestru cyfrif rydych yn cytuno i’r"
-
-#: src/themes/OLH/templates/core/accounts/register.html:85
-#: src/themes/OLH/templates/core/accounts/register.html:87
-#: src/themes/OLH/templates/elements/journal_footer.html:25
-#: src/themes/OLH/templates/elements/journal_footer.html:27
-#: src/themes/OLH/templates/press/elements/press_footer.html:9
-#: src/themes/OLH/templates/press/elements/press_footer.html:11
-#: src/themes/clean/templates/core/accounts/register.html:29
-#: src/themes/clean/templates/core/accounts/register.html:31
-#: src/themes/clean/templates/elements/journal_footer.html:33
-#: src/themes/clean/templates/elements/journal_footer.html:37
-#: src/themes/clean/templates/elements/press_footer.html:11
-#: src/themes/clean/templates/elements/press_footer.html:14
-#: src/themes/material/templates/core/accounts/register.html:35
-#: src/themes/material/templates/core/accounts/register.html:37
-#: src/themes/material/templates/elements/journal_footer.html:28
-msgid "Privacy Policy"
-msgstr "Polisi Preifatrwydd"
-
-#: src/themes/OLH/templates/core/accounts/register.html:106
-#: src/themes/OLH/templates/core/accounts/reset_password.html:48
-#: src/themes/clean/templates/core/accounts/register.html:54
-#: src/themes/clean/templates/core/accounts/reset_password.html:43
-#: src/themes/material/templates/core/accounts/register.html:53
-#: src/themes/material/templates/core/accounts/reset_password.html:41
-msgid "Password Guide"
-msgstr "Canllaw Cyfrinair "
-
-#: src/themes/OLH/templates/core/accounts/register.html:107
-#: src/themes/OLH/templates/core/accounts/reset_password.html:49
-#: src/themes/clean/templates/core/accounts/reset_password.html:49
+#: src/themes/OLH/templates/core/accounts/register.html:111
+#: src/themes/OLH/templates/core/accounts/reset_password.html:53
+#: src/themes/clean/templates/core/accounts/reset_password.html:53
 #: src/themes/material/templates/core/accounts/register.html:54
-#: src/themes/material/templates/core/accounts/reset_password.html:42
+#: src/themes/material/templates/core/accounts/reset_password.html:44
 msgid "When it comes to passwords, length is better than complexity."
 msgstr "Pan ddaw’n fater o gyfrineiriau, mae hyd yn well na chymhlethdod."
 
-#: src/themes/OLH/templates/core/accounts/register.html:108
-#: src/themes/OLH/templates/core/accounts/reset_password.html:50
+#: src/themes/OLH/templates/core/accounts/register.html:112
+#: src/themes/OLH/templates/core/accounts/reset_password.html:54
 #: src/themes/material/templates/core/accounts/register.html:55
-#: src/themes/material/templates/core/accounts/reset_password.html:43
+#: src/themes/material/templates/core/accounts/reset_password.html:45
 msgid ""
 "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
 "secure than a long and uncomplicated password (our awesome moon base rocks)."
@@ -3114,8 +3578,8 @@ msgstr ""
 "Mae’n goel gyffredin fod cyfrinair byr a chymhleth (Jfjfy&65^87) yn fwy "
 "diogel na chyfrinair hir llai cymhleth (gwinllan a roddwyd i’n gofal)."
 
-#: src/themes/OLH/templates/core/accounts/register.html:109
-#: src/themes/OLH/templates/core/accounts/reset_password.html:51
+#: src/themes/OLH/templates/core/accounts/register.html:113
+#: src/themes/OLH/templates/core/accounts/reset_password.html:55
 msgid ""
 "We recommend selecting a long, but easy to remember password such as our "
 "awesome moon base rocks which would take an estimated septillion years to "
@@ -3127,40 +3591,26 @@ msgstr ""
 "flynyddoedd i’w ddatrys yn hytrach na chyfrinair cymhleth fel Jfjfy&65^87 a "
 "fyddai’n cymryd ychydig dros 600 o flynyddoedd ar gyfrifiadur safonol."
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:6
-#: src/themes/OLH/templates/core/accounts/reset_password.html:38
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:4
-#: src/themes/clean/templates/core/accounts/reset_password.html:5
-#: src/themes/clean/templates/core/accounts/reset_password.html:29
-#: src/themes/material/templates/core/accounts/get_reset_token.html:4
-#: src/themes/material/templates/core/accounts/reset_password.html:5
-#: src/themes/material/templates/core/accounts/reset_password.html:29
+#: src/themes/OLH/templates/core/accounts/reset_password.html:10
+#: src/themes/OLH/templates/core/accounts/reset_password.html:42
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:8
+#: src/themes/clean/templates/core/accounts/reset_password.html:9
+#: src/themes/clean/templates/core/accounts/reset_password.html:33
+#: src/themes/hourglass/templates/core/accounts/get_reset_token.html:9
+#: src/themes/hourglass/templates/core/accounts/reset_password.html:10
+#: src/themes/material/templates/core/accounts/get_reset_token.html:8
+#: src/themes/material/templates/core/accounts/reset_password.html:9
+#: src/themes/material/templates/core/accounts/reset_password.html:31
 msgid "Reset Password"
 msgstr "Ailosod Cyfrinair"
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:26
-#: src/themes/clean/templates/core/accounts/reset_password.html:16
-#: src/themes/material/templates/core/accounts/reset_password.html:16
+#: src/themes/OLH/templates/core/accounts/reset_password.html:30
+#: src/themes/clean/templates/core/accounts/reset_password.html:20
+#: src/themes/material/templates/core/accounts/reset_password.html:20
 msgid "Enter your new password twice to complete the reset process"
 msgstr "Nodwch eich cyfrinair newydd ddwywaith i gwblhau’r broses ailosod "
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:29
-#: src/themes/clean/templates/core/accounts/reset_password.html:19
-#, python-format
-msgid ""
-"Your password should be %(request.press.password_length)s characters long."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/reset_password.html:33
-#: src/themes/material/templates/core/accounts/register.html:26
-msgid ""
-"For more information read our\n"
-"                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-"\">password guide</a>\n"
-"                        ."
-msgstr ""
-
-#: src/themes/OLH/templates/core/base.html:60
+#: src/themes/OLH/templates/core/base.html:61
 #: src/themes/OLH/templates/core/nav.html:7
 #: src/themes/OLH/templates/press/nav.html:6
 #: src/themes/OLH/templates/press/press_index.html:5
@@ -3176,18 +3626,6 @@ msgstr ""
 msgid "Home"
 msgstr "Hafan"
 
-#: src/themes/OLH/templates/core/login.html:27
-#: src/themes/OLH/templates/press/core/login.html:25
-#: src/themes/clean/templates/core/login.html:14
-msgid "Log in with your account"
-msgstr "Mewngofnodi gyda’ch cyfrif"
-
-#: src/themes/OLH/templates/core/login.html:28
-#: src/themes/clean/templates/core/login.html:16
-#: src/themes/material/templates/core/login.html:18
-msgid "Log in with ORCiD"
-msgstr "Mewngofnodi gydag ORCiD"
-
 #: src/themes/OLH/templates/core/login.html:31
 #: src/themes/OLH/templates/press/core/login.html:28
 #: src/themes/clean/templates/core/login.html:20
@@ -3196,38 +3634,6 @@ msgstr "Mewngofnodi gydag ORCiD"
 #| msgid "Login with ORCiD"
 msgid "Login with"
 msgstr "Mewngofnodi gydag ORCiD"
-
-#: src/themes/OLH/templates/core/login.html:43
-#: src/themes/clean/templates/core/login.html:40
-msgid "Log in"
-msgstr "Mewngofnodi"
-
-#: src/themes/OLH/templates/core/login.html:44
-#: src/themes/clean/templates/core/login.html:44
-msgid "Forgotten your password?"
-msgstr "Wedi anghofio eich cyfrinair?"
-
-#: src/themes/OLH/templates/core/login.html:45
-#: src/themes/clean/templates/core/login.html:48
-msgid "Register a new account"
-msgstr "Cofrestru cyfrif newydd"
-
-#: src/themes/OLH/templates/core/nav.html:29
-#: src/themes/OLH/templates/core/nav.html:37
-#: src/themes/OLH/templates/journal/editorial_team.html:10
-#: src/themes/OLH/templates/journal/editorial_team.html:20
-#: src/themes/OLH/templates/press/nav.html:39
-#: src/themes/clean/templates/core/nav.html:32
-#: src/themes/clean/templates/core/nav.html:41
-#: src/themes/clean/templates/journal/editorial_team.html:4
-#: src/themes/clean/templates/journal/editorial_team.html:9
-#: src/themes/material/templates/core/nav.html:36
-#: src/themes/material/templates/core/nav.html:97
-#: src/themes/material/templates/journal/editorial_team.html:11
-#: src/themes/material/templates/preprints/editors.html:5
-#: src/themes/material/templates/preprints/editors.html:6
-msgid "Editorial Team"
-msgstr "Tîm Golygyddol"
 
 #: src/themes/OLH/templates/core/nav.html:44
 #: src/themes/OLH/templates/journal/become_reviewer.html:5
@@ -3306,13 +3712,13 @@ msgstr "Golygu Erthygl"
 msgid "Edit Issue"
 msgstr "Golygu Rhifyn"
 
-#: src/themes/OLH/templates/core/nav.html:66
+#: src/themes/OLH/templates/core/nav.html:65
 #: src/themes/OLH/templates/elements/right_hand_menu.html:31
 #: src/themes/material/templates/core/nav.html:194
 msgid "Edit News Item"
 msgstr "Golygu Eitem Newyddion"
 
-#: src/themes/OLH/templates/core/nav.html:70
+#: src/themes/OLH/templates/core/nav.html:69
 #: src/themes/OLH/templates/elements/right_hand_menu.html:35
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:8
 #: src/themes/OLH/templates/press/nav.html:51
@@ -3328,7 +3734,7 @@ msgstr "Golygu Eitem Newyddion"
 msgid "Admin"
 msgstr "Gweinyddwr"
 
-#: src/themes/OLH/templates/core/nav.html:74
+#: src/themes/OLH/templates/core/nav.html:73
 #: src/themes/OLH/templates/elements/right_hand_menu.html:39
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:13
 #: src/themes/OLH/templates/press/nav.html:55
@@ -3344,43 +3750,44 @@ msgstr "Gweinyddwr"
 msgid "Logout"
 msgstr "Allgofnodi"
 
-#: src/themes/OLH/templates/core/news/index.html:11
-#: src/themes/material/templates/core/news/index.html:11
+#: src/themes/OLH/templates/core/news/index.html:12
+#: src/themes/material/templates/core/news/index.html:12
 #: src/themes/material/templates/press/core/news/index.html:11
 msgid "Filtering tag"
 msgstr "Tag hidlo"
 
-#: src/themes/OLH/templates/core/news/index.html:24
-#: src/themes/OLH/templates/core/news/item.html:24
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:27
-#: src/themes/OLH/templates/press/core/news/index.html:22
-#: src/themes/OLH/templates/press/core/news/item.html:24
-#: src/themes/OLH/templates/press/core/news/item.html:33
-#: src/themes/material/templates/core/news/index.html:30
-#: src/themes/material/templates/core/news/item.html:30
+#: src/themes/OLH/templates/core/news/index.html:25
+#: src/themes/OLH/templates/core/news/item.html:25
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:28
+#: src/themes/OLH/templates/press/core/news/index.html:23
+#: src/themes/OLH/templates/press/core/news/item.html:25
+#: src/themes/OLH/templates/press/core/news/item.html:34
+#: src/themes/hourglass/templates/custom/news-item.html:16
+#: src/themes/material/templates/core/news/index.html:31
+#: src/themes/material/templates/core/news/item.html:31
 #: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
+#: src/themes/material/templates/press/core/news/item.html:18
 msgid "on"
 msgstr "ar"
 
-#: src/themes/OLH/templates/core/news/index.html:26
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:29
-#: src/themes/OLH/templates/press/core/news/index.html:24
+#: src/themes/OLH/templates/core/news/index.html:27
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:30
+#: src/themes/OLH/templates/press/core/news/index.html:25
 #: src/themes/clean/templates/core/news/index.html:17
 #: src/themes/clean/templates/press/core/news/index.html:17
-#: src/themes/material/templates/core/news/index.html:34
-#: src/themes/material/templates/journal/homepage_elements/news.html:36
+#: src/themes/material/templates/core/news/index.html:35
+#: src/themes/material/templates/journal/homepage_elements/news.html:37
 #: src/themes/material/templates/press/core/news/index.html:25
 msgid "Read More"
 msgstr "Darllen Rhagor"
 
-#: src/themes/OLH/templates/core/news/index.html:33
+#: src/themes/OLH/templates/core/news/index.html:34
 #: src/themes/material/templates/press/core/news/index.html:30
 msgid "This journal currently has no news items to display."
 msgstr ""
 "Ar hyn o bryd nid oes gan y cyfnodolyn hwn eitemau newyddion i’w dangos."
 
-#: src/themes/OLH/templates/core/news/item.html:40
+#: src/themes/OLH/templates/core/news/item.html:41
 #: src/themes/clean/templates/core/news/item.html:20
 #: src/themes/clean/templates/press/core/news/item.html:16
 #, fuzzy
@@ -3388,23 +3795,17 @@ msgstr ""
 msgid "Tags "
 msgstr "Tagiau"
 
-#: src/themes/OLH/templates/core/news/item.html:47
+#: src/themes/OLH/templates/core/news/item.html:48
 #: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
+#: src/themes/material/templates/core/news/item.html:44
 msgid "Back to"
 msgstr ""
 
-#: src/themes/OLH/templates/core/news/item.html:47
+#: src/themes/OLH/templates/core/news/item.html:48
 #: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
+#: src/themes/material/templates/core/news/item.html:44
 msgid "List"
 msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
-msgid "Change Your Email Address"
-msgstr "Newid eich cyfeiriad ebost"
 
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:8
 #, fuzzy
@@ -3428,62 +3829,12 @@ msgstr ""
 "cyfeiriad ebost hefyd yn newid eich enw defnyddiwr gan fod y rhain yr un "
 "fath â’i gilydd."
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
-#, fuzzy
-#| msgid "Email Address"
-msgid "Current Email Address"
-msgstr "Cyfeiriad ebost"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
-#, fuzzy
-#| msgid "Email Address"
-msgid "New Email Address"
-msgstr "Cyfeiriad ebost"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
-msgid "Update Email Address"
-msgstr "Diweddaru Cyfeiriad Ebost"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
-#, fuzzy
-#| msgid "Register for"
-msgid "Register for Article Notifications"
-msgstr "Cofrestru ar gyfer"
-
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:31
 #: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:43
 msgid ""
 "Use the button below to register to receive notifications of new articles\n"
 "                            published in this journal "
 msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
-msgid "Unsubscribe from Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
-msgid "Subscribe to Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
-msgid "Update Password"
-msgstr "Diweddaru Cyfrinair"
 
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:53
 #: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:66
@@ -3494,34 +3845,11 @@ msgstr ""
 "Gallwch ddiweddaru eich cyfrinair drwy nodi eich cyfrinair presennol a’ch "
 "cyfrinair newydd."
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
-msgid "Current Password"
-msgstr "Cyfrinair Presennol"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
-msgid "New Password"
-msgstr "Cyfrinair Newydd"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
-msgid "Enter Password Again"
-msgstr "Nodwch y Cyfrinair Eto"
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:41
-#: src/themes/clean/templates/elements/accounts/user_form.html:38
-#: src/themes/material/templates/elements/accounts/user_form.html:39
-msgid "Social Media and Accounts"
-msgstr "Cyfryngau Cymdeithasol a Chyfrifon "
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:95
-#: src/themes/OLH/templates/journal/article.html:108
-#: src/themes/clean/templates/elements/accounts/user_form.html:92
-#: src/themes/material/templates/elements/accounts/user_form.html:93
-msgid "Options"
-msgstr "Opsiynau "
+#: src/themes/OLH/templates/elements/accounts/user_form.html:5
+#: src/themes/clean/templates/elements/accounts/user_form.html:5
+#: src/themes/material/templates/elements/accounts/user_form.html:6
+msgid "Core Data"
+msgstr "Data Craidd"
 
 #: src/themes/OLH/templates/elements/edit_author.html:5
 msgid "NB."
@@ -3573,13 +3901,13 @@ msgid "Date"
 msgstr "Dyddiad"
 
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:26
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:34
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:35
 #: src/themes/OLH/templates/elements/journal/article_list_filters.html:6
 #: src/themes/OLH/templates/elements/journal/search_form.html:19
 #: src/themes/OLH/templates/press/press_journals.html:93
 #: src/themes/OLH/templates/press/press_journals.html:94
 #: src/themes/clean/templates/elements/journal/article_list_filters.html:7
-#: src/themes/clean/templates/journal/articles.html:81
+#: src/themes/clean/templates/journal/articles.html:82
 #: src/themes/clean/templates/journal/full-text-search.html:54
 #: src/themes/clean/templates/press/press_journals.html:56
 #: src/themes/material/templates/journal/articles.html:95
@@ -3589,18 +3917,14 @@ msgstr "Dyddiad"
 msgid "Filter"
 msgstr "Hidlo"
 
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:36
-#: src/themes/clean/templates/journal/articles.html:84
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:37
+#: src/themes/clean/templates/journal/articles.html:85
 #: src/themes/material/templates/journal/articles.html:109
 msgid "Clear Filters"
 msgstr "Clirio Hidlyddion"
 
-#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
-#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
-msgid "Apply"
-msgstr ""
-
 #: src/themes/OLH/templates/elements/journal/authors_block.html:4
+#: src/themes/clean/templates/elements/article_listing.html:27
 #: src/themes/clean/templates/elements/journal/authors_block.html:4
 #: src/themes/material/templates/elements/article_listing.html:25
 msgid "and"
@@ -3614,7 +3938,7 @@ msgstr "Hefyd yn rhan o:"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:5
 #: src/themes/clean/templates/elements/journal/citation_modals.html:6
-#: src/themes/clean/templates/journal/article.html:294
+#: src/themes/clean/templates/journal/article.html:304
 msgid "Harvard-style Citation"
 msgstr "Cyfeirnod yn Arddull Harvard"
 
@@ -3627,37 +3951,37 @@ msgid "Preprints"
 msgstr "Rhagargraffiadau"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:19
-#: src/themes/OLH/templates/journal/article.html:135
+#: src/themes/OLH/templates/journal/article.html:137
 msgid "Vancouver Citation Style"
 msgstr "Cyfeirnodi yn Arddull Vancouver "
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:19
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:40
-#: src/themes/OLH/templates/journal/article.html:136
+#: src/themes/OLH/templates/journal/article.html:138
 msgid "APA Citation Style"
 msgstr "Cyfeirnodi yn Arddull APA "
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:27
 #: src/themes/clean/templates/elements/journal/citation_modals.html:28
-#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/clean/templates/journal/article.html:305
 msgid "Vancouver-style Citation"
 msgstr "Cyfeirnod yn Arddull Vancouver"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:40
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:63
-#: src/themes/OLH/templates/journal/article.html:134
+#: src/themes/OLH/templates/journal/article.html:136
 msgid "Harvard Citation Style"
 msgstr "Cyfeirnodi yn Arddull Harvard "
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:49
 #: src/themes/clean/templates/elements/journal/citation_modals.html:49
-#: src/themes/clean/templates/journal/article.html:296
+#: src/themes/clean/templates/journal/article.html:306
 msgid "APA-style Citation"
 msgstr "Cyfeirnodi yn Arddull APA"
 
 #: src/themes/OLH/templates/elements/journal/editorial_social_content.html:4
 #: src/themes/clean/templates/elements/journal/editorial_social_content.html:4
-#: src/themes/clean/templates/journal/article.html:283
+#: src/themes/clean/templates/journal/article.html:293
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -3676,17 +4000,45 @@ msgstr "Github"
 msgid "Linkedin"
 msgstr "Linkedin"
 
+#: src/themes/OLH/templates/elements/journal/issue_list.html:16
+#: src/themes/clean/templates/elements/journal/issue_list.html:5
+#: src/themes/clean/templates/journal/issues.html:14
+#: src/themes/material/templates/elements/journal/issue_list.html:16
+#: src/themes/material/templates/elements/journal/issue_list.html:20
+msgid "items"
+msgstr "Eitemau"
+
+#: src/themes/OLH/templates/elements/journal/issue_list.html:24
+msgid "There are no issues published in this journal yet."
+msgstr "Does dim rhifynnau o’r cyfnodolyn hwn wedi’u cyhoeddi eto."
+
+#: src/themes/OLH/templates/elements/journal/issue_list_by_decade.html:3
+#: src/themes/material/templates/elements/journal/issue_list_by_decade.html:3
+msgid ""
+"\n"
+"            Issues are grouped by decade. Select a decade to view the "
+"issues\n"
+"            published during that decade.\n"
+"        "
+msgstr ""
+
 #: src/themes/OLH/templates/elements/journal/issue_sidebar.html:7
-#: src/themes/OLH/templates/journal/article.html:208
-#: src/themes/OLH/templates/journal/article.html:263
+#: src/themes/OLH/templates/journal/article.html:210
+#: src/themes/OLH/templates/journal/article.html:246
+#: src/themes/OLH/templates/journal/article.html:334
 #: src/themes/OLH/templates/repository/preprint.html:114
+#: src/themes/OLH/templates/repository/preprint.html:152
 #: src/themes/clean/templates/elements/journal/issue_sidebar.html:6
-#: src/themes/clean/templates/journal/article.html:102
-#: src/themes/clean/templates/journal/article.html:281
+#: src/themes/clean/templates/journal/article.html:101
+#: src/themes/clean/templates/journal/article.html:184
+#: src/themes/clean/templates/journal/article.html:291
 #: src/themes/material/templates/elements/journal/issue_sidebar.html:5
-#: src/themes/material/templates/journal/article.html:188
+#: src/themes/material/templates/journal/article.html:123
+#: src/themes/material/templates/journal/article.html:169
+#: src/themes/material/templates/journal/article.html:273
 #: src/themes/material/templates/preprints/article.html:133
-#: src/themes/material/templates/repository/preprint.html:132
+#: src/themes/material/templates/repository/preprint.html:130
+#: src/themes/material/templates/repository/preprint.html:203
 msgid "Downloads"
 msgstr "Lawrlwythiadau"
 
@@ -3746,11 +4098,11 @@ msgid "Sort articles by"
 msgstr "Teitl eich erthygl"
 
 #: src/themes/OLH/templates/elements/journal/summary_modal.html:3
-#: src/themes/OLH/templates/journal/article.html:437
+#: src/themes/OLH/templates/journal/article.html:428
 #: src/themes/clean/templates/elements/journal/summary_modal.html:6
-#: src/themes/clean/templates/journal/article.html:250
+#: src/themes/clean/templates/journal/article.html:260
 #: src/themes/material/templates/elements/summary_modal.html:5
-#: src/themes/material/templates/journal/article.html:380
+#: src/themes/material/templates/journal/article.html:382
 msgid "Non Specialist Summary"
 msgstr "Crynodeb nad yw’n Arbenigol "
 
@@ -3815,9 +4167,9 @@ msgid "Public Submissions"
 msgstr "Cyflwyniadau Cyhoeddus"
 
 #: src/themes/OLH/templates/elements/section_block.html:12
-#: src/themes/OLH/templates/journal/article.html:298
+#: src/themes/OLH/templates/journal/article.html:279
 #: src/themes/clean/templates/elements/sections_block.html:9
-#: src/themes/clean/templates/journal/article.html:242
+#: src/themes/clean/templates/journal/article.html:252
 #: src/themes/material/templates/elements/sections_display.html:11
 msgid "Peer Reviewed"
 msgstr "Cymheiriwyd"
@@ -3909,7 +4261,7 @@ msgstr "Erthygl"
 
 #: src/themes/OLH/templates/journal/article.html:28
 #: src/themes/OLH/templates/journal/article.html:64
-#: src/themes/OLH/templates/journal/article.html:159
+#: src/themes/OLH/templates/journal/article.html:162
 #: src/themes/OLH/templates/journal/print.html:15
 #: src/themes/clean/templates/journal/article.html:38
 #: src/themes/clean/templates/journal/print.html:15
@@ -3917,41 +4269,86 @@ msgid "Author"
 msgstr "Awdur"
 
 #: src/themes/OLH/templates/journal/article.html:115
-#: src/themes/material/templates/journal/article.html:250
+#: src/themes/clean/templates/journal/article.html:172
+#: src/themes/material/templates/journal/article.html:231
 msgid "Share"
 msgstr "Rhannu"
 
+#: src/themes/OLH/templates/journal/article.html:116
+#: src/themes/clean/templates/journal/article.html:176
+#: src/themes/material/templates/journal/article.html:236
+#, fuzzy
+#| msgid "Facebook"
+msgid "Share on Facebook"
+msgstr "Facebook"
+
+#: src/themes/OLH/templates/journal/article.html:118
+#: src/themes/clean/templates/journal/article.html:179
+#: src/themes/material/templates/journal/article.html:239
+#, fuzzy
+#| msgid "Share"
+msgid "Share on X"
+msgstr "Rhannu"
+
+#: src/themes/OLH/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:182
+#: src/themes/material/templates/journal/article.html:242
+msgid "Share on LinkedIn"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:128
+#, fuzzy
+#| msgid "Edit Article"
+msgid "print article"
+msgstr "Golygu Erthygl"
+
+#: src/themes/OLH/templates/journal/article.html:129
+msgid "decrease text size"
+msgstr ""
+
 #: src/themes/OLH/templates/journal/article.html:130
+msgid "increase text size"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:132
+#, fuzzy
+#| msgid "Dyslexia"
+msgid "Dyslexia mode"
+msgstr "Dyslecsia"
+
+#: src/themes/OLH/templates/journal/article.html:132
 msgid "Dyslexia"
 msgstr "Dyslecsia"
 
-#: src/themes/OLH/templates/journal/article.html:137
-#: src/themes/OLH/templates/journal/article.html:210
-#: src/themes/OLH/templates/journal/article.html:353
-#: src/themes/OLH/templates/journal/article.html:357
+#: src/themes/OLH/templates/journal/article.html:134
+#, fuzzy
+#| msgid "Edit Article"
+msgid "Cite article"
+msgstr "Golygu Erthygl"
+
+#: src/themes/OLH/templates/journal/article.html:139
+#: src/themes/OLH/templates/journal/article.html:213
+#: src/themes/OLH/templates/journal/article.html:339
 #: src/themes/clean/templates/journal/article.html:104
-#: src/themes/clean/templates/journal/article.html:186
-#: src/themes/clean/templates/journal/article.html:191
-#: src/themes/clean/templates/journal/article.html:298
-#: src/themes/clean/templates/journal/article.html:301
+#: src/themes/clean/templates/journal/article.html:190
+#: src/themes/clean/templates/journal/article.html:308
+#: src/themes/clean/templates/journal/article.html:311
 #: src/themes/material/templates/elements/journal/issue_sidebar.html:8
-#: src/themes/material/templates/journal/article.html:124
 #: src/themes/material/templates/journal/article.html:127
-#: src/themes/material/templates/journal/article.html:293
-#: src/themes/material/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:279
 #: src/themes/material/templates/preprints/article.html:113
 #: src/themes/material/templates/preprints/article.html:117
 #: src/themes/material/templates/preprints/article.html:139
 msgid "Download"
 msgstr "Lawrlwytho"
 
-#: src/themes/OLH/templates/journal/article.html:138
+#: src/themes/OLH/templates/journal/article.html:140
 #, fuzzy
 #| msgid "Download"
 msgid " Download"
 msgstr "Lawrlwytho"
 
-#: src/themes/OLH/templates/journal/article.html:183
+#: src/themes/OLH/templates/journal/article.html:186
 #: src/themes/OLH/templates/journal/print.html:35
 #: src/themes/clean/templates/journal/article.html:89
 #: src/themes/clean/templates/journal/print.html:35
@@ -3959,139 +4356,158 @@ msgstr "Lawrlwytho"
 msgid "How to Cite"
 msgstr "Sut i Gyfeirnodi"
 
-#: src/themes/OLH/templates/journal/article.html:190
+#: src/themes/OLH/templates/journal/article.html:193
 #: src/themes/clean/templates/journal/article.html:95
 #: src/themes/material/templates/journal/article.html:101
 msgid "Rights"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:195
-#: src/themes/clean/templates/journal/article.html:143
+#: src/themes/OLH/templates/journal/article.html:198
+#: src/themes/clean/templates/journal/article.html:129
 #: src/themes/material/templates/journal/article.html:110
 msgid "Publisher Notes"
 msgstr "Nodiadau’r Cyhoeddwr"
 
-#: src/themes/OLH/templates/journal/article.html:213
-#: src/themes/OLH/templates/journal/article.html:361
+#: src/themes/OLH/templates/journal/article.html:216
+#: src/themes/OLH/templates/journal/article.html:343
 #, fuzzy
 #| msgid "View"
 msgid "View PDF"
 msgstr "Golwg "
 
-#: src/themes/OLH/templates/journal/article.html:239
-#, python-format
-msgid ""
-"\n"
-"                                                        (grant %(id)s)\n"
-"                                                    "
+#: src/themes/OLH/templates/journal/article.html:227
+#: src/themes/OLH/templates/journal/article.html:356
+#: src/themes/clean/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:207
+#: src/themes/material/templates/journal/article.html:143
+#: src/themes/material/templates/journal/article.html:298
+msgid "Downloads are not available for this article."
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:257
-#: src/themes/clean/templates/journal/article.html:280
-#: src/themes/material/templates/journal/article.html:182
+#: src/themes/OLH/templates/journal/article.html:240
+#: src/themes/OLH/templates/repository/preprint.html:151
+#: src/themes/clean/templates/journal/article.html:290
+#: src/themes/material/templates/journal/article.html:163
 #: src/themes/material/templates/preprints/article.html:132
+#: src/themes/material/templates/repository/preprint.html:202
 msgid "Views"
 msgstr "Golygon"
 
-#: src/themes/OLH/templates/journal/article.html:269
-#: src/themes/clean/templates/journal/article.html:289
-#: src/themes/material/templates/journal/article.html:220
+#: src/themes/OLH/templates/journal/article.html:253
+#: src/themes/clean/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:201
 msgid "Citations"
 msgstr "Cyfeirnodau "
 
-#: src/themes/OLH/templates/journal/article.html:283
-#: src/themes/clean/templates/journal/article.html:221
+#: src/themes/OLH/templates/journal/article.html:267
+#: src/themes/clean/templates/journal/article.html:233
+#: src/themes/material/templates/journal/article.html:354
 #: src/themes/material/templates/preprints/article.html:123
 msgid "Published on"
 msgstr "Cyhoeddwyd ar"
 
 #: src/themes/OLH/templates/journal/article.html:287
-#: src/themes/clean/templates/journal/article.html:224
-msgid "Accepted on"
-msgstr "Derbyniwyd ar"
-
-#: src/themes/OLH/templates/journal/article.html:306
-#: src/themes/OLH/templates/repository/preprint.html:126
-#: src/themes/clean/templates/journal/article.html:245
+#: src/themes/OLH/templates/repository/preprint.html:127
+#: src/themes/clean/templates/journal/article.html:255
 #: src/themes/material/templates/preprints/article.html:124
-#: src/themes/material/templates/repository/preprint.html:190
+#: src/themes/material/templates/repository/preprint.html:189
 msgid "License"
 msgstr "Trwydded"
 
-#: src/themes/OLH/templates/journal/article.html:374
+#: src/themes/OLH/templates/journal/article.html:359
 msgid "Downloads are not available until this article is published "
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:383
-#: src/themes/material/templates/journal/article.html:434
+#: src/themes/OLH/templates/journal/article.html:368
+#: src/themes/material/templates/journal/article.html:410
 msgid "Identifiers"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:393
-#: src/themes/material/templates/journal/article.html:326
+#: src/themes/OLH/templates/journal/article.html:378
+#: src/themes/material/templates/journal/article.html:308
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Publication details"
 msgstr "Ffioedd Cyhoeddi"
 
-#: src/themes/OLH/templates/journal/article.html:396
-#: src/themes/clean/templates/journal/article.html:227
-#: src/themes/material/templates/journal/article.html:330
+#: src/themes/OLH/templates/journal/article.html:381
+#: src/themes/clean/templates/journal/article.html:237
+#: src/themes/material/templates/journal/article.html:312
 msgid "Pages"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:399
-#: src/themes/clean/templates/journal/article.html:230
+#: src/themes/OLH/templates/journal/article.html:384
+#: src/themes/clean/templates/journal/article.html:240
 #, fuzzy
 #| msgid "Grant Number"
 msgid "Article Number"
 msgstr "Rhif Grant"
 
-#: src/themes/OLH/templates/journal/article.html:402
-#: src/themes/clean/templates/journal/article.html:233
-#: src/themes/material/templates/journal/article.html:342
+#: src/themes/OLH/templates/journal/article.html:387
+#: src/themes/clean/templates/journal/article.html:243
+#: src/themes/material/templates/journal/article.html:324
 #, fuzzy
 #| msgid "Published"
 msgid "Publisher"
 msgstr "Cyhoeddwyd"
 
-#: src/themes/OLH/templates/journal/article.html:405
-#: src/themes/clean/templates/journal/article.html:236
+#: src/themes/OLH/templates/journal/article.html:390
+#: src/themes/clean/templates/journal/article.html:246
 #, fuzzy
 #| msgid "Publications"
 msgid "Original Publication"
 msgstr "Cyhoeddiadau"
 
-#: src/themes/OLH/templates/journal/article.html:408
-#: src/themes/clean/templates/journal/article.html:239
-#: src/themes/material/templates/journal/article.html:354
+#: src/themes/OLH/templates/journal/article.html:393
+#: src/themes/clean/templates/journal/article.html:249
+#: src/themes/material/templates/journal/article.html:336
 msgid "Original ISSN"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:416
-#: src/themes/clean/templates/journal/article.html:209
-#: src/themes/material/templates/journal/article.html:366
-#: src/themes/material/templates/repository/preprint.html:140
+#: src/themes/OLH/templates/journal/article.html:396
+#: src/themes/clean/templates/journal/article.html:223
+#: src/themes/material/templates/journal/article.html:342
+#, fuzzy
+#| msgid "Submitted"
+msgid "Submitted on"
+msgstr "Cyflwynwyd"
+
+#: src/themes/OLH/templates/journal/article.html:399
+#: src/themes/clean/templates/journal/article.html:228
+#: src/themes/material/templates/journal/article.html:348
+msgid "Accepted on"
+msgstr "Derbyniwyd ar"
+
+#: src/themes/OLH/templates/journal/article.html:407
+#: src/themes/clean/templates/journal/article.html:211
+#: src/themes/material/templates/journal/article.html:368
+#: src/themes/material/templates/repository/preprint.html:138
 msgid "Supplementary Files"
 msgstr "Ffeiliau Atodol"
 
-#: src/themes/OLH/templates/journal/article.html:439
-#: src/themes/material/templates/journal/article.html:381
+#: src/themes/OLH/templates/journal/article.html:430
+#: src/themes/material/templates/journal/article.html:383
 msgid "View Summary"
 msgstr "Gweld y Crynodeb"
 
-#: src/themes/OLH/templates/journal/article.html:446
+#: src/themes/OLH/templates/journal/article.html:437
 msgid "Jump to"
 msgstr "Neidio i"
 
-#: src/themes/OLH/templates/journal/article.html:472
-#: src/themes/clean/templates/journal/article.html:305
-#: src/themes/material/templates/journal/article.html:478
+#: src/themes/OLH/templates/journal/article.html:463
+#: src/themes/clean/templates/journal/article.html:324
+#: src/themes/material/templates/journal/article.html:464
 msgid "File Checksums"
 msgstr "Checksums Ffeil"
 
-#: src/themes/OLH/templates/journal/article.html:485
-#: src/themes/material/templates/journal/article.html:446
+#: src/themes/OLH/templates/journal/article.html:473
+#: src/themes/clean/templates/journal/article.html:334
+#: src/themes/material/templates/journal/article.html:475
+msgid "File Checksums are not available for this article."
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:480
+#: src/themes/material/templates/journal/article.html:422
 msgid "Peer Review"
 msgstr "Adolygiadau Cymheiriaid"
 
@@ -4127,7 +4543,6 @@ msgstr "Casgliad"
 
 #: src/themes/OLH/templates/journal/collections.html:29
 #: src/themes/OLH/templates/repository/preprint.html:124
-#: src/themes/material/templates/journal/article.html:400
 msgid "Published"
 msgstr "Cyhoeddwyd"
 
@@ -4162,21 +4577,21 @@ msgstr "Cyfnodolion Nodwedd "
 msgid "Unnamed Journal"
 msgstr "Cyfnodolyn Dienw"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
 #: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
 #, fuzzy
 #| msgid "Dates"
 msgid "Latest"
 msgstr "Dyddiadau"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
 #: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
 msgid "Posts"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:35
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:36
 #: src/themes/clean/templates/press/core/news/index.html:21
 msgid "This journal currently has no news items to display"
 msgstr ""
@@ -4192,18 +4607,6 @@ msgstr "Erthyglau Mwyaf Poblogaidd"
 #: src/themes/clean/templates/journal/homepage_elements/preprints.html:6
 msgid "Featured Preprints"
 msgstr "Rhagargraffiadau Nodwedd"
-
-#: src/themes/OLH/templates/journal/issues.html:31
-#: src/themes/clean/templates/journal/issues.html:19
-#: src/themes/clean/templates/journal/issues.html:28
-#: src/themes/material/templates/journal/issues.html:29
-#: src/themes/material/templates/journal/issues.html:31
-msgid "items"
-msgstr "Eitemau"
-
-#: src/themes/OLH/templates/journal/issues.html:39
-msgid "There are no issues published in this journal yet."
-msgstr "Does dim rhifynnau o’r cyfnodolyn hwn wedi’u cyhoeddi eto."
 
 #: src/themes/OLH/templates/journal/keyword.html:6
 #: src/themes/OLH/templates/journal/keyword.html:12
@@ -4249,37 +4652,38 @@ msgstr "Cyflwyniadau"
 msgid "Login with ORCiD"
 msgstr "Mewngofnodi gydag ORCiD"
 
-#: src/themes/OLH/templates/press/core/news/index.html:5
-#: src/themes/OLH/templates/press/core/news/index.html:10
-#: src/themes/OLH/templates/press/core/news/item.html:5
+#: src/themes/OLH/templates/press/core/news/index.html:6
+#: src/themes/OLH/templates/press/core/news/index.html:11
+#: src/themes/OLH/templates/press/core/news/item.html:6
 #: src/themes/clean/templates/press/core/news/index.html:9
 #: src/themes/clean/templates/press/nav.html:16
+#: src/themes/hourglass/templates/press/news/index.html:4
 #: src/themes/material/templates/core/nav.html:88
 #: src/themes/material/templates/press/core/news/index.html:5
 #: src/themes/material/templates/press/core/news/index.html:10
-#: src/themes/material/templates/press/core/news/item.html:5
+#: src/themes/material/templates/press/core/news/item.html:6
 msgid "News"
 msgstr "Newyddion"
 
-#: src/themes/OLH/templates/press/core/news/index.html:31
+#: src/themes/OLH/templates/press/core/news/index.html:32
 msgid "This press currently has no news items to display."
 msgstr "Does dim eitemau newyddion gan y wasg hon i’w dangos ar hyn o bryd."
 
-#: src/themes/OLH/templates/press/core/news/item.html:33
+#: src/themes/OLH/templates/press/core/news/item.html:34
 #: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
+#: src/themes/material/templates/press/core/news/item.html:18
 msgid "Posted by"
 msgstr "Postiwyd gan"
 
-#: src/themes/OLH/templates/press/core/news/item.html:40
-#: src/themes/material/templates/core/news/item.html:35
-#: src/themes/material/templates/press/core/news/item.html:22
+#: src/themes/OLH/templates/press/core/news/item.html:41
+#: src/themes/material/templates/core/news/item.html:36
+#: src/themes/material/templates/press/core/news/item.html:23
 msgid "Tags"
 msgstr "Tagiau"
 
-#: src/themes/OLH/templates/press/core/news/item.html:45
+#: src/themes/OLH/templates/press/core/news/item.html:46
 #: src/themes/clean/templates/press/core/news/item.html:18
-#: src/themes/material/templates/press/core/news/item.html:30
+#: src/themes/material/templates/press/core/news/item.html:31
 msgid "Back to News List"
 msgstr "Yn ôl i’r Rhestr Newyddion"
 
@@ -4292,6 +4696,7 @@ msgstr "Map o’r Safle"
 #: src/themes/OLH/templates/press/press_journals.html:5
 #: src/themes/clean/templates/press/nav.html:37
 #: src/themes/clean/templates/press/press_journals.html:10
+#: src/themes/hourglass/templates/press/press_journals.html:9
 #: src/themes/material/templates/press/press_journals.html:9
 msgid "Journals"
 msgstr "Cyfnodolion "
@@ -4307,16 +4712,22 @@ msgstr "Cynadleddau "
 msgid "Repositories"
 msgstr ""
 
+#: src/themes/OLH/templates/press/nav.html:39
+#: src/themes/material/templates/preprints/editors.html:5
+#: src/themes/material/templates/preprints/editors.html:6
+msgid "Editorial Team"
+msgstr "Tîm Golygyddol"
+
 #: src/themes/OLH/templates/press/press_journals.html:48
 msgid "Disciplines"
 msgstr "Disgyblaethau"
 
 #: src/themes/OLH/templates/press/press_journals.html:61
 #: src/themes/OLH/templates/press/press_journals.html:68
-#: src/themes/clean/templates/journal/article.html:195
+#: src/themes/clean/templates/journal/article.html:194
 #: src/themes/clean/templates/press/press_journals.html:32
 #: src/themes/clean/templates/press/press_journals.html:39
-#: src/themes/material/templates/journal/article.html:303
+#: src/themes/material/templates/journal/article.html:283
 #: src/themes/material/templates/press/press_journals.html:36
 #: src/themes/material/templates/press/press_journals.html:43
 msgid "View"
@@ -4372,7 +4783,7 @@ msgstr "Cyswllt Awdur "
 #: src/themes/OLH/templates/repository/nav.html:6
 #: src/themes/material/templates/repository/nav.html:21
 #: src/themes/material/templates/repository/nav.html:45
-#: src/themes/material/templates/repository/preprint.html:168
+#: src/themes/material/templates/repository/preprint.html:166
 #, fuzzy
 #| msgid "Subject"
 msgid "Subjects"
@@ -4387,7 +4798,7 @@ msgstr "Rhagargraffiad"
 
 #: src/themes/OLH/templates/repository/preprint.html:60
 #: src/themes/material/templates/preprints/article.html:63
-#: src/themes/material/templates/repository/preprint.html:87
+#: src/themes/material/templates/repository/preprint.html:85
 msgid "Comments"
 msgstr "Sylwadau"
 
@@ -4411,16 +4822,23 @@ msgstr ""
 msgid "Last Updated"
 msgstr "Diweddaru"
 
-#: src/themes/OLH/templates/repository/preprint.html:134
+#: src/themes/OLH/templates/repository/preprint.html:138
 #: src/themes/material/templates/preprints/article.html:135
 msgid "Versions"
 msgstr "Fersiynau"
 
-#: src/themes/OLH/templates/repository/preprint.html:139
+#: src/themes/OLH/templates/repository/preprint.html:143
 msgid "This is the only version of the preprint."
 msgstr "Dyma’r unig fersiwn o’r rhagargraffiad."
 
-#: src/themes/OLH/templates/repository/preprint.html:143
+#: src/themes/OLH/templates/repository/preprint.html:149
+#: src/themes/clean/templates/journal/article.html:288
+#: src/themes/material/templates/preprints/article.html:130
+#: src/themes/material/templates/repository/preprint.html:201
+msgid "Metrics"
+msgstr "Metrigau "
+
+#: src/themes/OLH/templates/repository/preprint.html:156
 #: src/themes/material/templates/preprints/article.html:152
 #: src/themes/material/templates/preprints/list.html:6
 #: src/themes/material/templates/preprints/list.html:14
@@ -4431,16 +4849,11 @@ msgstr "Pob Rhagargraffiad"
 msgid "You do not have permission to view this page"
 msgstr ""
 
-#: src/themes/clean/templates/500.html:21
-#: src/themes/clean/templates/core/base.html:37
-msgid "Skip to main content"
-msgstr ""
-
 #: src/themes/clean/templates/500.html:27
 msgid "A server error has occurred."
 msgstr ""
 
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:10
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:14
 msgid ""
 "The ORCiD you logged in with is not currently linked with an account in our "
 "system. You can either\n"
@@ -4452,15 +4865,12 @@ msgstr ""
 "fewngofnodi gyda chyfrif sy’n bodoli eisoes i gysylltu eich ORCiD i’w "
 "ddefnyddio yn y dyfodol."
 
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:34
 msgid "Forgot your password"
 msgstr "Wedi anghofio eich cyfrinair"
 
-#: src/themes/clean/templates/core/accounts/public_profile.html:10
-msgid "profile photo"
-msgstr "ffoto proffil"
-
-#: src/themes/clean/templates/core/accounts/register.html:24
+#: src/themes/clean/templates/core/accounts/register.html:26
+#: src/themes/clean/templates/core/accounts/reset_password.html:26
 msgid ""
 "For more information read our <a href=\"#\" data-toggle=\"modal\" data-"
 "target=\"#passwordmodal\">password guide</a>."
@@ -4496,16 +4906,7 @@ msgstr ""
 "flynyddoedd i’w ddatrys yn hytrach na chyfrinair cymhleth fel Jfjfy&65^87 a "
 "fyddai’n cymryd ychydig dros 600 o flynyddoedd ar gyfrifiadur safonol."
 
-#: src/themes/clean/templates/core/accounts/reset_password.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:23
-msgid ""
-"For more information read our\n"
-"                                    <a href=\"#passwordmodal\" class=\"modal-"
-"trigger\">password guide</a>\n"
-"                                    ."
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/reset_password.html:50
+#: src/themes/clean/templates/core/accounts/reset_password.html:54
 msgid ""
 "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
 "secure than a long and\n"
@@ -4514,7 +4915,7 @@ msgstr ""
 "Mae’n fyth cyffredin fod cyfrinair byr a chymhleth (Jfjfy&65^87) yn fwy "
 "diogel na chyfrinair hir llai cymhleth (our awesome moon base rocks)."
 
-#: src/themes/clean/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/reset_password.html:56
 msgid ""
 "We recommend selecting a long, but easy to remember password such as <em>our "
 "awesome moon base\n"
@@ -4580,10 +4981,22 @@ msgstr "Nodwch y Cyfrinair Newydd"
 msgid "Enter New Password Again"
 msgstr "Nodwch y Cyfrinair Newydd Eto"
 
+#: src/themes/clean/templates/elements/journal/issue_list.html:8
+msgid "This journal has no issues"
+msgstr "Nid oes gan y cyfnodolyn hwn unrhyw rifynnau"
+
+#: src/themes/clean/templates/elements/journal/issue_list_by_decade.html:2
+msgid ""
+"\n"
+"        Issues are grouped by decade. Select a decade to view the issues\n"
+"        published during that decade.\n"
+"    "
+msgstr ""
+
 #: src/themes/clean/templates/elements/journal/table_modal.html:12
 #: src/themes/clean/templates/elements/public_reviews.html:35
 #: src/themes/material/templates/core/accounts/register.html:61
-#: src/themes/material/templates/core/accounts/reset_password.html:49
+#: src/themes/material/templates/core/accounts/reset_password.html:51
 #: src/themes/material/templates/elements/summary_modal.html:13
 msgid "Close"
 msgstr "Cau"
@@ -4613,47 +5026,28 @@ msgstr ""
 msgid "Sections submission information"
 msgstr "Gwybodaeth cyflwyno adrannau "
 
-#: src/themes/clean/templates/journal/article.html:133
-#, python-format
-msgid ""
-"\n"
-"                                        (grant %(id)s)\n"
-"                                    "
-msgstr ""
-
-#: src/themes/clean/templates/journal/article.html:268
+#: src/themes/clean/templates/journal/article.html:278
 #, fuzzy
 #| msgid "Peer Review"
 msgid "Open Peer Reviews"
 msgstr "Adolygiadau Cymheiriaid"
 
-#: src/themes/clean/templates/journal/article.html:278
-#: src/themes/material/templates/preprints/article.html:130
-msgid "Metrics"
-msgstr "Metrigau "
-
-#: src/themes/clean/templates/journal/article.html:285
-#: src/themes/material/templates/journal/article.html:203
+#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/material/templates/journal/article.html:184
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: src/themes/clean/templates/journal/article.html:287
-#: src/themes/material/templates/journal/article.html:211
+#: src/themes/clean/templates/journal/article.html:297
+#: src/themes/material/templates/journal/article.html:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/themes/clean/templates/journal/article.html:292
+#: src/themes/clean/templates/journal/article.html:302
 #: src/themes/material/templates/preprints/article.html:145
 msgid "Citation"
 msgstr "Cyfeirnod "
 
-#: src/themes/clean/templates/journal/article.html:317
-#: src/themes/material/templates/journal/article.html:494
-#: src/themes/material/templates/journal/submissions.html:72
-msgid "Table of Contents"
-msgstr "Tabl Cynnwys"
-
-#: src/themes/clean/templates/journal/article.html:343
+#: src/themes/clean/templates/journal/article.html:366
 msgid "View Larger Table"
 msgstr ""
 
@@ -4669,7 +5063,7 @@ msgstr "Adrannau "
 
 #: src/themes/clean/templates/journal/authors.html:26
 #: src/themes/material/templates/journal/authors.html:31
-#: src/themes/material/templates/journal/editorial_team.html:36
+#: src/themes/material/templates/journal/editorial_team.html:34
 #, fuzzy
 #| msgid "Edit Profile"
 msgid "View Profile"
@@ -4701,13 +5095,9 @@ msgstr "Nesaf"
 msgid "Play"
 msgstr "Chwarae"
 
-#: src/themes/clean/templates/journal/issues.html:16
+#: src/themes/clean/templates/journal/issues.html:14
 msgid "The current issue is"
 msgstr "Y rhifyn cyfredol yw"
-
-#: src/themes/clean/templates/journal/issues.html:30
-msgid "This journal has no issues"
-msgstr "Nid oes gan y cyfnodolyn hwn unrhyw rifynnau"
 
 #: src/themes/clean/templates/press/press_journals.html:52
 #, fuzzy
@@ -4720,7 +5110,65 @@ msgstr "Nid oes gan y cyfnodolyn hwn unrhyw rifynnau"
 msgid "Start typing to filter."
 msgstr ""
 
-#: src/themes/material/templates/core/accounts/activate_account.html:25
+#: src/themes/hourglass/templates/core/accounts/orcid_registration.html:10
+#, fuzzy
+#| msgid "Unregistered ORCiD"
+msgid "Unregistered ORCID"
+msgstr "Dadgofrestru ORCiD"
+
+#: src/themes/hourglass/templates/custom/get-reset-token.html:27
+#, fuzzy
+#| msgid "Enter your email address to begin the reset process"
+msgid ""
+"\n"
+"                  Enter your email address to begin the reset process\n"
+"                "
+msgstr "Nodwch eich cyfeiriad ebost i ddechrau’r broses ailosod "
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:19
+#, fuzzy
+#| msgid ""
+#| "The ORCiD you logged in with is not currently linked with an account in "
+#| "our system. You can either register a new account, or login with an "
+#| "existing account to link your ORCiD for future use."
+msgid ""
+"\n"
+"          <p>The ORCiD you logged in with is not currently linked with\n"
+"          an account in our system. You can either register a new account, "
+"or\n"
+"          login with an existing account to link your ORCiD for future use.</"
+"p>\n"
+"        "
+msgstr ""
+"Nid yw’r ORCiD y defnyddioch i fewngofnodi ar hyn o bryd yn gysylltiedig â "
+"chyfrif yn ein system. Gallwch naill ai gofrestru cyfrif newydd, neu "
+"fewngofnodi gyda chyfrif sy’n bodoli eisoes i gysylltu eich ORCiD i’w "
+"ddefnyddio yn y dyfodol."
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:43
+#, fuzzy
+#| msgid "Register an Account"
+msgid "Register an account"
+msgstr "Cofrestru Cyfrif"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:46
+#, fuzzy
+#| msgid "Reset Your Password"
+msgid "Reset your password"
+msgstr "Ailosod eich Cyfrinair"
+
+#: src/themes/hourglass/templates/custom/profile.html:40
+msgid ""
+"\n"
+"                    Please note: If you update your email,\n"
+"                    You will be logged out, and you won't be\n"
+"                    able to log in again until you follow\n"
+"                    the verification link in an email\n"
+"                    sent to your new email address.\n"
+"                  "
+msgstr ""
+
+#: src/themes/material/templates/core/accounts/activate_account.html:29
 msgid ""
 "There was no inactive account with this activation code found. It is "
 "possible that your account is already active, you can check by attempting to "
@@ -4728,8 +5176,15 @@ msgstr ""
 "Ni chanfuwyd cyfrif segur gyda’r cod actifadu hwn. Mae’n bosibl fod eich "
 "cyfrif eisoes yn weithredol, gallwch wirio drwy geisio "
 
+#: src/themes/material/templates/core/accounts/register.html:29
+#: src/themes/material/templates/core/accounts/reset_password.html:26
+msgid ""
+"For more information read our <a href=\"#\" data-target=\"passwordmodal\" "
+"class=\"modal-trigger\">password guide</a>."
+msgstr ""
+
 #: src/themes/material/templates/core/accounts/register.html:56
-#: src/themes/material/templates/core/accounts/reset_password.html:44
+#: src/themes/material/templates/core/accounts/reset_password.html:46
 msgid ""
 "We recommend selecting a long, but easy to remember password such as <i>our "
 "awesome moon base\n"
@@ -4757,7 +5212,7 @@ msgstr "Cofrestru Cyfrif"
 msgid "Reset Your Password"
 msgstr "Ailosod eich Cyfrinair"
 
-#: src/themes/material/templates/core/news/index.html:39
+#: src/themes/material/templates/core/news/index.html:40
 #, fuzzy
 #| msgid "This journal currently has no news items to display."
 msgid "This journal currently has no items to display."
@@ -4806,57 +5261,45 @@ msgstr "Gallwch allforio eich data i ffeil JSON i’w ailddefnyddio."
 msgid "Export"
 msgstr "Allforio "
 
+#: src/themes/material/templates/elements/journal/issue_list.html:26
+#, fuzzy
+#| msgid "Close"
+msgid "close"
+msgstr "Cau"
+
+#: src/themes/material/templates/elements/journal/issue_list.html:30
+msgid "View Issue"
+msgstr "Gweld Rhifyn"
+
 #: src/themes/material/templates/elements/license_block.html:4
 #, fuzzy
 #| msgid "Author Information"
 msgid "More Information "
 msgstr "Gwybodaeth Awdur "
 
-#: src/themes/material/templates/journal/article.html:161
-#, python-format
-msgid ""
-"\n"
-"                                                (grant %(id)s)\n"
-"                                            "
-msgstr ""
-
-#: src/themes/material/templates/journal/article.html:195
+#: src/themes/material/templates/journal/article.html:176
 msgid "Tweets"
 msgstr "Trydar"
 
-#: src/themes/material/templates/journal/article.html:336
+#: src/themes/material/templates/journal/article.html:318
 #, fuzzy
 #| msgid "Article Info"
 msgid "Article No."
 msgstr "Gwybodaeth am yr Erthygl"
 
-#: src/themes/material/templates/journal/article.html:348
+#: src/themes/material/templates/journal/article.html:330
 #, fuzzy
 #| msgid "Publications"
 msgid "Publication"
 msgstr "Cyhoeddiadau"
 
-#: src/themes/material/templates/journal/article.html:389
-msgid "Dates"
-msgstr "Dyddiadau"
-
-#: src/themes/material/templates/journal/article.html:450
+#: src/themes/material/templates/journal/article.html:426
 msgid "This article has been peer reviewed."
 msgstr "Mae’r erthygl hon wedi’i chymheirio"
 
 #: src/themes/material/templates/journal/collections.html:33
 msgid "View Collection"
 msgstr "Gweld y Casgliad"
-
-#: src/themes/material/templates/journal/issues.html:35
-#, fuzzy
-#| msgid "Close"
-msgid "close"
-msgstr "Cau"
-
-#: src/themes/material/templates/journal/issues.html:39
-msgid "View Issue"
-msgstr "Gweld Rhifyn"
 
 #: src/themes/material/templates/journal/new_search.html:26
 #: src/themes/material/templates/journal/search.html:28
@@ -4921,30 +5364,91 @@ msgstr "Sefydliad Awdur "
 msgid "Start New Submission"
 msgstr "Dechrau Cyflwyniad"
 
-#: src/themes/material/templates/repository/preprint.html:70
+#: src/themes/material/templates/repository/preprint.html:68
 #, fuzzy
 #| msgid "Comments"
 msgid "Add a Comment"
 msgstr "Sylwadau"
 
-#: src/utils/forms.py:102
+#: src/utils/forms.py:107
 #, python-format
 msgid "What is %(num1)i %(operator)s %(num2)i? "
 msgstr "Beth yw %(num1)i %(operator)s %(num2)i? "
 
-#: src/utils/forms.py:103
+#: src/utils/forms.py:108
 msgid "Answer this question: "
 msgstr "Atebwch y cwestiwn hwn: "
 
-#: src/utils/transactional_emails.py:370
+#: src/utils/forms.py:153
+msgid "HTML is not allowed in this field"
+msgstr ""
+
+#: src/utils/transactional_emails.py:385
 #, fuzzy
 #| msgid "Accepted"
 msgid "accepted"
 msgstr "Derbyniwyd"
 
-#: src/utils/transactional_emails.py:380
+#: src/utils/transactional_emails.py:395
 msgid "declined"
 msgstr ""
+
+#~ msgid "Password 1"
+#~ msgstr "Cyfrinair 1"
+
+#~ msgid "Password 2"
+#~ msgstr "Cyfrinair 2"
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to create a typesetting assignment?"
+#~ msgstr "Nodwch eich cyfrinair newydd ddwywaith i gwblhau’r broses ailosod "
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to create a proofreading assignment?"
+#~ msgstr "Nodwch eich cyfrinair newydd ddwywaith i gwblhau’r broses ailosod "
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to complete the proofreading task?"
+#~ msgstr "Nodwch eich cyfrinair newydd ddwywaith i gwblhau’r broses ailosod "
+
+#~ msgid ""
+#~ "Please avoid pasting content from word processors as they can add "
+#~ "unwanted styling to the abstract. You can retype the abstract here or "
+#~ "copy and paste it into notepad/a plain text editor before pasting here."
+#~ msgstr ""
+#~ "Osgowch ludo cynnwys o broseswyr geiriau gan eu bod yn gallu ychwanegu "
+#~ "gwedd ddieisiau i’r crynodeb. Gallwch aildeipio’r crynodeb yma neu ei "
+#~ "ludo i notepad/golygydd testun plaen cyn gludo yma."
+
+#, fuzzy
+#~| msgid "Options"
+#~ msgid "Email Options"
+#~ msgstr "Opsiynau "
+
+#, fuzzy
+#~| msgid "Submission Checklist"
+#~ msgid "Submission Complete"
+#~ msgstr "Rhestr Wirio Cyflwyniad"
+
+#~ msgid "allows the following licenses for submission"
+#~ msgstr "caniatáu'r trwyddedau canlynol ar gyfer cyflwyno  "
+
+#~ msgid "somebody"
+#~ msgstr "rhywun"
+
+#, fuzzy
+#~| msgid "Account"
+#~ msgid "account"
+#~ msgstr "Cyfrif"
+
+#~ msgid "profile photo"
+#~ msgstr "ffoto proffil"
+
+#~ msgid "Dates"
+#~ msgstr "Dyddiadau"
 
 #~ msgid "File Checksums (MD5)"
 #~ msgstr "Checksums Ffeil (MD5)"
@@ -5052,9 +5556,6 @@ msgstr ""
 #~ msgid "Completed"
 #~ msgstr "Cwblhawyd "
 
-#~ msgid "Funder DOI"
-#~ msgstr "DOI Cyllidwr"
-
 #~ msgid "(optional)"
 #~ msgstr "(dewisol)"
 
@@ -5108,8 +5609,8 @@ msgstr ""
 #~ "                            contain specific\n"
 #~ "                            characters but you should make it as long as "
 #~ "possible. For more information read our\n"
-#~ "                            <a href=\"#\" data-open=\"password-modal"
-#~ "\">password guide</a>"
+#~ "                            <a href=\"#\" data-open=\"password-"
+#~ "modal\">password guide</a>"
 #~ msgstr ""
 #~ "Dylai eich cyfrinair fod yn 12 nod o leiaf. Nid oes angen iddo gynnwys "
 #~ "nodau penodol ond dylech ei wneud mor hir â phosibl. I gael rhagor o "
@@ -5151,8 +5652,8 @@ msgstr ""
 #~| "                                    need to contain specific\n"
 #~| "                                    characters but you should make it as "
 #~| "long as possible. For more information read our\n"
-#~| "                                    <a href=\"#passwordmodal\" class="
-#~| "\"modal-trigger\"> password guide</a>."
+#~| "                                    <a href=\"#passwordmodal\" "
+#~| "class=\"modal-trigger\"> password guide</a>."
 #~ msgid ""
 #~ "Your password should be at minimum 12 characters long. It does not\n"
 #~ "                                    need to contain specific\n"
@@ -5193,8 +5694,8 @@ msgstr ""
 #~ "                        to contain specific characters but you should "
 #~ "make it as long as possible. For more\n"
 #~ "                        information read on\n"
-#~ "                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-#~ "\"> password guide</a>\n"
+#~ "                        <a href=\"#passwordmodal\" class=\"modal-"
+#~ "trigger\"> password guide</a>\n"
 #~ "                        ."
 #~ msgstr ""
 #~ "Dylai eich cyfrinair fod yn 12 nod o leiaf. Nid oes angen iddo gynnwys "

--- a/src/core/locales/de/LC_MESSAGES/django.po
+++ b/src/core/locales/de/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Janeway\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-13 10:37+0000\n"
+"POT-Creation-Date: 2024-12-05 10:48+0000\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -10,49 +10,56 @@ msgstr ""
 "X-Generator: POEditor.com\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/comms/models.py:94
+#: src/comms/models.py:119
 #, python-brace-format
 msgid "Posted by {byline}"
 msgstr "Gepostet von {byline}"
 
-#: src/comms/models.py:95
+#: src/comms/models.py:120
 #, python-brace-format
 msgid "Posted by  {byline}"
 msgstr "Gepostet von  {byline}"
 
-#: src/copyediting/forms.py:16
+#: src/copyediting/forms.py:17
 msgid "Are you sure you want to create a copyediting assignment?"
 msgstr "Sind Sie sicher, dass Sie einen Copyediting Auftrag aufgeben möchten?"
 
-#: src/copyediting/forms.py:99
+#: src/copyediting/forms.py:104
 msgid "Are you sure you want to ask the author to review copyedits?"
 msgstr "Sind Sie sicher, dass Sie den Autor nach einem Review fragen möchten?"
 
-#: src/copyediting/forms.py:146
+#: src/copyediting/forms.py:151
 msgid "Are you sure you want to complete the copyedit task?"
 msgstr "Sind Sie sicher, dass Sie den Copyediting Auftrag abschließen möchten?"
 
-#: src/core/forms/forms.py:110
-msgid "Password 1"
-msgstr "Passwort 1"
-
-#: src/core/forms/forms.py:111
-msgid "Password 2"
-msgstr "Passwort 2"
-
-#: src/core/forms/forms.py:129
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/core/forms/forms.py:114 src/core/forms/forms.py:162
+#: src/templates/admin/core/accounts/orcid_registration.html:29
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
 #: src/themes/OLH/templates/press/core/login.html:33
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:24
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:28
 #: src/themes/clean/templates/core/login.html:34
+#: src/themes/hourglass/templates/custom/orcid-registration.html:32
 msgid "Password"
 msgstr "Passwort"
 
-#: src/core/forms/forms.py:130
+#: src/core/forms/forms.py:123 src/core/forms/forms.py:170
 msgid "Repeat Password"
 msgstr "Passwort wiederholen"
 
-#: src/core/forms/forms.py:133
+#: src/core/forms/forms.py:148 src/core/models.py:235
+#: src/templates/admin/core/accounts/orcid_registration.html:25
+#: src/templates/admin/repository/article.html:213
+#: src/templates/admin/repository/author_article.html:92
+#: src/templates/admin/repository/submit/authors.html:77
+#: src/templates/admin/submission/submit_authors.html:70
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:33
+#: src/themes/OLH/templates/press/core/login.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:25
+#: src/themes/hourglass/templates/custom/orcid-registration.html:28
+msgid "Email"
+msgstr "Email"
+
+#: src/core/forms/forms.py:179
 msgid ""
 "Check this box if you would like to receive notifications of new articles "
 "published in this journal"
@@ -60,15 +67,15 @@ msgstr ""
 "Klicken Sie diese Box an, wenn Sie Benachrichtigungen über neu publizierte "
 "Artikel in dieser Zeitschrift erhalten möchten"
 
-#: src/core/forms/forms.py:495
+#: src/core/forms/forms.py:578
 msgid "E-mail"
 msgstr "E-mail"
 
-#: src/core/forms/forms.py:694
+#: src/core/forms/forms.py:783
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
 
-#: src/core/forms/forms.py:725
+#: src/core/forms/forms.py:814
 #, fuzzy, python-format
 #| msgid ""
 #| "The account belonging to %(email)s has not yet been activated, so the "
@@ -118,221 +125,215 @@ msgstr ""
 msgid "Issues and Collections"
 msgstr "Ausgaben und Sammlungen"
 
-#: src/core/janeway_global_settings.py:252
+#: src/core/janeway_global_settings.py:254
 msgid "English"
 msgstr "Englisch"
 
-#: src/core/janeway_global_settings.py:253
+#: src/core/janeway_global_settings.py:255
 msgid "English (US)"
 msgstr "Englisch (US)"
 
-#: src/core/janeway_global_settings.py:254
+#: src/core/janeway_global_settings.py:256
 msgid "French"
 msgstr "Französisch"
 
-#: src/core/janeway_global_settings.py:255
+#: src/core/janeway_global_settings.py:257
 msgid "German"
 msgstr "Deutsch"
 
-#: src/core/janeway_global_settings.py:256
+#: src/core/janeway_global_settings.py:258
 msgid "Dutch"
 msgstr "Niederländisch"
 
-#: src/core/janeway_global_settings.py:257
+#: src/core/janeway_global_settings.py:259
 msgid "Welsh"
 msgstr "Walisisch"
 
-#: src/core/logic.py:810
+#: src/core/logic.py:833
 msgid "Your password must be {} characters long"
 msgstr "Ihr Passwort muss {} Zeichen lang sein"
 
-#: src/core/logic.py:814
+#: src/core/logic.py:837
 msgid "An uppercase character is required"
 msgstr "Es wird ein Großbuchstabe benötigt"
 
-#: src/core/logic.py:817
+#: src/core/logic.py:840
 msgid "A number is required"
 msgstr "Es wird eine Ziffer benötigt"
 
-#: src/core/models.py:69
+#: src/core/models.py:77
 msgid "Miss"
 msgstr "Frau"
 
-#: src/core/models.py:70
+#: src/core/models.py:78
 msgid "Ms"
 msgstr "Frau"
 
-#: src/core/models.py:71
+#: src/core/models.py:79
 msgid "Mrs"
 msgstr "Frau"
 
-#: src/core/models.py:72
+#: src/core/models.py:80
 msgid "Mr"
 msgstr "Herr"
 
-#: src/core/models.py:73
+#: src/core/models.py:81
 msgid "Mx"
 msgstr "(keine Angabe)"
 
-#: src/core/models.py:74
+#: src/core/models.py:82
 msgid "Dr"
 msgstr "Dr. / Dr.'in"
 
-#: src/core/models.py:75
+#: src/core/models.py:83
 msgid "Prof."
 msgstr "Prof. / Prof.'in"
 
-#: src/core/models.py:208 src/templates/admin/repository/article.html:213
-#: src/templates/admin/repository/author_article.html:92
-#: src/templates/admin/repository/submit/authors.html:80
-#: src/templates/admin/submission/submit_authors.html:65
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:26
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:29
-#: src/themes/OLH/templates/press/core/login.html:30
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:16
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:18
-msgid "Email"
-msgstr "Email"
-
-#: src/core/models.py:209
+#: src/core/models.py:236
 msgid "Username"
 msgstr "Benutzername"
 
-#: src/core/models.py:211
+#: src/core/models.py:242
 msgid "First name"
 msgstr "Vorname"
 
-#: src/core/models.py:212 src/submission/forms.py:271
+#: src/core/models.py:248 src/submission/forms.py:286
 msgid "Middle name"
 msgstr "Zweiter Vorname"
 
-#: src/core/models.py:213 src/submission/forms.py:272
+#: src/core/models.py:254 src/submission/forms.py:287
 msgid "Last name"
 msgstr "Nachname"
 
-#: src/core/models.py:217
+#: src/core/models.py:263
 msgid "Salutation"
 msgstr "Anrede"
 
-#: src/core/models.py:222
-msgid "Name suffix eg. jr"
+#: src/core/models.py:269
+#, fuzzy
+#| msgid "Name suffix eg. jr"
+msgid "Name suffix"
 msgstr "Namenszusatz, z.B. Jr"
 
-#: src/core/models.py:224
-#: src/themes/OLH/templates/core/accounts/public_profile.html:19
-#: src/themes/clean/templates/core/accounts/public_profile.html:19
-#: src/themes/material/templates/core/accounts/public_profile.html:19
+#: src/core/models.py:274
+#: src/themes/OLH/templates/core/accounts/public_profile.html:50
+#: src/themes/clean/templates/core/accounts/public_profile.html:23
+#: src/themes/material/templates/core/accounts/public_profile.html:23
 msgid "Biography"
 msgstr "Biografie"
 
-#: src/core/models.py:225 src/submission/models.py:1943
+#: src/core/models.py:276 src/submission/models.py:2014
 msgid "ORCiD"
 msgstr "ORCiD"
 
-#: src/core/models.py:226 src/submission/forms.py:275
+#: src/core/models.py:280 src/submission/forms.py:290
 msgid "Institution"
 msgstr "Institution"
 
-#: src/core/models.py:227 src/submission/forms.py:276
+#: src/core/models.py:286 src/submission/forms.py:291
 msgid "Department"
 msgstr "Fachbereich"
 
-#: src/core/models.py:228
+#: src/core/models.py:289
 msgid "Twitter Handle"
 msgstr "X Benutzername"
 
-#: src/core/models.py:229
+#: src/core/models.py:290
 msgid "Facebook Handle"
 msgstr "Facebook Benutzername"
 
-#: src/core/models.py:230
+#: src/core/models.py:291
 msgid "Linkedin Profile"
 msgstr "Linkedin Profil"
 
-#: src/core/models.py:231
+#: src/core/models.py:292
 #: src/themes/OLH/templates/elements/journal/editorial_social_content.html:3
 #: src/themes/clean/templates/elements/journal/editorial_social_content.html:3
 msgid "Website"
 msgstr "Website"
 
-#: src/core/models.py:232
+#: src/core/models.py:293
 msgid "Github Username"
 msgstr "Github Benutzername"
 
-#: src/core/models.py:236
+#: src/core/models.py:297
 msgid "Confirmation Code"
 msgstr "Bestätigungscode"
 
-#: src/core/models.py:237
+#: src/core/models.py:300
 msgid "Signature"
 msgstr "Signatur"
 
-#: src/core/models.py:243
-#: src/themes/OLH/templates/core/accounts/public_profile.html:15
-#: src/themes/clean/templates/core/accounts/public_profile.html:15
-#: src/themes/material/templates/core/accounts/public_profile.html:15
+#: src/core/models.py:307
+#: src/themes/OLH/templates/core/accounts/public_profile.html:45
+#: src/themes/clean/templates/core/accounts/public_profile.html:19
+#: src/themes/material/templates/core/accounts/public_profile.html:19
 msgid "Country"
 msgstr "Land"
 
-#: src/core/models.py:246
+#: src/core/models.py:314
 msgid "Preferred Timezone"
 msgstr "Bevorzugte Zeitzone"
 
-#: src/core/models.py:254
+#: src/core/models.py:323
 msgid "Enable Digest"
 msgstr "Kurzfassung aktivieren"
 
-#: src/core/models.py:259
+#: src/core/models.py:328
 msgid "If enabled, your basic profile will be available to the public."
 msgstr "Wenn aktiv, kann Ihr Profil öffentlich eingesehen werden."
 
-#: src/core/models.py:261
+#: src/core/models.py:330
 msgid "Enable public profile"
 msgstr "Öffentliches Profil aktivieren"
 
-#: src/core/models.py:566 src/core/models.py:578
+#: src/core/models.py:639 src/core/models.py:651
 msgid "Expires on"
 msgstr "verfällt am"
 
-#: src/core/models.py:840 src/core/models.py:1118
+#: src/core/models.py:915 src/core/models.py:1193
 msgid "Article PK"
 msgstr "Artikel-Hauptschlüssel"
 
-#: src/core/models.py:845 src/core/models.py:1123 src/repository/models.py:838
-#: src/templates/admin/elements/submit/file.html:24
-#: src/templates/admin/submission/submit_files.html:40
-#: src/templates/admin/submission/submit_files.html:80
-#: src/templates/admin/submission/submit_review.html:120
+#: src/core/models.py:920 src/core/models.py:1198 src/repository/models.py:848
+#: src/templates/admin/submission/submit_files.html:46
+#: src/templates/admin/submission/submit_files.html:86
+#: src/templates/admin/submission/submit_review.html:136
 msgid "Label"
 msgstr "Kennzeichen"
 
-#: src/core/models.py:846 src/core/models.py:1124
-#: src/templates/admin/elements/submit/file.html:31
+#: src/core/models.py:921 src/core/models.py:1199
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/core/models.py:857
+#: src/core/models.py:932
 msgid "Remote URL of file"
 msgstr "Remote-URL der Datei"
 
-#: src/core/models.py:1150
+#: src/core/models.py:1225
 msgid "Other"
 msgstr "Andere"
 
-#: src/core/models.py:1151
+#: src/core/models.py:1226
 msgid "Image"
 msgstr "Bild"
 
-#: src/core/models.py:1493
+#: src/core/models.py:1594 src/templates/admin/journal/contact.html:38
+#: src/themes/OLH/templates/journal/contact.html:30
+#: src/themes/OLH/templates/press/journal/contact.html:22
+#: src/themes/clean/templates/journal/contact.html:27
+msgid "Who would you like to contact?"
+msgstr "Wen möchten Sie kontaktieren?"
+
+#: src/core/models.py:1595
 msgid "Your contact email address"
 msgstr "Ihre Kontaktadresse (E-Mail)"
 
-#: src/core/models.py:1494
+#: src/core/models.py:1596
 msgid "Subject"
 msgstr "Thema"
 
-#: src/core/models.py:1495
+#: src/core/models.py:1597
 msgid "Your message"
 msgstr "Ihre Nachricht"
 
@@ -352,11 +353,11 @@ msgid ""
 msgstr ""
 "MIME Typ {mimetype} ist nicht zulässig. Zulässig sind: {validator.mimetypes}"
 
-#: src/core/views.py:78
+#: src/core/views.py:80
 msgid "You have been banned from logging in due to failed attempts."
 msgstr "Sie wurden aufgrund von Fehlversuchen für die Anmeldung gesperrt."
 
-#: src/core/views.py:122
+#: src/core/views.py:124
 msgid ""
 "Password reset process has been initiated, please check your inbox for a "
 "reset request link."
@@ -364,7 +365,7 @@ msgstr ""
 "Der Prozess zum Zurücksetzen des Passworts wurde eingeleitet. Bitte prüfen "
 "Sie Ihren Posteingang auf einen Link zum Zurücksetzen."
 
-#: src/core/views.py:132
+#: src/core/views.py:134
 msgid ""
 "Wrong email/password combination or your email address has not been "
 "confirmed yet."
@@ -372,15 +373,15 @@ msgstr ""
 "Die Kombination von E-Mail und Passwort stimmt nicht oder Ihre E-Mail "
 "Adresse wurde noch nicht bestätigt."
 
-#: src/core/views.py:219
+#: src/core/views.py:226
 msgid "You have been logged out."
 msgstr "Sie wurden erfolgreich abgemeldet."
 
-#: src/core/views.py:236
+#: src/core/views.py:249
 msgid "If your account was found, an email has been sent to you."
 msgstr "Falls Ihr Konto gefunden wurde, wurde Ihnen eine E-Mail geschickt."
 
-#: src/core/views.py:355
+#: src/core/views.py:377
 msgid ""
 "Your account has been created. Please follow the instructions in the email "
 "that has been sent to you."
@@ -388,39 +389,39 @@ msgstr ""
 "Ihr Konto wurde angelegt. Bitte folgen Sie den Anweisungen aus der E-Mail, "
 "die Ihnen gerade zugeschickt wurde."
 
-#: src/core/views.py:400
+#: src/core/views.py:420
 msgid "Account activated"
 msgstr "Account aktiviert"
 
-#: src/core/views.py:442
+#: src/core/views.py:469
 msgid "An account with that email address already exists."
 msgstr "Ein Konto mit dieser E-Mail existiert bereits."
 
-#: src/core/views.py:448
+#: src/core/views.py:475
 msgid "Email address is not valid."
 msgstr "Neue E-Mail-Adresse ist nicht gültig."
 
-#: src/core/views.py:463
+#: src/core/views.py:490
 msgid "Password updated."
 msgstr "Passwort aktualisiert."
 
-#: src/core/views.py:467
+#: src/core/views.py:494
 msgid "Passwords do not match"
 msgstr "Passwörter stimmen nicht überein"
 
-#: src/core/views.py:470
+#: src/core/views.py:497
 msgid "Old password is not correct."
 msgstr "Das alte Passwort ist nicht korrekt."
 
-#: src/core/views.py:480
+#: src/core/views.py:507
 msgid "Successfully subscribed to article notifications."
 msgstr "Erfolgreich für Artikelbenachrichtigungen angemeldet."
 
-#: src/core/views.py:491
+#: src/core/views.py:518
 msgid "Successfully unsubscribed from article notifications."
 msgstr "Erfolgreich von den Artikelbenachrichtigungen abgemeldet."
 
-#: src/core/views.py:1943
+#: src/core/views.py:2079
 msgid ""
 "You cannot remove a section that contains articles. Remove articles from the "
 "section if you want to delete it."
@@ -428,73 +429,85 @@ msgstr ""
 "Sie können eine Rubrik, die Artikel enthält, nicht entfernen. Entfernen Sie "
 "Artikel aus der Rubrik, wenn Sie diese löschen möchten."
 
+#: src/core/views.py:2711 src/journal/forms.py:24 src/journal/views.py:2866
+msgid "Newest"
+msgstr "Neuste"
+
+#: src/core/views.py:2712 src/journal/forms.py:25 src/journal/views.py:2867
+msgid "Oldest"
+msgstr "Älteste"
+
+#: src/core/views.py:2713
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name A-Z"
+msgstr "Nachname"
+
+#: src/core/views.py:2714
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name Z-A"
+msgstr "Nachname"
+
 #: src/discussion/models.py:27
 msgid "Max. 300 characters."
 msgstr "Maximal 300 Zeichen."
 
 #. Translators: Search order options
-#: src/journal/forms.py:20
+#: src/journal/forms.py:21
 msgid "Relevance"
 msgstr "Relevanz"
 
-#: src/journal/forms.py:21 src/journal/views.py:2629
+#: src/journal/forms.py:22 src/journal/views.py:2868
 msgid "Titles A-Z"
 msgstr "Titel A-Z"
 
-#: src/journal/forms.py:22 src/journal/views.py:2630
+#: src/journal/forms.py:23 src/journal/views.py:2869
 msgid "Titles Z-A"
 msgstr "Titel Z-A"
 
-#: src/journal/forms.py:23 src/journal/views.py:2627
-msgid "Newest"
-msgstr "Neuste"
-
-#: src/journal/forms.py:24 src/journal/views.py:2628
-msgid "Oldest"
-msgstr "Älteste"
-
-#: src/journal/forms.py:97
+#: src/journal/forms.py:98
 #: src/themes/clean/templates/core/homepage_elements/search_bar.html:20
 msgid "Search term"
 msgstr "Suchwort"
 
-#: src/journal/forms.py:98
+#: src/journal/forms.py:99
 msgid "Search Titles"
 msgstr "Suche nach Titeln"
 
-#: src/journal/forms.py:99
+#: src/journal/forms.py:100
 msgid "Search Abstract"
 msgstr "Suche nach Abstracts"
 
-#: src/journal/forms.py:100
+#: src/journal/forms.py:101
 msgid "Search Authors"
 msgstr "Suche nach Autor*innen"
 
-#: src/journal/forms.py:101
+#: src/journal/forms.py:102
 msgid "Search Keywords"
 msgstr "Suche nach Schlagwörtern"
 
-#: src/journal/forms.py:102
+#: src/journal/forms.py:103
 msgid "Search Full Text"
 msgstr "Suche nach Volltexten"
 
-#: src/journal/forms.py:103
+#: src/journal/forms.py:104
 msgid "Search ORCIDs"
 msgstr "Suche nach ORCIDs"
 
-#: src/journal/forms.py:104 src/templates/common/elements/sorting.html:16
+#: src/journal/forms.py:105 src/templates/common/elements/sorting.html:16
 #: src/themes/clean/templates/elements/sorting.html:17
 #: src/themes/material/templates/elements/sorting.html:31
 msgid "Sort results by"
 msgstr "Sortiere Ergebnisse nach"
 
-#: src/journal/logic.py:212
+#: src/journal/logic.py:216
 msgid "Articles without a section cannot be added to an issue."
 msgstr ""
 "Artikel müssen einer Rubrik zugehören, bevor sie einer Ausgabe zugeordnet "
 "werden können."
 
-#: src/journal/models.py:80
+#: src/journal/models.py:101
 msgid ""
 "Short acronym for the journal. Used as part of the journal URLin path mode "
 "and to uniquely identify the journal"
@@ -502,7 +515,7 @@ msgstr ""
 "Kurzes Akronym für das Journal. Wird als Teil der URL des Journals im "
 "Pfadmodus und zur eindeutigen Identifizierung des Journals verwendet"
 
-#: src/journal/models.py:98
+#: src/journal/models.py:119
 msgid ""
 "The default thumbnail for articles, not to be confused with 'Default cover "
 "image'."
@@ -510,11 +523,11 @@ msgstr ""
 "Das Standard-Thumbnail für Artikel, nicht zu verwechseln mit dem \"Standard-"
 "Coverbild\"."
 
-#: src/journal/models.py:106
+#: src/journal/models.py:127
 msgid "Replaces the press logo in the footer."
 msgstr "Ersetzt das Logo im Footer der Übersichtsseite (press)."
 
-#: src/journal/models.py:113
+#: src/journal/models.py:134
 msgid ""
 "The default cover image for journal issues and for the journal's listing on "
 "the press-level website."
@@ -522,12 +535,12 @@ msgstr ""
 "Das Standard-Cover für die Ausgaben-Seite und die Auflistung der Journals "
 "auf der Übersichtsseite (press)."
 
-#: src/journal/models.py:121
+#: src/journal/models.py:142
 msgid "The default background image for article openers and carousel items."
 msgstr ""
 "Das Standard-Hintergrundbild für Newsartikel und das Nachrichtenkarussell."
 
-#: src/journal/models.py:129
+#: src/journal/models.py:150
 msgid ""
 "The logo-sized image at the top of all pages, typically used for journal "
 "logos."
@@ -535,7 +548,7 @@ msgstr ""
 "Das Bild in Logogröße am oberen Rand aller Seiten, das normalerweise für "
 "Journalogos verwendet wird."
 
-#: src/journal/models.py:137
+#: src/journal/models.py:158
 msgid ""
 "The tiny round or square image appearing in browser tabs before the webpage "
 "title"
@@ -543,30 +556,36 @@ msgstr ""
 "Das kleine runde oder quadratische Bild, das in Browser-Tabs vor dem "
 "Webseitentitel erscheint"
 
-#: src/journal/models.py:148
+#: src/journal/models.py:166
+msgid ""
+"A default image displayed on the profile and editorial team pages when the "
+"user has no set profile image."
+msgstr ""
+
+#: src/journal/models.py:183
 msgid "This field has been deprecated in v1.4.3"
 msgstr ""
 
-#: src/journal/models.py:158
+#: src/journal/models.py:193
 msgid "When enabled, the journal is marked as not hosted in Janeway."
 msgstr ""
 "Wenn diese Option aktiviert ist, wird das Journal als nicht in Janeway "
 "gehostet markiert."
 
-#: src/journal/models.py:169
+#: src/journal/models.py:204
 msgid "If the journal is remote you can link to its submission page."
 msgstr ""
 "Bei einem Remote-Journal können Sie zu dessen Einreichungsseite verlinken."
 
-#: src/journal/models.py:174
+#: src/journal/models.py:209
 msgid "If the journal is remote you can link to its home page."
 msgstr "Bei einem Remote-Journal können Sie zur Homepage verlinken."
 
-#: src/journal/models.py:178
+#: src/journal/models.py:213
 msgid "Enables a \"View PDF\" link on article pages."
 msgstr "Ermöglicht einen \"PDF anzeigen\"-Link auf Artikelseiten."
 
-#: src/journal/models.py:220
+#: src/journal/models.py:255
 msgid ""
 "Whether to display article numbers. Article numbers are distinct from "
 "article ID and can be set in Edit Metadata."
@@ -575,26 +594,26 @@ msgstr ""
 "sich von der Artikel-ID und können unter \"Metadaten bearbeiten\" "
 "eingestellt werden."
 
-#: src/journal/models.py:532
+#: src/journal/models.py:600
 msgid "Please add as much detail as you can."
 msgstr "Bitte fügen Sie so viele Details wie möglich hinzu."
 
-#: src/journal/models.py:573
+#: src/journal/models.py:724
 msgid "Autogenerated cache of the display format of an issue title"
 msgstr ""
 "Automatisch erzeugter Zwischenspeicher für das Anzeigeformat eines "
 "Ausgabetitels"
 
-#: src/journal/models.py:588
+#: src/journal/models.py:739
 msgid "Image representing the cover of a printed issue or volume"
 msgstr ""
 "Bild, das das Cover einer gedruckten Ausgabe oder eines Bandes darstellt"
 
-#: src/journal/models.py:594
+#: src/journal/models.py:745
 msgid "landscape hero image used in the carousel and issue page"
 msgstr "Hero Image für das Nachrichtenkarussell und die Ausgabenseite"
 
-#: src/journal/models.py:613
+#: src/journal/models.py:764
 msgid ""
 "An optional alphanumeric code (Slug) used to generate a verbose  url for "
 "this issue. e.g: 'winter-special-issue'."
@@ -602,76 +621,92 @@ msgstr ""
 "Ein optionaler alphanumerischer Code (Slug), um eine ausführlichere URL für "
 "diese Ausgabe zu erzeugen, z.B. \"Winter-Spezial-Ausgabe\"."
 
-#: src/journal/models.py:635
+#: src/journal/models.py:786
 msgid ""
 "An ISBN is relevant for non-serial collections such as conference proceedings"
 msgstr ""
 "Eine ISBN ist für nicht serielle Sammlungen wie Konferenzberichte relevant"
 
-#: src/journal/models.py:676
+#: src/journal/models.py:827
 #: src/themes/OLH/templates/press/press_journals.html:71
 #: src/themes/clean/templates/press/press_journals.html:42
 #: src/themes/material/templates/press/press_journals.html:46
 msgid "Current Issue"
 msgstr "Aktuelle Ausgabe"
 
-#: src/journal/models.py:734
+#: src/journal/models.py:885
 msgid "pages"
 msgstr "Seiten"
 
-#: src/journal/models.py:736
+#: src/journal/models.py:887
 msgid "page"
 msgstr "Seite"
 
-#: src/journal/views.py:751
+#: src/journal/views.py:771
 msgid "No file uploaded"
 msgstr "Keine Datei hochgeladen"
 
-#: src/journal/views.py:1009
+#: src/journal/views.py:1097
 msgid "Issue not in this journal’s issue list."
 msgstr "Ausgabe nicht in der Ausgabenliste dieses Journals enthalten."
 
-#: src/journal/views.py:1129
+#: src/journal/views.py:1143
+msgid ""
+"Publication date set to { article.date_published.strftime(\"%Y-%m-%d %H:%M "
+"%Z\") } "
+msgstr ""
+
+#: src/journal/views.py:1150
+#, fuzzy
+#| msgid "Publication Fees"
+msgid "Publication date unset"
+msgstr "Publikationsgebühren"
+
+#: src/journal/views.py:1156
+msgid "Something went wrong when trying to save the form. "
+msgstr ""
+
+#: src/journal/views.py:1241
 msgid "Article set for publication."
 msgstr "Artikel zur Veröffentlichung bereit."
 
-#: src/journal/views.py:1401
+#: src/journal/views.py:1516
 msgid "You cannot move the first section up the order list"
 msgstr "Die erste Rubrik kann nicht nach oben verschoben werden"
 
-#: src/journal/views.py:1433
+#: src/journal/views.py:1548
 msgid "You cannot move the last section down the order list"
 msgstr "Die letzte Rubrik kann nicht nach unten verschoben werden"
 
-#: src/journal/views.py:1440
+#: src/journal/views.py:1555
 msgid "This page accepts post requests only."
 msgstr "Die Seite akzeptiert nur POST-Anfragen."
 
-#: src/journal/views.py:1511
+#: src/journal/views.py:1626
 msgid "User is already a guest editor."
 msgstr "Nutzer*in ist bereits Gast-Redakteur*in"
 
-#: src/journal/views.py:1517
+#: src/journal/views.py:1632
 msgid "This user is not a member of this journal."
 msgstr "Nutzer*in ist noch kein Mitglied dieses Journals."
 
-#: src/journal/views.py:1570
+#: src/journal/views.py:1685
 msgid "Editor removed from Issue."
 msgstr "Redakteur*in wurde von dieser Ausgabe entfernt."
 
-#: src/journal/views.py:1576
+#: src/journal/views.py:1691
 msgid "Issue Editor not found."
 msgstr "Redakteur*in der Ausgabe kann nicht gefunden werden."
 
-#: src/journal/views.py:1582
+#: src/journal/views.py:1697
 msgid "No Issue Editor ID supplied."
 msgstr "Es wurde keine ID angegeben für Redakteur*in der Ausgabe."
 
-#: src/journal/views.py:1729
+#: src/journal/views.py:1851
 msgid "Uploaded file is not UTF-8 encoded"
 msgstr "Geladene Datei ist nicht im UTF-8 Format kodiert."
 
-#: src/journal/views.py:1823
+#: src/journal/views.py:1945
 msgid ""
 "You must login before you can become a reviewer. Click the button below to "
 "login."
@@ -679,7 +714,7 @@ msgstr ""
 "Sie müssen sich anmelden, bevor Sie Gutachter*in werden können. Klicken Sie "
 "auf die Schaltfläche unten, um sich anzumelden."
 
-#: src/journal/views.py:1828
+#: src/journal/views.py:1950
 msgid ""
 "You are not yet a reviewer for this journal. Click the button below to "
 "become a reviewer."
@@ -687,99 +722,96 @@ msgstr ""
 "Sie sind noch kein*e Gutachter*in für diese Zeitschrift. Klicken Sie auf die "
 "Schaltfläche, um Gutachter*in zu werden."
 
-#: src/journal/views.py:1833
+#: src/journal/views.py:1955
 msgid "You are already a reviewer."
 msgstr "Sie sind bereits Gutachter*in."
 
-#: src/journal/views.py:1840
+#: src/journal/views.py:1962
 msgid "You are now a reviewer"
 msgstr "Sie sind jetzt Gutachter*in."
 
-#: src/journal/views.py:1879
+#: src/journal/views.py:2001
 msgid "Your message has been sent."
 msgstr "Ihre Nachricht wurde versendet."
 
-#: src/journal/views.py:2313 src/journal/views.py:2330
-#: src/journal/views.py:2340
+#: src/journal/views.py:2478
+#, fuzzy
+#| msgid "Production file uploaded."
+msgid "Manuscript file uploaded."
+msgstr "Produktionsdatei wurde hochgeladen."
+
+#: src/journal/views.py:2495
+#, fuzzy
+#| msgid "Proofing file uploaded."
+msgid "Data/figure file uploaded."
+msgstr "Datei für den Prüfdruck (Proof) wurde hochgeladen."
+
+#: src/journal/views.py:2506
 msgid "Production file uploaded."
 msgstr "Produktionsdatei wurde hochgeladen."
 
-#: src/journal/views.py:2350
+#: src/journal/views.py:2516
+#, fuzzy
+#| msgid "No file uploaded"
+msgid "Galley file uploaded."
+msgstr "Keine Datei hochgeladen"
+
+#: src/journal/views.py:2552
 msgid "Proofing file uploaded."
 msgstr "Datei für den Prüfdruck (Proof) wurde hochgeladen."
 
-#: src/journal/views.py:2603
+#: src/journal/views.py:2558
+#, fuzzy
+#| msgid "Upload files"
+msgid "Saved file."
+msgstr "Dateien hochladen"
+
+#: src/journal/views.py:2568
+#, fuzzy
+#| msgid "Supplementary files"
+msgid "Supplementary file uploaded."
+msgstr "Zusätzliche Dateien"
+
+#: src/journal/views.py:2578
+#, fuzzy
+#| msgid "Proofing file uploaded."
+msgid "Typesetting source file uploaded."
+msgstr "Datei für den Prüfdruck (Proof) wurde hochgeladen."
+
+#: src/journal/views.py:2849
 msgid "Published after"
 msgstr "Veröffentlicht nach"
 
-#: src/journal/views.py:2607
+#: src/journal/views.py:2853
 msgid "Published before"
 msgstr "Veröffentlicht vor"
 
-#: src/journal/views.py:2612
-#: src/templates/admin/submission/submit_review.html:70
+#: src/journal/views.py:2858
+#: src/templates/admin/submission/submit_review.html:75
 msgid "Section"
 msgstr "Rubrik"
 
-#: src/journal/views.py:2631 src/themes/OLH/templates/repository/list.html:77
+#: src/journal/views.py:2870 src/themes/OLH/templates/repository/list.html:77
 #: src/themes/material/templates/preprints/list.html:80
 #: src/themes/material/templates/repository/list.html:61
 msgid "Author Name"
 msgstr "Name Autor*in"
 
-#: src/journal/views.py:2632
+#: src/journal/views.py:2871
 msgid "Volume"
 msgstr "Jahrgang"
 
-#: src/plugins_bak/typesetting/forms.py:16
-msgid "Are you sure you want to create a typesetting assignment?"
-msgstr "Sind Sie sicher, dass Sie einen Typesettingauftrag erstellen möchten?"
-
-#: src/plugins_bak/typesetting/forms.py:90
-msgid "Are you sure you want to create a proofreading assignment?"
-msgstr "Sind Sie sicher, dass sie einen Lektoratsauftrag erstellen möchten?"
-
-#: src/plugins_bak/typesetting/forms.py:160
-msgid "Text to show as the download link on the article page"
-msgstr "Text, der als Download-Link auf der Artikelseite angezeigt werden soll"
-
-#: src/plugins_bak/typesetting/forms.py:199
-msgid "Are you sure you want to complete the proofreading task?"
-msgstr "Sind Sie sicher, dass sie den Lektoratsauftrag abschließen möchten?"
-
-#: src/plugins_bak/typesetting/forms.py:224
-msgid "You have not proofed some galleys:"
-msgstr "Sie haben einige Galleys noch nicht geprüft:"
-
-#: src/plugins_bak/typesetting/logic.py:164
-msgid "Article has no typeset files"
-msgstr "Der Artikel hat keine Dateien für das Typesetting"
-
-#: src/plugins_bak/typesetting/logic.py:165
-msgid "One or more typeset files are missing images"
-msgstr "Eine oder mehrere Dateien für das Typesetting enthalten keine Bilder"
-
-#: src/plugins_bak/typesetting/logic.py:167
-msgid "One or more typesetting or proofing tasks haven't been completed"
-msgstr ""
-"Eine oder mehrere Typesetting- oder Lektoratsarbeiten wurden nicht "
-"abgeschlossen"
-
-#: src/plugins_bak/typesetting/templates/typesetting/typesetting_proofreading_assignment.html:116
-msgid "Mark Task as Complete"
-msgstr "Aufgabe als Erledigt markieren"
-
-#: src/press/views.py:406
+#: src/press/views.py:405
 msgid "Description deleted."
 msgstr "Beschreibung gelöscht"
 
-#: src/press/views.py:419
+#: src/press/views.py:418
 msgid "Description saved."
 msgstr "Beschreibung gespeichert"
 
-#: src/repository/forms.py:44 src/submission/forms.py:75
+#: src/repository/forms.py:42 src/submission/forms.py:87
 #: src/templates/admin/core/manager/sections/section_articles.html:30
-#: src/templates/admin/submission/submit_review.html:46
+#: src/templates/admin/submission/submit_review.html:51
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:21
 #: src/themes/OLH/templates/repository/list.html:75
 #: src/themes/clean/templates/journal/articles.html:65
@@ -789,7 +821,7 @@ msgstr "Beschreibung gespeichert"
 msgid "Title"
 msgstr "Titel"
 
-#: src/repository/forms.py:47 src/submission/forms.py:79
+#: src/repository/forms.py:45
 msgid "Enter your article's abstract here"
 msgstr "Geben Sie hier das Abstract Ihres Artikels ein"
 
@@ -813,7 +845,7 @@ msgstr ""
 "Wenn \"Wahr\" ausgewählt wird, müssen alle hochgeladenen Dateien von "
 "Autor*innen PDF-Dateien sein."
 
-#: src/repository/models.py:350
+#: src/repository/models.py:375
 msgid ""
 "If this field is to be output as a dc metadata field you can addthe type "
 "here."
@@ -821,84 +853,74 @@ msgstr ""
 "Wenn dieses Feld als DublinCore-Metadatenfeld ausgegeben werden soll, können "
 "Sie hier den Typ hinzufügen."
 
-#: src/repository/models.py:396 src/repository/models.py:983
-#: src/repository/models.py:1140 src/submission/models.py:632
+#: src/repository/models.py:421 src/repository/models.py:993
+#: src/repository/models.py:1144 src/submission/models.py:622
 msgid "Your article title"
 msgstr "Titel Ihres Artikels"
 
-#: src/repository/models.py:403 src/submission/models.py:645
-msgid "Copying and pasting from word processors is supported."
-msgstr ""
-"Das Kopieren und Einfügen aus Textverarbeitungsprogrammen wird unterstützt."
-
-#: src/repository/models.py:949
-#: src/templates/admin/submission/submit_review.html:101
+#: src/repository/models.py:959
+#: src/templates/admin/submission/submit_review.html:117
 msgid "ORCID"
 msgstr "ORCID"
 
-#: src/repository/models.py:990 src/repository/models.py:1146
-msgid ""
-"Please avoid pasting content from word processors as they can add unwanted "
-"styling to the abstract. You can retype the abstract here or copy and paste "
-"it into notepad/a plain text editor before pasting here."
-msgstr ""
-"Bitte vermeiden Sie es, das Abstract aus einem Textverarbeitungsprogramm "
-"hierher zu kopieren, da dies zu ungewünschten Formatierungen führen kann. "
-"Sie können den Text hier neu tippen oder zunächst in Notepad oder einen "
-"Plain Text Editor kopieren, bevor Sie ihn hier einfügen. "
-
-#: src/repository/models.py:1209
+#: src/repository/models.py:1206
 msgid "Approved"
 msgstr "Bestätigt"
 
-#: src/repository/models.py:1211
+#: src/repository/models.py:1208
 msgid "Under Review"
 msgstr "In Begutachtung"
 
-#: src/repository/models.py:1213 src/templates/admin/review/view_review.html:64
+#: src/repository/models.py:1210 src/templates/admin/review/view_review.html:64
 msgid "Declined"
 msgstr "Abgelehnt"
 
-#: src/repository/views.py:1076
+#: src/repository/views.py:1097
 msgid "Author information saved"
 msgstr "Autor*innen-Informationen gespeichert"
 
-#: src/review/forms.py:237
+#: src/review/forms.py:242
 msgid "Are you sure you want to request revisions?"
 msgstr "Sind Sie sicher, dass Sie Korrekturen beantragen wollen?"
 
-#: src/review/forms.py:281
+#: src/review/forms.py:292
 msgid "Are you sure you want to complete the revision request?"
 msgstr "Sind Sie sicher, dass Sie den Korrekturauftrag abschließen wollen?"
 
-#: src/review/forms.py:406
+#: src/review/forms.py:415
 msgid "Author can access this review"
 msgstr "Autor*in kann auf das Gutachten zugreifen"
 
-#: src/review/forms.py:407
+#: src/review/forms.py:416
 msgid "Author can access review file"
 msgstr "Autor*in kann auf Gutachtendatei zugreifen"
 
-#: src/review/forms.py:427
+#: src/review/forms.py:436
 #, python-format
 msgid "Author can see ‘%(name)s’"
 msgstr "Autor*in kann ‘%(name)s’ sehen"
 
-#: src/review/models.py:195
+#: src/review/models.py:198
 msgid "Anonymity"
 msgstr "Anonymität"
 
-#: src/review/models.py:331
+#: src/review/models.py:334
 msgid "available for the author to access"
 msgstr "Autor kann darauf zugreifen"
 
-#: src/review/models.py:332
+#: src/review/models.py:335
 msgid "not available for the author to access"
 msgstr "Autor kann darauf nicht zugreifen"
 
-#: src/review/views.py:1605
+#: src/review/views.py:1664
 msgid "This article has already been accepted or declined."
 msgstr "Dieser Artikel wurde schon akzeptiert oder abgelehnt"
+
+#: src/security/templatetags/securitytags.py:102
+#, fuzzy
+#| msgid "Anonymity"
+msgid "[Anonymised data]"
+msgstr "Anonymität"
 
 #: src/submission/decorators.py:22
 msgid "This page can only be accessed on Journals."
@@ -908,68 +930,72 @@ msgstr "Diese Seite ist nur über Zeitschriften zugänglich."
 msgid "Submission is disabled for this journal."
 msgstr "Abgabe ist für diese Zeitschrift deaktiviert. "
 
-#: src/submission/forms.py:76
-#: src/templates/admin/submission/submit_review.html:48
+#: src/submission/forms.py:88
+#: src/templates/admin/submission/submit_review.html:53
 msgid "Subtitle"
 msgstr "Untertitel"
 
-#: src/submission/forms.py:274
+#: src/submission/forms.py:289
 msgid "Enter biography here"
 msgstr "Biografie hier eingeben"
 
-#: src/submission/forms.py:277
+#: src/submission/forms.py:292
 msgid "Twitter handle"
 msgstr "X Benutzername"
 
-#: src/submission/forms.py:278
+#: src/submission/forms.py:293
 msgid "LinkedIn profile"
 msgstr "LinkeIn Profil"
 
-#: src/submission/forms.py:279
+#: src/submission/forms.py:294
 msgid "ImpactStory profile"
 msgstr "ImpactStory Profil"
 
-#: src/submission/forms.py:280
+#: src/submission/forms.py:295
 msgid "ORCID ID"
 msgstr "ORCID ID"
 
-#: src/submission/forms.py:281
+#: src/submission/forms.py:296
 msgid "Email address"
 msgstr "E-Mail Adresse"
 
-#: src/submission/forms.py:338
+#: src/submission/forms.py:352
 #, python-format
 msgid "Currently linked to %s, leave blank to use this address"
 msgstr "Derzeit verlinkt mit %s, leer lassen, um diese Adresse zu verwenden"
 
-#: src/submission/forms.py:343
+#: src/submission/forms.py:357
 #, python-format
 msgid "If left blank, the account ORCiD will be used (%s)"
 msgstr "Bleibt das Feld leer, wird die Account-ORCiD verwendet (%s)"
 
-#: src/submission/logic.py:98
+#: src/submission/logic.py:99
 msgid "You must upload a file that is either a Doc, Docx, RTF or ODT."
 msgstr ""
 "Sie müssen eine Datei in den Formaten Doc, Docx, RTF oder ODT hochladen."
 
-#: src/submission/models.py:639
+#: src/submission/models.py:347
+msgid "Additional information regarding this funding entry"
+msgstr ""
+
+#: src/submission/models.py:629
 msgid "Do not use--deprecated in version 1.4.1 and later."
 msgstr ""
 
-#: src/submission/models.py:654
+#: src/submission/models.py:644
 msgid "The primary language of the article"
 msgstr "Die Hauptsprache des Artikels"
 
-#: src/submission/models.py:715
+#: src/submission/models.py:719
 msgid "Custom page range. e.g.: 'I-VII' or 1-3,4-8"
 msgstr "Benutzerdefinierter Seitenbereich, z.B. 'I-VII' oder 1-3,4-8"
 
-#: src/submission/models.py:738
+#: src/submission/models.py:742
 msgid "Add any comments you'd like the editor to consider here."
 msgstr ""
 "Fügen Sie hier Anmerkungen hinzu, welche die Redaktion berücksichtigen soll."
 
-#: src/submission/models.py:761
+#: src/submission/models.py:765
 msgid ""
 "Custom 'how to cite' text. To be used only if the block generated by Janeway "
 "is not suitable."
@@ -977,7 +1003,7 @@ msgstr ""
 "Benutzerdefinierter Text für die Zitierweise. Nur zu verwenden, wenn der von "
 "Janeway generierte Zitierstil nicht geeignet ist."
 
-#: src/submission/models.py:767 src/submission/models.py:774
+#: src/submission/models.py:771 src/submission/models.py:778
 msgid ""
 "Name of the publisher who published this article Only relevant to migrated "
 "articles from a different publisher"
@@ -985,7 +1011,7 @@ msgstr ""
 "Name des Verlags, der diesen Artikel veröffentlicht hat Nur relevant für "
 "migrierte Artikel aus einem anderen Verlag"
 
-#: src/submission/models.py:780
+#: src/submission/models.py:784
 msgid ""
 "Original ISSN of this article's journal when published Only relevant for "
 "back content published under a different title"
@@ -994,19 +1020,19 @@ msgstr ""
 "wurde Nur relevant für zurückliegende Inhalte, die unter einem anderen Titel "
 "veröffentlicht wurden"
 
-#: src/submission/models.py:1898
+#: src/submission/models.py:1948
 msgid "Optional name prefix (e.g: Prof or Dr)"
 msgstr "optionales Namenspräfix (z.B. Prof. oder Dr.)"
 
-#: src/submission/models.py:1903
+#: src/submission/models.py:1954
 msgid "Optional name suffix (e.g.: Jr or III)"
 msgstr "optionale Namensergänzung (z.B. Jr. oder III.)"
 
-#: src/submission/models.py:1914
+#: src/submission/models.py:1985
 msgid "Frozen Biography"
 msgstr "Archivierte Biografie"
 
-#: src/submission/models.py:1915
+#: src/submission/models.py:1986
 msgid ""
 "The author's biography at the time they published the linked article. For "
 "this article only, it overrides any main biography attached to the author's "
@@ -1019,11 +1045,11 @@ msgstr ""
 "die archivierte Biografie nicht ausgefüllt wird, wird keine Biografie für "
 "das Konto aufgeführt."
 
-#: src/submission/models.py:1939
+#: src/submission/models.py:2009
 msgid "Author Email"
 msgstr "E-Mail Autor*in"
 
-#: src/submission/models.py:1944
+#: src/submission/models.py:2015
 msgid ""
 "ORCiD to be displayed when no account is associated with this author. It "
 "should be introduced in code format (e.g: 0000-0000-0000-000X)"
@@ -1031,7 +1057,7 @@ msgstr ""
 "ORCiD wird angezeigt, wenn kein Autoren-Konto verbunden ist. Es sollte im "
 "Code-Format eingeführt werden (z.B. 0000-0000-0000-000X)"
 
-#: src/submission/models.py:1951
+#: src/submission/models.py:2022
 msgid ""
 "If checked, this authors email address link will be displayed on the article "
 "page."
@@ -1039,86 +1065,86 @@ msgstr ""
 "Wenn diese Option aktiviert ist, wird der Link zur Autoren-E-Mail-Adresse "
 "auf der Artikelseite angezeigt."
 
-#: src/submission/models.py:2311
-#: src/templates/admin/submission/submit_files.html:69
+#: src/submission/models.py:2387
+#: src/templates/admin/submission/submit_files.html:75
 msgid "Figures and Data Files"
 msgstr "Abbildungen und Datensätze"
 
-#: src/submission/models.py:2318
+#: src/submission/models.py:2394
 msgid "The default license applied when no option is presented"
 msgstr "Eine Standardlizenz wird angewendet, wenn keine Auswahl angezeigt wird"
 
-#: src/submission/models.py:2326
+#: src/submission/models.py:2402
 msgid "The default language of articles when lang is hidden"
 msgstr "Die Standardsprache der Artikel, wenn die Auswahl ausgeblendet ist"
 
-#: src/submission/models.py:2332
+#: src/submission/models.py:2408
 msgid "The default section of articles when no option is presented"
 msgstr "Der Standardrubrik der Artikel, wenn keine Auswahl angezeigt wird"
 
-#: src/submission/views.py:260 src/submission/views.py:295
-#: src/submission/views.py:320
+#: src/submission/views.py:284 src/submission/views.py:319
+#: src/submission/views.py:344
 #, python-brace-format
 msgid "{author_name} added to the article."
 msgstr "{author_name} wurde dem Artikel hinzugefügt."
 
-#: src/submission/views.py:288
+#: src/submission/views.py:312
 msgid "Errors found in the new author form"
 msgstr "Es sind Fehler im Formular Neuer Autor aufgetreten"
 
-#: src/submission/views.py:309
+#: src/submission/views.py:333
 msgid "An empty search is not allowed."
 msgstr "Eine leere Suche ist nicht zulässig."
 
-#: src/submission/views.py:327
+#: src/submission/views.py:351
 msgid "No author found with those details."
 msgstr "Mit diesen Angaben konnte kein/e Autor*in gefunden werden."
 
-#: src/submission/views.py:337
+#: src/submission/views.py:361
 msgid "You must select a main author."
 msgstr "Ein Hauptautor muss ausgewählt werden."
 
-#: src/submission/views.py:447
+#: src/submission/views.py:569
 msgid "File deleted"
 msgstr "Datei gelöscht"
 
-#: src/submission/views.py:501
+#: src/submission/views.py:624
 msgid "You must upload a manuscript file."
 msgstr "Sie müssen eine Manuskriptdatei hochladen."
 
-#: src/submission/views.py:564
+#: src/submission/views.py:692
 #, python-brace-format
 msgid "Article {title} submitted"
 msgstr "Artikel {title} eingereicht"
 
-#: src/submission/views.py:661
+#: src/submission/views.py:791
 msgid "Metadata updated."
 msgstr "Metadaten aktualisiert."
 
-#: src/submission/views.py:673
+#: src/submission/views.py:803
 msgid "Primary author set."
 msgstr "Erstautor*in gesetzt."
 
-#: src/submission/views.py:690
+#: src/submission/views.py:820
 #, python-brace-format
 msgid "Author {author_name} updated."
 msgstr "Autor*in {author_name} aktualisiert."
 
-#: src/submission/views.py:708
+#: src/submission/views.py:838
 msgid "Frozen Author deleted."
 msgstr "Archivierter Autor*innen-Eintrag gelöscht."
 
-#: src/submission/views.py:823
+#: src/submission/views.py:953
 msgid "License saved."
 msgstr "Lizenz gespeichert."
 
-#: src/submission/views.py:868
+#: src/submission/views.py:998
 #, fuzzy, python-brace-format
 #| msgid "License {license_name} deleted."
 msgid "License {license_name} deleted."
 msgstr "Lizenz {license name} entfernt."
 
-#: src/submission/views.py:904
+#: src/submission/views.py:1034
 msgid "Configuration updated."
 msgstr "Konfiguration aktualisiert."
 
@@ -1147,6 +1173,446 @@ msgstr ""
 #: src/templates/admin/copyediting/author_review.html:92
 msgid "Complete Copyedit Task"
 msgstr "Copyedit Auftrag abschließen"
+
+#: src/templates/admin/core/accounts/activate_account.html:5
+#: src/templates/admin/core/accounts/activate_account.html:10
+#: src/templates/admin/core/accounts/activate_account.html:15
+#: src/templates/admin/core/accounts/activate_account.html:29
+#: src/themes/OLH/templates/core/accounts/activate_account.html:9
+#: src/themes/OLH/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:30
+#: src/themes/clean/templates/core/accounts/activate_account.html:9
+#: src/themes/clean/templates/core/accounts/activate_account.html:17
+#: src/themes/clean/templates/core/accounts/activate_account.html:21
+#: src/themes/hourglass/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:18
+#: src/themes/material/templates/core/accounts/activate_account.html:23
+msgid "Activate Account"
+msgstr "Konto aktivieren"
+
+#: src/templates/admin/core/accounts/activate_account.html:17
+#, fuzzy
+#| msgid "Account activated"
+msgid "No account to activate"
+msgstr "Account aktiviert"
+
+#: src/templates/admin/core/accounts/activate_account.html:24
+#, fuzzy
+#| msgid ""
+#| "You can complete the activation process by clicking the button below."
+msgid ""
+"\n"
+"      You can complete the activation process by clicking the button\n"
+"      below.\n"
+"    "
+msgstr ""
+"Sie können den Aktivierungsprozess abschließen, indem Sie auf die "
+"Schaltfläche unten klicken."
+
+#: src/templates/admin/core/accounts/activate_account.html:32
+msgid ""
+"\n"
+"      Sorry, we could not find an account to activate, or your account is "
+"active\n"
+"      already. You can check if it is active by attempting to log in.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:38
+#: src/templates/admin/core/accounts/login.html:5
+#: src/templates/admin/core/accounts/login.html:13
+#: src/templates/admin/core/accounts/orcid_registration.html:38
+#: src/themes/OLH/templates/core/login.html:43
+#: src/themes/clean/templates/core/login.html:40
+msgid "Log in"
+msgstr "Anmelden"
+
+#: src/templates/admin/core/accounts/edit_profile.html:9
+#: src/templates/admin/core/accounts/edit_profile.html:17
+#: src/themes/OLH/templates/core/accounts/edit_profile.html:8
+#: src/themes/clean/templates/core/accounts/edit_profile.html:9
+#: src/themes/hourglass/templates/core/accounts/edit_profile.html:11
+#: src/themes/material/templates/core/accounts/edit_profile.html:8
+msgid "Edit Profile"
+msgstr "Profil bearbeiten"
+
+#: src/templates/admin/core/accounts/edit_profile.html:26
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
+msgid "Change Your Email Address"
+msgstr "Ändern Sie Ihre Email-Adresse"
+
+#: src/templates/admin/core/accounts/edit_profile.html:28
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                <p>If you want to change your email address you may do so "
+#| "below, however, you will be logged out and your\n"
+#| "                account will be marked as inactive until you follow the "
+#| "instructions in the verification email. <strong>Note: </strong>\n"
+#| "                Changing your email address will also change your "
+#| "username as these are one and the same.</p>\n"
+#| "                "
+msgid ""
+"\n"
+"          <p>If you want to change your email address you may do so below,\n"
+"          however, you will be logged out and your\n"
+"          account will be marked as inactive until you follow the\n"
+"          instructions in the verification email. <strong>Note: </strong>\n"
+"          Changing your email address will also change your username as "
+"these\n"
+"          are one and the same.</p>\n"
+"        "
+msgstr ""
+"\n"
+" Wenn Sie Ihre E-Mail-Adresse ändern möchten, können Sie dies unten tun, "
+"aber Sie werden ausgeloggt und Ihr Konto wird als inaktiv markiert, bis Sie "
+"den Anweisungen in der Bestätigungs-E-Mail folgen. <strong>Note: </"
+"strong>Wenn Sie Ihre Mailadresse ändern wird sich auch Ihr Benutzername "
+"ändern, da diese ein und dasselbe sind.</p>"
+
+#: src/templates/admin/core/accounts/edit_profile.html:36
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
+msgid "Current Email Address"
+msgstr "Aktuelle E-Mail-Adresse"
+
+#: src/templates/admin/core/accounts/edit_profile.html:43
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
+msgid "New Email Address"
+msgstr "Neue E-Mail-Adresse"
+
+#: src/templates/admin/core/accounts/edit_profile.html:50
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
+msgid "Update Email Address"
+msgstr "Aktualisierung der Email-Adresse"
+
+#: src/templates/admin/core/accounts/edit_profile.html:58
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
+msgid "Register for Article Notifications"
+msgstr "Für Artikelbenachrichtigungen anmelden"
+
+#: src/templates/admin/core/accounts/edit_profile.html:61
+#, fuzzy
+#| msgid ""
+#| "Use the button below to register to receive notifications of new "
+#| "articles\n"
+#| "                            published in this journal "
+msgid ""
+"\n"
+"              Use the button below to register to receive notifications of "
+"new articles\n"
+"              published in this journal.\n"
+"            "
+msgstr ""
+"Nutzen Sie den unteren Button um sich für Benachrichtigungen über neue "
+"Artikel\n"
+"                            dieses Journals zu registrieren "
+
+#: src/templates/admin/core/accounts/edit_profile.html:68
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
+msgid "Unsubscribe from Article Notifications"
+msgstr "Von Artikelbenachrichtigungen abmelden"
+
+#: src/templates/admin/core/accounts/edit_profile.html:72
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
+msgid "Subscribe to Article Notifications"
+msgstr "Artikelbenachrichtigungen aktivieren"
+
+#: src/templates/admin/core/accounts/edit_profile.html:80
+#: src/templates/admin/core/accounts/edit_profile.html:115
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
+msgid "Update Password"
+msgstr "Passwort aktualisieren"
+
+#: src/templates/admin/core/accounts/edit_profile.html:82
+#, fuzzy
+#| msgid ""
+#| "You can update your password by entering your existing password plus your "
+#| "new password."
+msgid ""
+"\n"
+"          You can update your password by entering your existing\n"
+"          password plus your new password.\n"
+"        "
+msgstr ""
+"Sie können Ihr Passwort aktualisieren, indem Sie Ihr vorhandenes und Ihr "
+"neues Passwort eingeben."
+
+#: src/templates/admin/core/accounts/edit_profile.html:91
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
+msgid "Current Password"
+msgstr "Aktuelles Passwort"
+
+#: src/templates/admin/core/accounts/edit_profile.html:98
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
+msgid "New Password"
+msgstr "Neues Passwort"
+
+#: src/templates/admin/core/accounts/edit_profile.html:105
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
+msgid "Enter Password Again"
+msgstr "Passwort erneut eingeben"
+
+#: src/templates/admin/core/accounts/edit_profile.html:122
+#, fuzzy
+#| msgid "Profile Image"
+msgid "Profile Details"
+msgstr "Profilbild"
+
+#: src/templates/admin/core/accounts/edit_profile.html:132
+#: src/templates/admin/core/accounts/reset_password.html:31
+#: src/templates/admin/press/edit_press_journal_description.html:24
+#: src/templates/admin/review/view_review.html:168
+#: src/templates/admin/review/view_review.html:189
+msgid "Save"
+msgstr "Speichern"
+
+#: src/templates/admin/core/accounts/get_reset_token.html:5
+#: src/templates/admin/core/accounts/get_reset_token.html:10
+#: src/templates/admin/core/accounts/get_reset_token.html:14
+#, fuzzy
+#| msgid "Reset Password"
+msgid "Reset password"
+msgstr "Passwort zurücksetzen"
+
+#: src/templates/admin/core/accounts/get_reset_token.html:20
+msgid ""
+"\n"
+"      Enter your email address and then follow the link sent to you by "
+"email.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:27
+#, fuzzy
+#| msgid "Request Token"
+msgid "Request link"
+msgstr "Code anfordern"
+
+#: src/templates/admin/core/accounts/login.html:24
+#: src/themes/OLH/templates/core/login.html:28
+#: src/themes/clean/templates/core/login.html:16
+#: src/themes/material/templates/core/login.html:18
+msgid "Log in with ORCiD"
+msgstr "Anmelden mit ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:33
+#, fuzzy
+#| msgid "Login with"
+msgid "Log in with"
+msgstr "Einloggen mit"
+
+#: src/templates/admin/core/accounts/login.html:45
+#: src/themes/OLH/templates/core/login.html:27
+#: src/themes/OLH/templates/press/core/login.html:25
+#: src/themes/clean/templates/core/login.html:14
+msgid "Log in with your account"
+msgstr "Melden Sie sich mit Ihrem Konto an"
+
+#: src/templates/admin/core/accounts/login.html:50
+#: src/templates/admin/core/accounts/orcid_registration.html:43
+#: src/themes/OLH/templates/core/login.html:44
+#: src/themes/clean/templates/core/login.html:44
+msgid "Forgotten your password?"
+msgstr "Passwort vergessen?"
+
+#: src/templates/admin/core/accounts/login.html:55
+#: src/templates/admin/core/accounts/orcid_registration.html:48
+#: src/themes/OLH/templates/core/login.html:45
+#: src/themes/clean/templates/core/login.html:48
+msgid "Register a new account"
+msgstr "Ein neues Konto eröffnen"
+
+#: src/templates/admin/core/accounts/orcid_registration.html:5
+#: src/templates/admin/core/accounts/orcid_registration.html:10
+#: src/templates/admin/core/accounts/orcid_registration.html:14
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:9
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:23
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:8
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:13
+msgid "Unregistered ORCiD"
+msgstr "Nicht registrierte ORCiD"
+
+#: src/templates/admin/core/accounts/orcid_registration.html:19
+#, fuzzy
+#| msgid ""
+#| "The ORCiD you logged in with is not currently linked with an account in "
+#| "our system. You can either register a new account, or login with an "
+#| "existing account to link your ORCiD for future use."
+msgid ""
+"\n"
+"    The ORCiD you logged in with is not currently linked with an\n"
+"    account in our system. You can either register a new account, or login "
+"with\n"
+"    an existing account to link your ORCiD for future use.\n"
+"  "
+msgstr ""
+"Sie haben sich mit einer ORCiD angemeldet, die derzeit in unserem System "
+"nicht mit einem Konto verknüpft ist. Sie können ein neues Konto anlegen oder "
+"sich mit einem bestehenden Konto anmelden und die ORCiD mit diesem für die "
+"Zukunft verknüpfen."
+
+#: src/templates/admin/core/accounts/password_guide.html:11
+#: src/themes/OLH/templates/core/accounts/register.html:110
+#: src/themes/OLH/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/register.html:54
+#: src/themes/clean/templates/core/accounts/reset_password.html:47
+#: src/themes/material/templates/core/accounts/register.html:53
+#: src/themes/material/templates/core/accounts/reset_password.html:43
+msgid "Password Guide"
+msgstr "Passwort-Anleitung"
+
+#: src/templates/admin/core/accounts/password_guide.html:15
+#, fuzzy
+#| msgid "When it comes to passwords, length is better than complexity."
+msgid ""
+"\n"
+"        When it comes to passwords, length is better than complexity.\n"
+"      "
+msgstr ""
+"Wenn es um die Sicherheit von Passwörter geht, ist Länge besser als "
+"Komplexität."
+
+#: src/templates/admin/core/accounts/password_guide.html:18
+#, fuzzy
+#| msgid ""
+#| "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
+#| "secure than a long and uncomplicated password (our awesome moon base "
+#| "rocks)."
+msgid ""
+"\n"
+"        Its a common myth that a short and complex password\n"
+"        (Jfjfy&65^87) is more secure than a long and uncomplicated password\n"
+"        (our awesome moon base rocks).\n"
+"      "
+msgstr ""
+"Es ist ein verbreiteter Mythos, dass ein kurzes und komplexes Passwort "
+"(Jfjfy&65^87) sicherer ist als ein langes und unkompliziertes Passwort "
+"(unsere fantastische Mondbasis)."
+
+#: src/templates/admin/core/accounts/password_guide.html:23
+#, fuzzy
+#| msgid ""
+#| "We recommend selecting a long, but easy to remember password such as our "
+#| "awesome moon base rocks which would take an estimated septillion years to "
+#| "crack as opposed to a complex one like Jfjfy&65^87 which would take just "
+#| "over 600 years on a standard computer."
+msgid ""
+"\n"
+"        We recommend selecting a long, but easy to remember\n"
+"        password such as our awesome moon base rocks which would take an\n"
+"        estimated septillion years to crack as opposed to a complex one "
+"like\n"
+"        Jfjfy&65^87 which would take just over 600 years on a standard\n"
+"        computer.\n"
+"      "
+msgstr ""
+"Wir empfehlen die Erstellung eines langen, aber leicht zu merkenden "
+"Passworts, wie zum Beispiel \"unsere fantastische Mondbasis\", welches "
+"schätzungsweise einige Quadrillionen Jahre zur Entschlüsselung dauern würde "
+"- im Gegensatz zu einem komplexen wie \"Jfjfy&65^87\", welches auf einem "
+"Standardcomputer etwas über 600 Jahre für die Entschlüsselung brauchen würde."
+
+#: src/templates/admin/core/accounts/register.html:5
+#: src/templates/admin/core/accounts/register.html:10
+#: src/templates/admin/core/accounts/register.html:14
+#, fuzzy
+#| msgid "Register for an account with"
+msgid "Register for an account"
+msgstr "Accountregistrierung"
+
+#: src/templates/admin/core/accounts/register.html:39
+#: src/templates/admin/core/accounts/reset_password.html:19
+#: src/themes/OLH/templates/core/accounts/register.html:31
+#: src/themes/OLH/templates/core/accounts/reset_password.html:31
+#: src/themes/clean/templates/core/accounts/register.html:22
+#: src/themes/clean/templates/core/accounts/reset_password.html:21
+#: src/themes/material/templates/core/accounts/register.html:24
+#: src/themes/material/templates/core/accounts/reset_password.html:21
+msgid "Password Rules"
+msgstr "Passwortrichtlinien"
+
+#: src/templates/admin/core/accounts/register.html:43
+#: src/templates/admin/core/accounts/reset_password.html:23
+#, fuzzy
+#| msgid ""
+#| "For more information read our <a href=\"#\" data-open=\"password-"
+#| "modal\">password guide</a>."
+msgid ""
+"\n"
+"    For more information read our <a href=\"#\"\n"
+"    data-open=\"password-modal\">password guide</a>.\n"
+"  "
+msgstr ""
+"Für weitere Informationen lesen Sie <a href=\"#\" data-open=\"password-"
+"modal\">password guide</a>."
+
+#: src/templates/admin/core/accounts/register.html:55
+#: src/themes/OLH/templates/core/accounts/register.html:91
+#: src/themes/clean/templates/core/accounts/register.html:31
+#: src/themes/hourglass/templates/custom/register.html:24
+#: src/themes/material/templates/core/accounts/register.html:37
+msgid "By registering an account you agree to our"
+msgstr "Mit der Registrierung eines Kontos stimmen Sie unseren Bedingungen zu"
+
+#: src/templates/admin/core/accounts/register.html:63
+#: src/templates/admin/journal/submissions.html:35
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:52
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:54
+#: src/themes/OLH/templates/core/accounts/register.html:9
+#: src/themes/OLH/templates/core/accounts/register.html:100
+#: src/themes/OLH/templates/core/base.html:142
+#: src/themes/OLH/templates/core/nav.html:76
+#: src/themes/OLH/templates/journal/submissions.html:30
+#: src/themes/OLH/templates/press/nav.html:58
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:45
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:47
+#: src/themes/clean/templates/core/accounts/register.html:9
+#: src/themes/clean/templates/core/accounts/register.html:39
+#: src/themes/clean/templates/core/nav.html:104
+#: src/themes/clean/templates/journal/submissions.html:17
+#: src/themes/clean/templates/press/nav.html:79
+#: src/themes/hourglass/templates/core/accounts/register.html:11
+#: src/themes/material/templates/core/accounts/register.html:10
+#: src/themes/material/templates/core/accounts/register.html:44
+#: src/themes/material/templates/core/nav.html:79
+#: src/themes/material/templates/core/nav.html:134
+#: src/themes/material/templates/journal/submissions.html:33
+#: src/themes/material/templates/press/nav.html:67
+#: src/themes/material/templates/press/nav.html:115
+#: src/themes/material/templates/repository/nav.html:60
+msgid "Register"
+msgstr "Registrieren"
+
+#: src/templates/admin/core/accounts/reset_password.html:5
+#: src/templates/admin/core/accounts/reset_password.html:10
+#: src/templates/admin/core/accounts/reset_password.html:14
+#, fuzzy
+#| msgid "Enter New Password"
+msgid "Enter your new password"
+msgstr "Neues Kennwort eingeben"
 
 #: src/templates/admin/core/manager/sections/manage_section.html:15
 #: src/templates/admin/core/manager/sections/manage_section.html:22
@@ -1289,6 +1755,30 @@ msgstr ""
 "Sie können keine Rubrik löschen, die Artikel enthält. Entfernen Sie die "
 "Artikel aus der Rubrik, wenn Sie diese löschen möchten."
 
+#: src/templates/admin/core/manager/users/list.html:16
+#, fuzzy
+#| msgid "Journals"
+msgid "Journal Users"
+msgstr "Zeitschriften"
+
+#: src/templates/admin/core/manager/users/list.html:18
+#, fuzzy
+#| msgid "All Preprints"
+msgid "All Users"
+msgstr "Alle Preprints"
+
+#: src/templates/admin/core/manager/users/list.html:40
+#, fuzzy
+#| msgid "Username"
+msgid "Users"
+msgstr "Benutzername"
+
+#: src/templates/admin/core/manager/users/list.html:70
+#, fuzzy
+#| msgid "No articles to display."
+msgid "No accounts to display."
+msgstr "Keine Artikel für die Anzeige"
+
 #: src/templates/admin/core/request_submission_access.html:14
 msgid "requires that you request permission to make a submission."
 msgstr ""
@@ -1303,27 +1793,44 @@ msgid "You have an active access request that was submitted on: "
 msgstr "Sie haben eine aktive Zugangsanfrage vom: "
 
 #: src/templates/admin/elements/accounts/user_form.html:4
-#: src/themes/OLH/templates/elements/accounts/user_form.html:5
-#: src/themes/clean/templates/elements/accounts/user_form.html:5
-#: src/themes/material/templates/elements/accounts/user_form.html:6
-msgid "Core Data"
-msgstr "Kerndaten"
+#: src/templates/admin/repository/article.html:212
+#: src/templates/admin/repository/author_article.html:91
+#: src/templates/admin/repository/submit/authors.html:76
+#: src/templates/admin/submission/submit_authors.html:69
+#: src/templates/admin/submission/submit_funding.html:72
+#: src/templates/common/elements/funder_info_for_readers.html:4
+msgid "Name"
+msgstr "Name"
 
-#: src/templates/admin/elements/accounts/user_form.html:61
+#: src/templates/admin/elements/accounts/user_form.html:13
+#, fuzzy
+#| msgid "Affiliation"
+msgid "Affiliations"
+msgstr "Zugehörigkeit"
+
+#: src/templates/admin/elements/accounts/user_form.html:20
+#: src/themes/OLH/templates/elements/accounts/user_form.html:41
+#: src/themes/clean/templates/elements/accounts/user_form.html:38
+#: src/themes/material/templates/elements/accounts/user_form.html:39
+msgid "Social Media and Accounts"
+msgstr "Social Media und Konten"
+
+#: src/templates/admin/elements/accounts/user_form.html:30
 #: src/themes/OLH/templates/elements/accounts/user_form.html:65
 #: src/themes/clean/templates/elements/accounts/user_form.html:62
 #: src/themes/material/templates/elements/accounts/user_form.html:63
 msgid "Biography and Signature"
 msgstr "Biographie und Signatur"
 
-#: src/templates/admin/elements/accounts/user_form.html:70
+#: src/templates/admin/elements/accounts/user_form.html:40
+#: src/templates/admin/elements/accounts/user_form.html:43
 #: src/themes/OLH/templates/elements/accounts/user_form.html:74
 #: src/themes/clean/templates/elements/accounts/user_form.html:71
 #: src/themes/material/templates/elements/accounts/user_form.html:72
 msgid "Review Interests"
 msgstr "Interessen prüfen"
 
-#: src/templates/admin/elements/accounts/user_form.html:71
+#: src/templates/admin/elements/accounts/user_form.html:50
 #: src/themes/OLH/templates/elements/accounts/user_form.html:75
 #: src/themes/clean/templates/elements/accounts/user_form.html:72
 #: src/themes/material/templates/elements/accounts/user_form.html:73
@@ -1331,16 +1838,21 @@ msgid "Hit Enter to add a new interest"
 msgstr ""
 "Drücken Sie die Eingabetaste, um ein neues Interessensgebiet hinzuzufügen"
 
-#: src/templates/admin/elements/accounts/user_form.html:75
+#: src/templates/admin/elements/accounts/user_form.html:53
 #: src/themes/OLH/templates/elements/accounts/user_form.html:79
 #: src/themes/clean/templates/elements/accounts/user_form.html:76
 #: src/themes/material/templates/elements/accounts/user_form.html:77
 msgid "Profile Image"
 msgstr "Profilbild"
 
-#: src/templates/admin/elements/accounts/user_form.html:91
-msgid "Email Options"
-msgstr "E-Mail Optionen"
+#: src/templates/admin/elements/accounts/user_form.html:69
+#: src/themes/OLH/templates/elements/accounts/user_form.html:95
+#: src/themes/OLH/templates/journal/article.html:107
+#: src/themes/OLH/templates/journal/article.html:108
+#: src/themes/clean/templates/elements/accounts/user_form.html:92
+#: src/themes/material/templates/elements/accounts/user_form.html:93
+msgid "Options"
+msgstr "Optionen"
 
 #: src/templates/admin/elements/confirm_modal.html:7
 #: src/templates/admin/elements/review/draft_decisions_js.html:13
@@ -1361,7 +1873,7 @@ msgstr "Ja"
 msgid "No, go back"
 msgstr "Nein, zurück"
 
-#: src/templates/admin/elements/forms/field.html:7
+#: src/templates/admin/elements/forms/field.html:13
 msgid "translatable"
 msgstr "übersetzbar"
 
@@ -1383,6 +1895,10 @@ msgid ""
 msgstr ""
 "Wenn Sie keine Metriken anzeigen möchten, können Sie sie alle deaktivieren, "
 "oder Sie können die Anzeige von Zitationsmetriken unten deaktivieren."
+
+#: src/templates/admin/elements/forms/group_article.html:37
+msgid "Enable the display of the dates an article was submitted and accepted."
+msgstr ""
 
 #: src/templates/admin/elements/forms/group_journal.html:32
 msgid ""
@@ -1423,7 +1939,7 @@ msgstr ""
 "Wie sollten Herausgeber*innen und Mitarbeiter*innen Hilfe zu Janeway "
 "erhalten?"
 
-#: src/templates/admin/elements/forms/group_journal_images.html:10
+#: src/templates/admin/elements/forms/group_journal_images.html:11
 msgid ""
 "For details about where each image appears, see the Janeway documentation: "
 msgstr ""
@@ -1452,16 +1968,16 @@ msgstr ""
 "Standardbegutachtungseinstellungen festlegen. Begutachtungsformulare können "
 "über den Begutachtungsformular-Manager verwaltet werden."
 
-#: src/templates/admin/elements/forms/group_review.html:29
+#: src/templates/admin/elements/forms/group_review.html:28
 msgid "Settings here determine the review form experience."
 msgstr ""
 "Die Einstellungen hier bestimmen, wie das Begutachtungsformular aussieht."
 
-#: src/templates/admin/elements/forms/group_review.html:41
+#: src/templates/admin/elements/forms/group_review.html:40
 msgid "Settings here determine the review experience for editors."
 msgstr "Einstellungen hier bestimmen die Review-Erfahrung für Editor*innen."
 
-#: src/templates/admin/elements/forms/group_review.html:49
+#: src/templates/admin/elements/forms/group_review.html:48
 msgid "Settings here determine the review experience for authors."
 msgstr ""
 "Die Einstellungen hier bestimmen das Begutachtungserlebnis für Autor*innen."
@@ -1478,15 +1994,31 @@ msgstr ""
 "Der nachstehende Text bildet die Einreichungsseite sowie die "
 "Einreichungsvereinbarung, die die Autor*innen akzeptieren."
 
-#: src/templates/admin/elements/fundref/fundref.html:24
+#: src/templates/admin/elements/forms/messages_in_callout.html:11
+msgid "Problems processing the form"
+msgstr ""
+
+#: src/templates/admin/elements/fundref/fundref.html:22
 msgid "Funder"
 msgstr "Fördermittel"
 
-#: src/templates/admin/elements/fundref/fundref.html:61
-#: src/templates/admin/elements/fundref/fundref.html:82
-#: src/templates/admin/elements/fundref/fundref.html:166
-#: src/templates/admin/submission/submit_funding.html:85
-#: src/templates/admin/submission/submit_funding.html:108
+#: src/templates/admin/elements/fundref/fundref.html:23
+#: src/templates/admin/submission/submit_funding.html:73
+#: src/templates/common/elements/funder_info_for_readers.html:5
+#, fuzzy
+#| msgid "Funder DOI"
+msgid "FundRef ID"
+msgstr "DOI der Fördermittelquelle"
+
+#: src/templates/admin/elements/fundref/fundref.html:24
+#, fuzzy
+#| msgid "Add funder"
+msgid "Add Funder"
+msgstr "Fördermittelquelle hinzufügen"
+
+#: src/templates/admin/elements/fundref/fundref.html:39
+#: src/templates/admin/submission/submit_funding.html:121
+#: src/templates/admin/submission/submit_funding.html:128
 msgid "Add funder"
 msgstr "Fördermittelquelle hinzufügen"
 
@@ -1508,6 +2040,34 @@ msgstr ""
 #: src/templates/admin/elements/issue/sort_toc.html:17
 msgid "Sort Articles"
 msgstr "Artikel sortieren"
+
+#: src/templates/admin/elements/list_filters.html:7
+#, fuzzy
+#| msgid "Sort and Filter"
+msgid "Search and filter"
+msgstr "Sortieren und filtern"
+
+#: src/templates/admin/elements/list_filters.html:28
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
+msgid "Apply"
+msgstr "Anwenden"
+
+#: src/templates/admin/elements/list_filters.html:32
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:10
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:11
+#: src/themes/material/templates/elements/journal/article_list_filters.html:15
+#, fuzzy
+#| msgid "Clear Filters"
+msgid "Clear all"
+msgstr "Filter löschen"
+
+#: src/templates/admin/elements/metadata.html:143
+#: src/templates/admin/submission/edit/metadata.html:244
+#: src/templates/admin/submission/submit_funding.html:75
+#: src/templates/common/elements/funder_info_for_readers.html:7
+msgid "Funding Statement"
+msgstr ""
 
 #: src/templates/admin/elements/move_to_next_modal.html:7
 msgid "Workflow Info"
@@ -1544,7 +2104,7 @@ msgid "Save Publisher Note"
 msgstr "Hinweis der Herausgeber*innen speichern"
 
 #: src/templates/admin/elements/repository/metadata_form.html:39
-#: src/templates/admin/repository/submit/start.html:73 src/utils/forms.py:55
+#: src/templates/admin/repository/submit/start.html:71 src/utils/forms.py:60
 msgid "Hit Enter to add a new keyword."
 msgstr "Drücken Sie die Eingabetaste, um ein neues Schlagwort hinzuzufügen."
 
@@ -1554,10 +2114,10 @@ msgid "Additional Fields"
 msgstr "Weitere Felder"
 
 #: src/templates/admin/elements/submit/author.html:8
-#: src/templates/admin/repository/submit/authors.html:65
-#: src/templates/admin/repository/submit/authors.html:116
-#: src/templates/admin/repository/submit/authors.html:123
-#: src/templates/admin/submission/submit_authors.html:49
+#: src/templates/admin/repository/submit/authors.html:62
+#: src/templates/admin/repository/submit/authors.html:113
+#: src/templates/admin/repository/submit/authors.html:120
+#: src/templates/admin/submission/submit_authors.html:54
 #: src/themes/OLH/templates/elements/submit/author.html:8
 msgid "Add New Author"
 msgstr "Autor*in neu hinzufügen"
@@ -1567,14 +2127,13 @@ msgstr "Autor*in neu hinzufügen"
 msgid "Add Author"
 msgstr "Autor*in hinzufügen"
 
-#: src/templates/admin/elements/submit/file.html:7
+#: src/templates/admin/elements/submit/file.html:9
 #: src/themes/OLH/templates/elements/submit/file.html:6
 #: src/themes/OLH/templates/elements/submit/preprint_file.html:6
 msgid "Add New File"
 msgstr "Neue Datei hinzufügen"
 
-#: src/templates/admin/elements/submit/file.html:35
-#: src/templates/admin/elements/submit/file.html:51
+#: src/templates/admin/elements/submit/file.html:33
 #: src/themes/OLH/templates/elements/submit/file.html:25
 #: src/themes/OLH/templates/elements/submit/preprint_file.html:25
 msgid "Add File"
@@ -1626,6 +2185,7 @@ msgstr "Kontaktinformationen"
 #: src/themes/clean/templates/journal/contact.html:5
 #: src/themes/clean/templates/journal/contact.html:21
 #: src/themes/clean/templates/press/nav.html:53
+#: src/themes/hourglass/templates/press/contact.html:4
 #: src/themes/material/templates/core/nav.html:42
 #: src/themes/material/templates/core/nav.html:103
 #: src/themes/material/templates/journal/contact.html:5
@@ -1635,14 +2195,6 @@ msgstr "Kontaktinformationen"
 msgid "Contact"
 msgstr "Kontakt"
 
-#: src/core/models.py:1492
-#: src/templates/admin/journal/contact.html:38
-#: src/themes/OLH/templates/journal/contact.html:30
-#: src/themes/OLH/templates/press/journal/contact.html:22
-#: src/themes/clean/templates/journal/contact.html:27
-msgid "Who would you like to contact?"
-msgstr "Wen möchten Sie kontaktieren?"
-
 #: src/templates/admin/journal/contact.html:52
 #: src/themes/OLH/templates/journal/contact.html:39
 #: src/themes/OLH/templates/press/journal/contact.html:30
@@ -1651,31 +2203,31 @@ msgstr "Wen möchten Sie kontaktieren?"
 msgid "Send Message"
 msgstr "Nachricht senden"
 
-#: src/templates/admin/journal/manage/archive_article.html:24
+#: src/templates/admin/journal/manage/archive_article.html:25
 msgid "Edit Article Images"
 msgstr "Artikelbilder bearbeiten"
 
-#: src/templates/admin/journal/manage/archive_article.html:26
+#: src/templates/admin/journal/manage/archive_article.html:27
 msgid "Edit Publication Info"
 msgstr "Informationen zur Publikation bearbeiten"
 
-#: src/templates/admin/journal/manage/archive_article.html:28
+#: src/templates/admin/journal/manage/archive_article.html:29
 msgid "Remote Article View"
 msgstr "Remote-Artikelansicht"
 
-#: src/templates/admin/journal/manage/archive_article.html:178
+#: src/templates/admin/journal/manage/archive_article.html:179
 msgid "Undo Article Rejection"
 msgstr "Ablehnung eines Artikels rückgängig machen"
 
-#: src/templates/admin/journal/manage/archive_article.html:182
+#: src/templates/admin/journal/manage/archive_article.html:183
 msgid "Review"
 msgstr "Gutachten"
 
-#: src/templates/admin/journal/manage/archive_article.html:184
+#: src/templates/admin/journal/manage/archive_article.html:185
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
-#: src/templates/admin/journal/manage/archive_article.html:186
+#: src/templates/admin/journal/manage/archive_article.html:187
 #, python-format
 msgid ""
 "You will have the opportunity to send an email to the author, and then the "
@@ -1704,52 +2256,26 @@ msgstr ""
 "zu überschreiben und die verfügbaren Sprachen, die für das Journal verfügbar "
 "sind, einzustellen."
 
-#: src/templates/admin/journal/submissions.html:35
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:48
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:50
-#: src/themes/OLH/templates/core/accounts/register.html:5
-#: src/themes/OLH/templates/core/accounts/register.html:96
-#: src/themes/OLH/templates/core/base.html:141
-#: src/themes/OLH/templates/core/nav.html:77
-#: src/themes/OLH/templates/journal/submissions.html:30
-#: src/themes/OLH/templates/press/nav.html:58
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:41
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:43
-#: src/themes/clean/templates/core/accounts/register.html:5
-#: src/themes/clean/templates/core/accounts/register.html:39
-#: src/themes/clean/templates/core/nav.html:104
-#: src/themes/clean/templates/journal/submissions.html:17
-#: src/themes/clean/templates/press/nav.html:79
-#: src/themes/material/templates/core/accounts/register.html:6
-#: src/themes/material/templates/core/accounts/register.html:44
-#: src/themes/material/templates/core/nav.html:79
-#: src/themes/material/templates/core/nav.html:134
-#: src/themes/material/templates/journal/submissions.html:33
-#: src/themes/material/templates/press/nav.html:67
-#: src/themes/material/templates/press/nav.html:115
-#: src/themes/material/templates/repository/nav.html:60
-msgid "Register"
-msgstr "Registrieren"
-
 #: src/templates/admin/journal/submissions.html:36
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:28
-#: src/themes/OLH/templates/core/base.html:141
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/themes/OLH/templates/core/base.html:142
 #: src/themes/OLH/templates/core/login.html:6
-#: src/themes/OLH/templates/core/nav.html:76
+#: src/themes/OLH/templates/core/nav.html:75
 #: src/themes/OLH/templates/elements/journal_footer.html:30
 #: src/themes/OLH/templates/journal/become_reviewer.html:16
 #: src/themes/OLH/templates/journal/submissions.html:31
 #: src/themes/OLH/templates/press/core/login.html:5
 #: src/themes/OLH/templates/press/elements/press_footer.html:15
 #: src/themes/OLH/templates/press/nav.html:57
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:19
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:23
 #: src/themes/clean/templates/core/login.html:5
 #: src/themes/clean/templates/core/nav.html:103
-#: src/themes/clean/templates/elements/journal_footer.html:41
+#: src/themes/clean/templates/elements/journal_footer.html:43
 #: src/themes/clean/templates/elements/press_footer.html:19
 #: src/themes/clean/templates/journal/become_reviewer.html:13
 #: src/themes/clean/templates/journal/submissions.html:18
 #: src/themes/clean/templates/press/nav.html:77
+#: src/themes/hourglass/templates/core/accounts/login.html:11
 #: src/themes/material/templates/core/login.html:5
 #: src/themes/material/templates/core/login.html:42
 #: src/themes/material/templates/core/nav.html:78
@@ -1763,7 +2289,7 @@ msgid "Login"
 msgstr "Anmeldung"
 
 #: src/templates/admin/journal/submissions.html:38
-#: src/templates/admin/submission/start.html:72
+#: src/templates/admin/submission/start.html:77
 #: src/themes/OLH/templates/core/nav.html:43
 #: src/themes/OLH/templates/journal/submissions.html:32
 #: src/themes/clean/templates/core/nav.html:71
@@ -1782,10 +2308,13 @@ msgid "Licences"
 msgstr "Lizenzen"
 
 #: src/templates/admin/journal/submissions.html:48
+#: src/templates/admin/submission/submit_info.html:109
 #: src/themes/OLH/templates/journal/submissions.html:40
 #: src/themes/clean/templates/journal/submissions.html:27
 #: src/themes/material/templates/journal/submissions.html:46
-msgid "allows the following licences for submission"
+#, fuzzy
+#| msgid "allows the following licences for submission"
+msgid "The following licences are allowed:"
 msgstr "Erlaubt sind die folgenden Lizenzen für die Einreichung"
 
 #: src/templates/admin/press/edit_press_journal_description.html:5
@@ -1796,8 +2325,9 @@ msgstr "Journalbeschreibung für die Übersichtsseite (press)"
 #: src/templates/admin/press/edit_press_journal_description.html:11
 #: src/templates/admin/press/edit_press_journal_description.html:17
 #: src/templates/admin/repository/article.html:215
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 #: src/templates/admin/review/view_review.html:112
+#: src/templates/admin/submission/submit_funding.html:76
 #: src/themes/OLH/templates/elements/edit_author.html:4
 msgid "Edit"
 msgstr "Editieren"
@@ -1817,12 +2347,6 @@ msgstr ""
 "(press) des Journals hinzufügen. Wenn das Feld leer gelassen wird, erscheint "
 "hier die Standard-Beschreibung."
 
-#: src/templates/admin/press/edit_press_journal_description.html:24
-#: src/templates/admin/review/view_review.html:168
-#: src/templates/admin/review/view_review.html:189
-msgid "Save"
-msgstr "Speichern"
-
 #: src/templates/admin/press/edit_press_journal_description.html:25
 msgid "Clear Description"
 msgstr "Beschreibung löschen"
@@ -1835,31 +2359,24 @@ msgstr "Jede Prüfkdruckrunde (Proof) ist beschränkt auf"
 msgid "proofreaders"
 msgstr "Korrektor*innen des Prüfdrucks (Proof)"
 
-#: src/templates/admin/repository/article.html:212
-#: src/templates/admin/repository/author_article.html:91
-#: src/templates/admin/repository/submit/authors.html:79
-#: src/templates/admin/submission/submit_authors.html:64
-#: src/templates/admin/submission/submit_funding.html:49
-msgid "Name"
-msgstr "Name"
-
 #: src/templates/admin/repository/article.html:214
 #: src/templates/admin/repository/author_article.html:93
-#: src/templates/admin/repository/submit/authors.html:81
-#: src/templates/admin/submission/submit_review.html:102
-#: src/themes/OLH/templates/core/accounts/public_profile.html:14
-#: src/themes/clean/templates/core/accounts/public_profile.html:14
-#: src/themes/material/templates/core/accounts/public_profile.html:14
+#: src/templates/admin/repository/submit/authors.html:78
+#: src/templates/admin/submission/submit_review.html:118
+#: src/themes/OLH/templates/core/accounts/public_profile.html:42
+#: src/themes/clean/templates/core/accounts/public_profile.html:18
+#: src/themes/material/templates/core/accounts/public_profile.html:18
 msgid "Affiliation"
 msgstr "Zugehörigkeit"
 
 #: src/templates/admin/repository/article.html:216
-#: src/templates/admin/repository/submit/authors.html:82
+#: src/templates/admin/repository/submit/authors.html:79
+#: src/templates/admin/submission/submit_funding.html:77
 msgid "Delete"
 msgstr "Löschen"
 
 #: src/templates/admin/repository/article.html:239
-#: src/templates/admin/repository/submit/authors.html:97
+#: src/templates/admin/repository/submit/authors.html:94
 msgid "No authors added."
 msgstr "Keine Autor*innen hinzugefügt."
 
@@ -1881,12 +2398,12 @@ msgstr ""
 msgid "Add Authors to"
 msgstr "Autor*innen hinzufügen zu "
 
-#: src/templates/admin/repository/submit/authors.html:23
-#: src/themes/clean/templates/journal/article.html:217
+#: src/templates/admin/repository/submit/authors.html:20
+#: src/themes/clean/templates/journal/article.html:219
 msgid "Information"
 msgstr "Informationen"
 
-#: src/templates/admin/repository/submit/authors.html:27
+#: src/templates/admin/repository/submit/authors.html:24
 msgid ""
 "You can add yourself as an author using the button below. This will copy "
 "metadata from your profile to create a"
@@ -1895,30 +2412,30 @@ msgstr ""
 "untenstehenden Button verwenden. Dadurch werden Metadaten aus Ihrem Profil "
 "kopiert um einen Autor*innen-Eintrag zu erstellen."
 
-#: src/templates/admin/repository/submit/authors.html:27
+#: src/templates/admin/repository/submit/authors.html:24
 msgid "author record."
 msgstr "Autor*innen-Eintrag"
 
-#: src/templates/admin/repository/submit/authors.html:28
+#: src/templates/admin/repository/submit/authors.html:25
 msgid ""
 "You can search the database of existing authors and add them as authors."
 msgstr ""
 "Sie können die Datenbank nach gelisteten Autor*innen durchsuchen und diese "
 "als Autor*innen hinzufügen."
 
-#: src/templates/admin/repository/submit/authors.html:29
+#: src/templates/admin/repository/submit/authors.html:26
 msgid "You can create a new record for an author using the form below."
 msgstr ""
 "Sie können einen neuen Eintrag für eine*n neue*n Autor*in hinzufügen, indem "
 "Sie das untenstehende Formular verwenden."
 
-#: src/templates/admin/repository/submit/authors.html:34
-#: src/templates/admin/submission/submit_authors.html:46
+#: src/templates/admin/repository/submit/authors.html:31
+#: src/templates/admin/submission/submit_authors.html:51
 msgid "Add Self as Author"
 msgstr "Sich selbst aus Autor*in hinzufügen"
 
-#: src/templates/admin/repository/submit/authors.html:37
-#: src/templates/admin/submission/submit_authors.html:44
+#: src/templates/admin/repository/submit/authors.html:34
+#: src/templates/admin/submission/submit_authors.html:49
 msgid ""
 "By default, your account is the owner of this submission, but is not an "
 "Author on record. You can add yourself using the button below."
@@ -1927,11 +2444,11 @@ msgstr ""
 "als Autor*in registriert. Sie können sich mit der Schaltfläche unten "
 "hinzufügen."
 
-#: src/templates/admin/repository/submit/authors.html:45
+#: src/templates/admin/repository/submit/authors.html:42
 msgid "Search for an Author"
 msgstr "Autor*in suchen"
 
-#: src/templates/admin/repository/submit/authors.html:48
+#: src/templates/admin/repository/submit/authors.html:45
 msgid ""
 "You can search by email or ORCiD. eg. person@example.com or "
 "0000-0003-2126-266X."
@@ -1939,12 +2456,12 @@ msgstr ""
 "Sie können nach Email-Adressen oder ORCiDs suchen, bpsw. person@example.com "
 "oder 0000-0003-2126-266X."
 
-#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/repository/submit/authors.html:58
 msgid "Add an Author"
 msgstr "Autor*in hinzufügen"
 
-#: src/templates/admin/repository/submit/authors.html:64
-#: src/templates/admin/submission/submit_authors.html:48
+#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/submission/submit_authors.html:53
 msgid ""
 "If you cannot find the author record by searching, and you are not the only "
 "author, you can add one by clicking the button below. This will open a popup "
@@ -1955,72 +2472,74 @@ msgstr ""
 "Schaltfläche unten klicken. Dies öffnet eine Eingabemaske für Sie, um ihre "
 "Details zu vervollständigen."
 
-#: src/templates/admin/repository/submit/authors.html:70
+#: src/templates/admin/repository/submit/authors.html:67
 #: src/themes/OLH/templates/journal/article.html:27
 #: src/themes/OLH/templates/journal/article.html:63
-#: src/themes/OLH/templates/journal/article.html:158
-#: src/themes/OLH/templates/journal/article.html:332
+#: src/themes/OLH/templates/journal/article.html:161
+#: src/themes/OLH/templates/journal/article.html:313
 #: src/themes/OLH/templates/journal/authors.html:4
 #: src/themes/OLH/templates/journal/authors.html:5
 #: src/themes/OLH/templates/journal/authors.html:11
 #: src/themes/OLH/templates/journal/print.html:15
 #: src/themes/OLH/templates/repository/preprint.html:33
 #: src/themes/clean/templates/journal/article.html:37
-#: src/themes/clean/templates/journal/article.html:167
+#: src/themes/clean/templates/journal/article.html:153
 #: src/themes/clean/templates/journal/authors.html:9
 #: src/themes/clean/templates/journal/print.html:15
-#: src/themes/material/templates/journal/article.html:269
+#: src/themes/material/templates/journal/article.html:250
 #: src/themes/material/templates/journal/authors.html:5
 #: src/themes/material/templates/journal/authors.html:6
 #: src/themes/material/templates/journal/authors.html:10
 #: src/themes/material/templates/preprints/article.html:28
-#: src/themes/material/templates/repository/preprint.html:149
+#: src/themes/material/templates/repository/preprint.html:147
 msgid "Authors"
 msgstr "Autor*innen"
 
-#: src/templates/admin/repository/submit/authors.html:73
+#: src/templates/admin/repository/submit/authors.html:70
 msgid ""
 "You can reorder the authors by dragging and dropping rows in the table below."
 msgstr ""
 "Sie können die Reihenfolge der Autor*innen verändern, indem Sie sie in der "
 "untenstehenden Tabelle anklicken und bei gedrückter Maustaste verschieben."
 
-#: src/templates/admin/repository/submit/authors.html:103
+#: src/templates/admin/repository/submit/authors.html:100
 msgid "Once you have added all of your authors you can complete this stage."
 msgstr ""
 "Sobald Sie alle Autor*innen hinzugefügt haben, können Sie diesen Schritt "
 "abschließen."
 
-#: src/templates/admin/repository/submit/authors.html:106
-msgid "Complete Step 2 of 3"
+#: src/templates/admin/repository/submit/authors.html:103
+#, fuzzy
+#| msgid "Complete Step 2 of 3"
+msgid "Complete Step 2 of 4"
 msgstr "Schritt 2 von 3 abgeschlossen"
 
 #: src/templates/admin/repository/submit/files.html:8
 msgid "Upload Files for"
 msgstr "Dateien hochladen für"
 
-#: src/templates/admin/repository/submit/files.html:29
+#: src/templates/admin/repository/submit/files.html:25
 msgid "You can use the form below to select and upload your manuscript file."
 msgstr ""
 "Sie können das untenstehende Formular verwenden, um Ihre Manuskript-Datei "
 "auszuwählen und hochzuladen."
 
-#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:43
 msgid "Supplementary files"
 msgstr "Zusätzliche Dateien"
 
-#: src/templates/admin/repository/submit/files.html:50
+#: src/templates/admin/repository/submit/files.html:46
 msgid "Optional links to externaly hosted supplementary files."
 msgstr "Zusätzliche Links zu andernorts gespeicherten zusätzlichen Dateien."
 
-#: src/templates/admin/repository/submit/files.html:51
-#: src/templates/admin/repository/submit/files.html:101
-#: src/templates/admin/repository/submit/files.html:108
+#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:97
+#: src/templates/admin/repository/submit/files.html:104
 #: src/templates/admin/repository/supp_files_body.html:53
 msgid "Add New Supplementary File"
 msgstr "Neue zusätzliche Dateien hinzufügen"
 
-#: src/templates/admin/repository/submit/files.html:60
+#: src/templates/admin/repository/submit/files.html:56
 msgid ""
 "If you want to change this file you can upload a new one and it will be "
 "overwritten."
@@ -2028,30 +2547,30 @@ msgstr ""
 "Wenn Sie diese Datei verändern möchten, können Sie eine neue Datei hochladen "
 "und die vorherige überschreiben."
 
-#: src/templates/admin/repository/submit/files.html:93
-msgid "Complete Step 3 of 3"
+#: src/templates/admin/repository/submit/files.html:89
+#, fuzzy
+#| msgid "Complete Step 3 of 3"
+msgid "Complete Step 3 of 4"
 msgstr "Schritt 3 von 3 abschließen"
 
-#: src/templates/admin/repository/submit/files.html:120
+#: src/templates/admin/repository/submit/files.html:116
 msgid "Submission Information"
 msgstr "Informationen zur Einreichung"
 
-#: src/templates/admin/repository/submit/review.html:8
-msgid "Submission Complete"
-msgstr "Einreichung abgeschlossen"
-
-#: src/templates/admin/repository/submit/start.html:26
+#: src/templates/admin/repository/submit/start.html:24
 msgid "Submission Agreement"
 msgstr "Einreichungs-Vereinbarung"
 
-#: src/templates/admin/repository/submit/start.html:38
+#: src/templates/admin/repository/submit/start.html:36
 #: src/themes/OLH/templates/repository/preprint.html:122
 #: src/themes/material/templates/preprints/article.html:121
 msgid "Metadata"
 msgstr "Metadaten"
 
-#: src/templates/admin/repository/submit/start.html:94
-msgid "Complete Step 1 of 3"
+#: src/templates/admin/repository/submit/start.html:92
+#, fuzzy
+#| msgid "Complete Step 1 of 3"
+msgid "Complete Step 1 of 4"
 msgstr "Schritt 1 von 3 abschließen"
 
 #: src/templates/admin/repository/version_queue.html:19
@@ -2063,16 +2582,35 @@ msgstr ""
 "so voreingestellt, dass die ältesten Anfragen zuerst aufgeführt werden."
 
 #: src/templates/admin/review/add_review_assignment.html:27
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                        You can select a reviewer using the radio buttons "
+#| "in the first column and complete the section under \"Set Options\".\n"
+#| "                        If you cannot find the reviewer you want in this "
+#| "list you can use \"Enroll Existing User\" to search the database and give "
+#| "users the Reviewer role, or \"Add New Reviewer\" to create a new account "
+#| "for a reviewer (this process is silent, they will not receive an account "
+#| "creation email).\n"
+#| "                        "
 msgid ""
 "\n"
-"                        You can select a reviewer using the radio buttons in "
-"the first column and complete the section under \"Set Options\".\n"
-"                        If you cannot find the reviewer you want in this "
-"list you can use \"Enroll Existing User\" to search the database and give "
-"users the Reviewer role, or \"Add New Reviewer\" to create a new account for "
-"a reviewer (this process is silent, they will not receive an account "
-"creation email).\n"
-"                        "
+"                                You can select a reviewer using the radio\n"
+"                                buttons in the first column and complete "
+"the\n"
+"                                section under 'Set Options'.\n"
+"                                If you cannot find the reviewer you want in\n"
+"                                this list you can use 'Enroll Existing User' "
+"to\n"
+"                                search the database and give users the "
+"Reviewer\n"
+"                                role, or 'Add New Reviewer' to create a new\n"
+"                                account for a reviewer (this process is "
+"silent,\n"
+"                                so they will not receive an account "
+"creation\n"
+"                                email).\n"
+"                            "
 msgstr ""
 "\n"
 " Über die Optionsfelder in der ersten Spalte können Sie eine*n Gutachter*in "
@@ -2083,7 +2621,7 @@ msgstr ""
 "Gutachter*in hinzufügen\" ein neues Gutachter-Konto erstellen (dieser "
 "Vorgang ist geräuschlos, er erhält keine E-Mail zur Kontoerstellung)."
 
-#: src/templates/admin/review/decision.html:44
+#: src/templates/admin/review/decision.html:57
 msgid ""
 "Note: This article has completed reviews that have not been made available "
 "to the author:"
@@ -2102,24 +2640,24 @@ msgstr "Gutachten ist sichtbar für: "
 msgid "No"
 msgstr "Nein"
 
-#: src/templates/admin/review/in_review.html:25
+#: src/templates/admin/review/in_review.html:23
 msgid "This article is not yet in the review stage"
 msgstr "Dieser Artikel ist noch nicht in der Begutachtungsphase"
 
-#: src/templates/admin/review/in_review.html:27
+#: src/templates/admin/review/in_review.html:25
 msgid "Before you can move this paper into review you need to"
 msgstr ""
 "Sie müssen diesen Artikel einem/einer Editor*in zuweisen bevor sie ihn in "
 "die Begutachtungsphase schieben können"
 
-#: src/templates/admin/review/in_review.html:28
+#: src/templates/admin/review/in_review.html:26
 msgid "assign an editor"
 msgstr ""
 "Sie müssen diesen Artikel einem/einer Editor*in zuweisen bevor sie ihn in "
 "die Begutachtungsphase schieben können"
 
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
 msgid ""
 "This paper has not had an automatic plagiarism check. If you wish to do so "
 "you can run a"
@@ -2127,14 +2665,14 @@ msgstr ""
 "Diese Artikel wurde keiner automatischen Plagiatsprüfung unterzogen. Sie "
 "können bei Bedarf über iThenticate eine Prüfung durchführen"
 
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
 msgid "Similarity Check via iThenticate"
 msgstr ""
 "Diese Artikel wurde keiner automatischen Plagiatsprüfung unterzogen. Sie "
 "können bei Bedarf über iThenticate eine Prüfung durchführen"
 
-#: src/templates/admin/review/in_review.html:68
+#: src/templates/admin/review/in_review.html:66
 #, python-format
 msgid ""
 "\n"
@@ -2147,7 +2685,7 @@ msgstr ""
 "für Gutachter*innen in Review-Runde %(round.round_number)s.\n"
 "                                            "
 
-#: src/templates/admin/review/in_review.html:217
+#: src/templates/admin/review/in_review.html:215
 msgid ""
 "\n"
 "                                The latest manuscript and figure files for "
@@ -2161,19 +2699,19 @@ msgstr ""
 "mit den neusten Versionen der Autor*innen ersetzt.\n"
 "                                "
 
-#: src/templates/admin/review/in_review.html:287
+#: src/templates/admin/review/in_review.html:285
 msgid "Move to Next Stage"
 msgstr "Zum nächsten Abschnitt verschieben"
 
-#: src/templates/admin/review/projected_issue.html:20
+#: src/templates/admin/review/projected_issue.html:27
 msgid "Save Projected Issue"
 msgstr "Geplante Ausgabe abspeichern."
 
-#: src/templates/admin/review/projected_issue.html:30
+#: src/templates/admin/review/projected_issue.html:37
 msgid "What is this for?"
 msgstr "Wofür ist das?"
 
-#: src/templates/admin/review/projected_issue.html:31
+#: src/templates/admin/review/projected_issue.html:38
 msgid ""
 "The projected issue field can be used internally to keep track of plans and "
 "communicate with typesetters, without affecting issue assignment or "
@@ -2185,7 +2723,7 @@ msgstr ""
 "der Ausgabe zu beeinflussen oder etwas zu veröffentlichen. Dies ist "
 "hilfreich für Zeitschriften, die Artikel fortlaufend veröffentlichen."
 
-#: src/templates/admin/review/projected_issue.html:32
+#: src/templates/admin/review/projected_issue.html:39
 msgid ""
 "You can assign articles directly to issues in the prepublication stage or "
 "through "
@@ -2193,15 +2731,15 @@ msgstr ""
 "Sie können Artikel direkt den Ausgaben in der Vorveröffentlichungsphase "
 "zuordnen oder über die"
 
-#: src/templates/admin/review/projected_issue.html:32
+#: src/templates/admin/review/projected_issue.html:39
 msgid "issue management"
 msgstr "Ausgabenverwaltung"
 
-#: src/templates/admin/review/projected_issue.html:33
+#: src/templates/admin/review/projected_issue.html:40
 msgid "How does it work?"
 msgstr "Wie funktioniert das?"
 
-#: src/templates/admin/review/projected_issue.html:34
+#: src/templates/admin/review/projected_issue.html:41
 msgid ""
 "Select an issue from the drop down on the left and press save. This "
 "article's projected issue will now be set."
@@ -2210,11 +2748,11 @@ msgstr ""
 "klicken Sie auf Speichern. Die geplante Ausgabe für diesen Artikel ist nun "
 "festgelegt."
 
-#: src/templates/admin/review/projected_issue.html:35
+#: src/templates/admin/review/projected_issue.html:42
 msgid "Can I unset a projected issue?"
 msgstr "Kann ich die Auswahl einer geplanten Ausgabe entfernen?"
 
-#: src/templates/admin/review/projected_issue.html:36
+#: src/templates/admin/review/projected_issue.html:43
 msgid "Yes, you can select the blank option (-------) from the dropdown."
 msgstr ""
 "Ja, Sie können die leere Option (-------) aus dem Dropdown-Menü auswählen."
@@ -2231,25 +2769,25 @@ msgstr ""
 "beachten Sie, dass Sie nach der Bestätigung keine weiteren Änderungen an "
 "Ihren Revisionen oder Exposé vornehmen können"
 
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 msgid "Assign"
 msgstr "Zuweisen"
 
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 msgid "Projected Issue"
 msgstr "Geplante Ausgabe"
 
-#: src/templates/admin/review/unassigned_article.html:122
+#: src/templates/admin/review/unassigned_article.html:125
 msgid "This article is projected to be published as part of"
 msgstr "Es ist geplant, diesen Artikel als Teil der Ausgabe zu veröffentlichen"
 
-#: src/templates/admin/review/unassigned_article.html:124
+#: src/templates/admin/review/unassigned_article.html:127
 msgid "This article is not projected to be published as part of any issue."
 msgstr ""
 "Es ist nicht geplant, dass dieser Artikel als Teil einer Ausgabe "
 "veröffentlicht wird."
 
-#: src/templates/admin/review/unassigned_article.html:137
+#: src/templates/admin/review/unassigned_article.html:140
 msgid ""
 "To check an article for possible plagiarism, you can send an article for an "
 "automated Similarity Check via iThenticate by clicking Send below. The "
@@ -2344,7 +2882,6 @@ msgid "Withdrawn"
 msgstr "Zurückgezogen"
 
 #: src/templates/admin/review/view_review.html:63
-#: src/themes/material/templates/journal/article.html:394
 msgid "Accepted"
 msgstr "Akzeptiert"
 
@@ -2431,7 +2968,7 @@ msgstr ""
 msgid "Suggested Reviewers"
 msgstr "Vorgeschlagene Gutachter"
 
-#: src/templates/admin/submission/edit/metadata.html:178
+#: src/templates/admin/submission/edit/metadata.html:195
 msgid ""
 "\n"
 "                            You can search the <a href=\"https://www."
@@ -2447,7 +2984,7 @@ msgstr ""
 "Drittmittelgeber hinzuzufügen.\n"
 "                        "
 
-#: src/templates/admin/submission/manager/delete_license.html:26
+#: src/templates/admin/submission/manager/delete_license.html:25
 msgid ""
 "This license is currently used by the following articles. If you delete it "
 "these articles will no longer have a license listed."
@@ -2456,9 +2993,13 @@ msgstr ""
 "Lizenz löschen, verfügen diese Artikel nicht mehr über eine zugewiesene "
 "Lizenz."
 
-#: src/templates/admin/submission/manager/delete_license.html:27
+#: src/templates/admin/submission/manager/delete_license.html:26
+#, fuzzy
+#| msgid ""
+#| "You should only delete this license if you are absolutley sure you want "
+#| "to remove it."
 msgid ""
-"You should only delete this license if you are absolutley sure you want to "
+"You should only delete this license if you are absolutely sure you want to "
 "remove it."
 msgstr ""
 "Sie sollten die Lizenz nur löschen wenn Sie absolut sicher sind, dass Sie "
@@ -2479,7 +3020,7 @@ msgstr ""
 "Bitte lesen Sie die folgenden Anweisungen sorgfältig durch, bevor Sie "
 "bestätigen"
 
-#: src/templates/admin/submission/start.html:24
+#: src/templates/admin/submission/start.html:29
 msgid ""
 "All authors must agree to the below statements in order to submit an article "
 "to"
@@ -2487,7 +3028,7 @@ msgstr ""
 "Autor*innen müssen den folgenden Bedingungen zustimmen um einen Artikel in "
 "{Title} hinzufügen zu können"
 
-#: src/templates/admin/submission/start.html:24
+#: src/templates/admin/submission/start.html:29
 msgid ""
 "If you do not agree with these terms you will be unable to proceed with your "
 "submission."
@@ -2495,32 +3036,32 @@ msgstr ""
 "Wenn Sie mit diesen Bedingungen nicht einverstanden sind, können Sie mit "
 "Ihrer Einreichung nicht fortfahren."
 
-#: src/templates/admin/submission/start.html:29
+#: src/templates/admin/submission/start.html:34
 msgid "Publication Fees"
 msgstr "Publikationsgebühren"
 
-#: src/templates/admin/submission/start.html:36
+#: src/templates/admin/submission/start.html:41
 msgid "Author(s) agrees to the above statement"
 msgstr "Autor*innen stimmen zu"
 
-#: src/templates/admin/submission/start.html:42
+#: src/templates/admin/submission/start.html:47
 msgid "Submission Checklist"
 msgstr "Checkliste Einreichung"
 
-#: src/templates/admin/submission/start.html:48
+#: src/templates/admin/submission/start.html:53
 msgid "Author(s) confirms that this article adheres to the above requirements"
 msgstr ""
 "Autor*innen bestätigen, dass dieser Artikel den obigen Anforderungen "
 "entspricht"
 
-#: src/templates/admin/submission/start.html:54
+#: src/templates/admin/submission/start.html:59
 msgid "Copyright Notice"
 msgstr "Urheberrechtshinweis"
 
-#: src/templates/admin/submission/start.html:66
-#: src/themes/OLH/templates/journal/article.html:428
-#: src/themes/clean/templates/journal/article.html:255
-#: src/themes/material/templates/journal/article.html:424
+#: src/templates/admin/submission/start.html:71
+#: src/themes/OLH/templates/journal/article.html:419
+#: src/themes/clean/templates/journal/article.html:265
+#: src/themes/material/templates/journal/article.html:400
 msgid "Competing Interests"
 msgstr "Konkurrierende Interessen"
 
@@ -2530,11 +3071,11 @@ msgstr "Konkurrierende Interessen"
 msgid "Author Information"
 msgstr "Informationen zum Autor / zur Autorin"
 
-#: src/templates/admin/submission/submit_authors.html:18
+#: src/templates/admin/submission/submit_authors.html:23
 msgid "Search for Existing Authors"
 msgstr "Suche nach vorhandenen Autor*innen"
 
-#: src/templates/admin/submission/submit_authors.html:25
+#: src/templates/admin/submission/submit_authors.html:30
 msgid ""
 "Search for a user using email address or ORCiD. If a user is matched, they "
 "will be automatically added as an author. This search only returns exact "
@@ -2544,12 +3085,12 @@ msgstr ""
 "Übereinstimmung gefunden wird, werden diese automatisch als Autor*in "
 "hinzugefügt. Diese Suche gibt nur exakte Übereinstimmungen zurück."
 
-#: src/templates/admin/submission/submit_authors.html:31
+#: src/templates/admin/submission/submit_authors.html:36
 msgid "Search by email address or ORCiD"
 msgstr "Suche nach E-Mail-Adresse oder ORCiD"
 
-#: src/templates/admin/submission/submit_authors.html:35
-#: src/themes/OLH/templates/core/base.html:153
+#: src/templates/admin/submission/submit_authors.html:40
+#: src/themes/OLH/templates/core/base.html:154
 #: src/themes/OLH/templates/journal/full-text-search.html:8
 #: src/themes/OLH/templates/journal/full-text-search.html:10
 #: src/themes/OLH/templates/journal/full-text-search.html:70
@@ -2572,23 +3113,23 @@ msgstr "Suche nach E-Mail-Adresse oder ORCiD"
 msgid "Search"
 msgstr "Suche"
 
-#: src/templates/admin/submission/submit_authors.html:40
+#: src/templates/admin/submission/submit_authors.html:45
 msgid "Add Authors"
 msgstr "Fügen Sie Autor*innen hinzu"
 
-#: src/templates/admin/submission/submit_authors.html:55
+#: src/templates/admin/submission/submit_authors.html:60
 msgid "Current Authors"
 msgstr "Aktuelle Autor*innen"
 
-#: src/templates/admin/submission/submit_authors.html:57
+#: src/templates/admin/submission/submit_authors.html:62
 msgid "Drag and drop an author to re-order them."
 msgstr "Autor*innen durch Ziehen und Ablegen neu anordnen"
 
-#: src/templates/admin/submission/submit_authors.html:81
+#: src/templates/admin/submission/submit_authors.html:86
 msgid "No authors yet, add one!"
 msgstr "Noch keine Autor*innen vorhanden, fügen Sie jemanden hinzu!"
 
-#: src/templates/admin/submission/submit_authors.html:88
+#: src/templates/admin/submission/submit_authors.html:93
 msgid ""
 "You are required to select a main author, this author will receive the "
 "communications regarding your articles process through our systems. This "
@@ -2598,14 +3139,14 @@ msgstr ""
 "die Mitteilungen bezüglich des Artikelprozesses durch unsere Systeme. Sie "
 "müssen sich nicht selbst nennen."
 
-#: src/templates/admin/submission/submit_authors.html:89
+#: src/templates/admin/submission/submit_authors.html:94
 msgid "Select main author"
 msgstr "Hauptautor*in wählen"
 
-#: src/templates/admin/submission/submit_authors.html:99
-#: src/templates/admin/submission/submit_files.html:112
-#: src/templates/admin/submission/submit_funding.html:75
-#: src/templates/admin/submission/submit_info.html:83
+#: src/templates/admin/submission/submit_authors.html:104
+#: src/templates/admin/submission/submit_files.html:118
+#: src/templates/admin/submission/submit_funding.html:111
+#: src/templates/admin/submission/submit_info.html:93
 msgid "Save and Continue"
 msgstr "Speichern und fortfahren"
 
@@ -2613,75 +3154,88 @@ msgstr "Speichern und fortfahren"
 msgid "Upload files"
 msgstr "Dateien hochladen"
 
-#: src/templates/admin/submission/submit_files.html:33
-#: src/templates/admin/submission/submit_files.html:74
+#: src/templates/admin/submission/submit_files.html:39
+#: src/templates/admin/submission/submit_files.html:80
 msgid "Upload"
 msgstr "Hochladen"
 
-#: src/templates/admin/submission/submit_files.html:41
-#: src/templates/admin/submission/submit_files.html:81
-#: src/templates/admin/submission/submit_review.html:121
+#: src/templates/admin/submission/submit_files.html:47
+#: src/templates/admin/submission/submit_files.html:87
+#: src/templates/admin/submission/submit_review.html:137
 msgid "File Name"
 msgstr "Dateiname"
 
-#: src/templates/admin/submission/submit_files.html:59
-#: src/templates/admin/submission/submit_files.html:97
+#: src/templates/admin/submission/submit_files.html:65
+#: src/templates/admin/submission/submit_files.html:103
 msgid "No files uploaded"
 msgstr "Keine Dateien hochgeladen"
 
 #: src/templates/admin/submission/submit_funding.html:7
-#: src/templates/admin/submission/submit_info.html:6
-#: src/templates/admin/submission/submit_review.html:43
-msgid "Article Info"
-msgstr "Informationen zum Artikel"
+#, fuzzy
+#| msgid "License Information"
+msgid "Funding Information"
+msgstr "Lizenzinformationen"
 
-#: src/templates/admin/submission/submit_funding.html:16
+#: src/templates/admin/submission/submit_funding.html:25
 #: src/templates/admin/submission/timeline.html:36
 #: src/templates/admin/submission/timeline.html:37
-#: src/themes/OLH/templates/journal/article.html:229
-#: src/themes/clean/templates/journal/article.html:123
-#: src/themes/material/templates/journal/article.html:151
+#: src/templates/common/elements/funder_info_for_readers.html:3
 msgid "Funding"
 msgstr "Fördermittel"
 
-#: src/templates/admin/submission/submit_funding.html:20
+#: src/templates/admin/submission/submit_funding.html:30
+msgid ""
+"\n"
+"                         Here you can search the FundRef database to add "
+"grant IDs to your article's metadata. If you can't find a specific funder, "
+"you can manually enter the details. You can also edit or delete entries as "
+"necessary.\n"
+"                    "
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:36
 msgid "Add Funding Source"
 msgstr "Fördermittelquelle hinzufügen"
 
-#: src/templates/admin/submission/submit_funding.html:27
+#: src/templates/admin/submission/submit_funding.html:47
 msgid "Search for funder"
 msgstr "Nach Fördermittelquelle suchen"
 
-#: src/templates/admin/submission/submit_funding.html:31
+#: src/templates/admin/submission/submit_funding.html:53
 msgid "Add funder manually"
 msgstr "Förderung manuell hinzufügen"
 
-#: src/templates/admin/submission/submit_funding.html:41
+#: src/templates/admin/submission/submit_funding.html:64
 msgid "Current Funders"
 msgstr "Aktuelle Fördermittelquelle"
 
-#: src/templates/admin/submission/submit_funding.html:50
+#: src/templates/admin/submission/submit_funding.html:74
 msgid "Grant Number"
 msgstr "Bewilligungsnummer"
 
-#: src/templates/admin/submission/submit_funding.html:65
+#: src/templates/admin/submission/submit_funding.html:100
 msgid "No funders added."
 msgstr "Keine Fördermittelquelle hinzugefügt."
 
-#: src/templates/admin/submission/submit_info.html:16
+#: src/templates/admin/submission/submit_info.html:6
+#: src/templates/admin/submission/submit_review.html:48
+msgid "Article Info"
+msgstr "Informationen zum Artikel"
+
+#: src/templates/admin/submission/submit_info.html:26
 msgid "This article is a preprint"
 msgstr "Dieser Artikel ist ein Preprint"
 
-#: src/templates/admin/submission/submit_info.html:21
+#: src/templates/admin/submission/submit_info.html:31
 msgid "Basic Information"
 msgstr "Allgemeine Informationen"
 
-#: src/templates/admin/submission/submit_info.html:58
+#: src/templates/admin/submission/submit_info.html:68
 msgid "View license information"
 msgstr "Lizenzinformationen einsehen"
 
-#: src/templates/admin/submission/submit_info.html:67
-#: src/themes/OLH/templates/journal/article.html:178
+#: src/templates/admin/submission/submit_info.html:77
+#: src/themes/OLH/templates/journal/article.html:181
 #: src/themes/OLH/templates/journal/keywords.html:6
 #: src/themes/OLH/templates/journal/keywords.html:12
 #: src/themes/OLH/templates/journal/print.html:33
@@ -2701,17 +3255,13 @@ msgstr "Lizenzinformationen einsehen"
 #: src/themes/material/templates/journal/search.html:50
 #: src/themes/material/templates/preprints/list.html:79
 #: src/themes/material/templates/repository/list.html:60
-#: src/themes/material/templates/repository/preprint.html:172
+#: src/themes/material/templates/repository/preprint.html:170
 msgid "Keywords"
 msgstr "Schlagwörter"
 
-#: src/templates/admin/submission/submit_info.html:96
+#: src/templates/admin/submission/submit_info.html:106
 msgid "License Information"
 msgstr "Lizenzinformationen"
-
-#: src/templates/admin/submission/submit_info.html:99
-msgid "allows the following licenses for submission"
-msgstr "Erlaubt die folgenden Lizenzen für die Einreichung"
 
 #: src/templates/admin/submission/submit_review.html:7
 #: src/templates/admin/submission/timeline.html:43
@@ -2721,7 +3271,7 @@ msgstr "Erlaubt die folgenden Lizenzen für die Einreichung"
 msgid "Review your submission"
 msgstr "Überprüfen Sie Ihre Einreichung"
 
-#: src/templates/admin/submission/submit_review.html:21
+#: src/templates/admin/submission/submit_review.html:26
 msgid ""
 "Please review your submission use the details below. If you need to make "
 "changes use the links above to move back along the submission steps. You "
@@ -2731,94 +3281,95 @@ msgid ""
 msgstr ""
 "Bitte kontrollieren Sie Ihre Einreichung mit Hilfe der Details. Wenn Sie "
 "Änderungen vornehmen möchten, nutzen Sie die obigen Links, um zu den "
-"verschiedenen Einreichungsschritten zu navigieren. Sie müssen den <strong>"
-"\"Einreichung vollständig\"</strong>-Button am Fuß der Seite klicken, um den "
-"Einreichungsprozess abzuschließen. Sie werden eine Bestätigungsmail erhalten."
+"verschiedenen Einreichungsschritten zu navigieren. Sie müssen den "
+"<strong>\"Einreichung vollständig\"</strong>-Button am Fuß der Seite "
+"klicken, um den Einreichungsprozess abzuschließen. Sie werden eine "
+"Bestätigungsmail erhalten."
 
-#: src/templates/admin/submission/submit_review.html:25
+#: src/templates/admin/submission/submit_review.html:30
 msgid "Agreements"
 msgstr "Zustimmungen"
 
-#: src/templates/admin/submission/submit_review.html:29
+#: src/templates/admin/submission/submit_review.html:34
 msgid "Agreed to Publication Fees statement"
 msgstr "Der Erklärung zu den Veröffentlichungsgebühren zugestimmt"
 
-#: src/templates/admin/submission/submit_review.html:33
+#: src/templates/admin/submission/submit_review.html:38
 msgid "Agreed to Submission Checklist"
 msgstr "Den Einreichungsbestimmungen zugestimmt"
 
-#: src/templates/admin/submission/submit_review.html:37
+#: src/templates/admin/submission/submit_review.html:42
 msgid "Agreed to Copyright statement"
 msgstr "Den Copyright-Bedingungen zugestimmt"
 
-#: src/templates/admin/submission/submit_review.html:59
-#: src/themes/OLH/templates/journal/article.html:175
+#: src/templates/admin/submission/submit_review.html:64
+#: src/themes/OLH/templates/journal/article.html:178
 #: src/themes/OLH/templates/journal/print.html:30
 #: src/themes/OLH/templates/repository/preprint.html:45
 #: src/themes/clean/templates/journal/article.html:78
 #: src/themes/clean/templates/journal/print.html:30
 #: src/themes/material/templates/journal/article.html:73
 #: src/themes/material/templates/preprints/article.html:43
-#: src/themes/material/templates/repository/preprint.html:157
+#: src/themes/material/templates/repository/preprint.html:155
 msgid "Abstract"
 msgstr "Abstract"
 
-#: src/templates/admin/submission/submit_review.html:68
+#: src/templates/admin/submission/submit_review.html:73
 msgid "Language"
 msgstr "Sprache"
 
-#: src/templates/admin/submission/submit_review.html:72
-#: src/themes/material/templates/journal/article.html:413
+#: src/templates/admin/submission/submit_review.html:77
+#: src/themes/material/templates/journal/article.html:389
 msgid "Licence"
 msgstr "Lizenz"
 
-#: src/templates/admin/submission/submit_review.html:94
+#: src/templates/admin/submission/submit_review.html:110
 msgid "Author Info"
 msgstr "Informationen über den Autor / die Autorin"
 
-#: src/templates/admin/submission/submit_review.html:97
+#: src/templates/admin/submission/submit_review.html:113
 msgid "First Name"
 msgstr "Vorname"
 
-#: src/templates/admin/submission/submit_review.html:98
+#: src/templates/admin/submission/submit_review.html:114
 msgid "Middle Name"
 msgstr "zweiter Vorname"
 
-#: src/templates/admin/submission/submit_review.html:99
+#: src/templates/admin/submission/submit_review.html:115
 msgid "Last Name"
 msgstr "Nachname"
 
-#: src/templates/admin/submission/submit_review.html:100
+#: src/templates/admin/submission/submit_review.html:116
 msgid "Email Address"
 msgstr "E-Mail Adresse"
 
-#: src/templates/admin/submission/submit_review.html:110
+#: src/templates/admin/submission/submit_review.html:126
 msgid "No ORCID supplied"
 msgstr "keine ORCID angegeben"
 
-#: src/templates/admin/submission/submit_review.html:117
+#: src/templates/admin/submission/submit_review.html:133
 #: src/templates/admin/submission/timeline.html:28
 #: src/templates/admin/submission/timeline.html:29
 msgid "Article Files"
 msgstr "Artikeldateien"
 
-#: src/templates/admin/submission/submit_review.html:122
+#: src/templates/admin/submission/submit_review.html:138
 msgid "File Type"
 msgstr "Dateityp"
 
-#: src/templates/admin/submission/submit_review.html:128
+#: src/templates/admin/submission/submit_review.html:144
 msgid "Manuscript"
 msgstr "Manuskript"
 
-#: src/templates/admin/submission/submit_review.html:136
+#: src/templates/admin/submission/submit_review.html:152
 msgid "Figure/Data"
 msgstr "Abbildungen / Daten"
 
-#: src/templates/admin/submission/submit_review.html:146
+#: src/templates/admin/submission/submit_review.html:162
 msgid "Comments to the Editor"
 msgstr "Kommentare an die Herausgeber*innen"
 
-#: src/templates/admin/submission/submit_review.html:149
+#: src/templates/admin/submission/submit_review.html:165
 msgid ""
 "Before submitting you have the option to add additional comments for the "
 "editor using the field below. Only the editor will see anything you add here."
@@ -2827,11 +3378,11 @@ msgstr ""
 "zusätzliche Kommentare an die Redaktion hinzuzufügen. Alles, was Sie hier "
 "hinzufügen, sieht nur die Redaktion."
 
-#: src/templates/admin/submission/submit_review.html:155
+#: src/templates/admin/submission/submit_review.html:171
 msgid "Complete"
 msgstr "Vollständig"
 
-#: src/templates/admin/submission/submit_review.html:155
+#: src/templates/admin/submission/submit_review.html:171
 #: src/themes/OLH/templates/core/nav.html:40
 #: src/themes/clean/templates/core/nav.html:47
 #: src/themes/material/templates/core/nav.html:39
@@ -2848,15 +3399,38 @@ msgstr "Einreichung gestartet"
 msgid "Article Information"
 msgstr "Informationen zum Artikel"
 
+#: src/templates/common/accounts/register_privacy_policy.html:3
+#: src/templates/common/accounts/register_privacy_policy.html:7
+#: src/templates/common/accounts/register_privacy_policy.html:11
+#: src/themes/OLH/templates/elements/journal_footer.html:25
+#: src/themes/OLH/templates/elements/journal_footer.html:27
+#: src/themes/OLH/templates/press/elements/press_footer.html:9
+#: src/themes/OLH/templates/press/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/journal_footer.html:33
+#: src/themes/clean/templates/elements/journal_footer.html:37
+#: src/themes/clean/templates/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/press_footer.html:14
+#: src/themes/hourglass/templates/custom/register.html:29
+#: src/themes/hourglass/templates/custom/register.html:35
+#: src/themes/material/templates/elements/journal_footer.html:28
+msgid "Privacy Policy"
+msgstr "Datenschutzbestimmungen"
+
+#: src/templates/common/elements/funder_info_for_readers.html:6
+#, fuzzy
+#| msgid "Funding"
+msgid "Funding ID"
+msgstr "Fördermittel"
+
 #: src/templates/common/elements/journal/article_issue_list.html:4
 #: src/themes/OLH/templates/core/nav.html:25
+#: src/themes/OLH/templates/journal/issues.html:5
 #: src/themes/OLH/templates/journal/issues.html:7
-#: src/themes/OLH/templates/journal/issues.html:9
 #: src/themes/clean/templates/core/nav.html:24
 #: src/themes/clean/templates/journal/issues.html:6
 #: src/themes/material/templates/core/nav.html:33
 #: src/themes/material/templates/core/nav.html:94
-#: src/themes/material/templates/journal/issues.html:6
+#: src/themes/material/templates/journal/issues.html:5
 msgid "Issues"
 msgstr "Ausgaben"
 
@@ -2876,6 +3450,30 @@ msgstr "Primary: "
 #: src/templates/common/elements/journal/article_issue_list.html:21
 msgid "This article is not a part of any issues"
 msgstr "Dieser Artikel ist nicht Teil einer Ausgabe"
+
+#: src/templates/common/elements/orcid_registration.html:16
+#, fuzzy
+#| msgid "Login with ORCiD"
+msgid "Register with ORCiD"
+msgstr "Einloggen mit ORCiD"
+
+#: src/templates/common/elements/password_rules.html:2
+#, python-format
+msgid "Your password should be %(password_length)s characters long."
+msgstr "Ihr Passwort sollte %(password_length)s Zeichen lang sein."
+
+#: src/templates/common/elements/password_rules.html:6
+msgid "Your password should contain at least one upper case letter."
+msgstr "Ihr Passwort sollte mindestens einen Großbuchstaben enthalten."
+
+#: src/templates/common/elements/password_rules.html:11
+msgid "Your password should contain at least one number."
+msgstr "Ihr Passwort sollte mindestens eine Zahl enthalten."
+
+#: src/templates/common/elements/skip_to_main_content.html:3
+#: src/themes/clean/templates/500.html:21
+msgid "Skip to main content"
+msgstr "Zum Hauptinhalt springen"
 
 #: src/templates/common/elements/sorting.html:7
 #: src/themes/clean/templates/elements/sorting.html:7
@@ -2929,33 +3527,30 @@ msgstr "Serverfehler"
 msgid "A server error has occurred"
 msgstr "Ein Server-Fehler ist aufgetreten"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:5
-#: src/themes/OLH/templates/core/accounts/activate_account.html:22
-#: src/themes/OLH/templates/core/accounts/activate_account.html:26
-#: src/themes/clean/templates/core/accounts/activate_account.html:5
-#: src/themes/clean/templates/core/accounts/activate_account.html:13
-#: src/themes/clean/templates/core/accounts/activate_account.html:17
-#: src/themes/material/templates/core/accounts/activate_account.html:5
-#: src/themes/material/templates/core/accounts/activate_account.html:14
-#: src/themes/material/templates/core/accounts/activate_account.html:19
-msgid "Activate Account"
-msgstr "Konto aktivieren"
+#: src/themes/OLH/templates/cms/page.html:22
+#: src/themes/clean/templates/cms/page.html:19
+#: src/themes/clean/templates/journal/article.html:340
+#: src/themes/material/templates/cms/page.html:25
+#: src/themes/material/templates/journal/article.html:484
+#: src/themes/material/templates/journal/submissions.html:72
+msgid "Table of Contents"
+msgstr "Inhaltsverzeichnis"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:25
-#: src/themes/clean/templates/core/accounts/activate_account.html:16
-#: src/themes/material/templates/core/accounts/activate_account.html:17
+#: src/themes/OLH/templates/core/accounts/activate_account.html:29
+#: src/themes/clean/templates/core/accounts/activate_account.html:20
+#: src/themes/material/templates/core/accounts/activate_account.html:21
 msgid "You can complete the activation process by clicking the button below."
 msgstr ""
 "Sie können den Aktivierungsprozess abschließen, indem Sie auf die "
 "Schaltfläche unten klicken."
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:29
-#: src/themes/clean/templates/core/accounts/activate_account.html:20
-#: src/themes/material/templates/core/accounts/activate_account.html:23
+#: src/themes/OLH/templates/core/accounts/activate_account.html:33
+#: src/themes/clean/templates/core/accounts/activate_account.html:24
+#: src/themes/material/templates/core/accounts/activate_account.html:27
 msgid "Error"
 msgstr "Fehler"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:31
+#: src/themes/OLH/templates/core/accounts/activate_account.html:35
 msgid ""
 "There was no inactive account with this activation code found. It is "
 "possible that your account is already active, you can check by attempting to"
@@ -2964,49 +3559,32 @@ msgstr ""
 "möglich, dass das Konto bereits aktiv ist. Sie können das überprüfen, indem "
 "Sie"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:32
-#: src/themes/clean/templates/core/accounts/activate_account.html:22
-#: src/themes/material/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:36
+#: src/themes/clean/templates/core/accounts/activate_account.html:26
+#: src/themes/material/templates/core/accounts/activate_account.html:30
 msgid "login"
 msgstr "Anmeldung"
 
-#: src/themes/OLH/templates/core/accounts/edit_profile.html:4
-#: src/themes/clean/templates/core/accounts/edit_profile.html:5
-#: src/themes/material/templates/core/accounts/edit_profile.html:4
-msgid "Edit Profile"
-msgstr "Profil bearbeiten"
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:5
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:9
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:86
 #: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:105
 #: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:100
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:25
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:15
-#: src/themes/material/templates/core/accounts/get_reset_token.html:14
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:20
+#: src/themes/material/templates/core/accounts/get_reset_token.html:20
 msgid "Enter your email address to begin the reset process"
 msgstr "Geben Sie Ihre E-Mail-Adresse ein, um mit dem Zurücksetzen zu beginnen"
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:27
-msgid "somebody"
-msgstr "jemand"
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:21
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:31
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:24
+#: src/themes/material/templates/core/accounts/get_reset_token.html:25
 msgid "Request Token"
 msgstr "Code anfordern"
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:5
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:19
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:4
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:9
-msgid "Unregistered ORCiD"
-msgstr "Nicht registrierte ORCiD"
-
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:20
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:24
 msgid ""
 "The ORCiD you logged in with is not currently linked with an account in our "
 "system. You can either register a new account, or login with an existing "
@@ -3017,27 +3595,27 @@ msgstr ""
 "sich mit einem bestehenden Konto anmelden und die ORCiD mit diesem für die "
 "Zukunft verknüpfen."
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:40
 #: src/themes/OLH/templates/press/core/login.html:36
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:29
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:33
 msgid "Log In"
 msgstr "Einloggen"
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:37
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:41
 #: src/themes/OLH/templates/press/core/login.html:37
 msgid "Forgot your password?"
 msgstr "Passwort vergessen?"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:5
-#: src/themes/OLH/templates/core/nav.html:73
+#: src/themes/OLH/templates/core/accounts/public_profile.html:9
+#: src/themes/OLH/templates/core/nav.html:72
 #: src/themes/OLH/templates/elements/right_hand_menu.html:38
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:12
 #: src/themes/OLH/templates/press/nav.html:54
 #: src/themes/OLH/templates/repository/elements/right_hand_menu.html:10
-#: src/themes/clean/templates/core/accounts/public_profile.html:4
+#: src/themes/clean/templates/core/accounts/public_profile.html:8
 #: src/themes/clean/templates/core/nav.html:98
 #: src/themes/clean/templates/press/nav.html:71
-#: src/themes/material/templates/core/accounts/public_profile.html:5
+#: src/themes/material/templates/core/accounts/public_profile.html:9
 #: src/themes/material/templates/core/nav.html:165
 #: src/themes/material/templates/core/nav.html:200
 #: src/themes/material/templates/press/nav.html:135
@@ -3045,132 +3623,57 @@ msgstr "Passwort vergessen?"
 msgid "Profile"
 msgstr "Profil"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:13
-#: src/themes/clean/templates/core/accounts/public_profile.html:13
-#: src/themes/material/templates/core/accounts/public_profile.html:13
+#: src/themes/OLH/templates/core/accounts/public_profile.html:19
+#: src/themes/clean/templates/core/accounts/public_profile.html:17
+#: src/themes/material/templates/core/accounts/public_profile.html:17
 msgid "Roles"
 msgstr "Rollen"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:25
-#: src/themes/clean/templates/core/accounts/public_profile.html:25
-#: src/themes/material/templates/core/accounts/public_profile.html:25
+#: src/themes/OLH/templates/core/accounts/public_profile.html:27
+#, fuzzy
+#| msgid "Editorial Team"
+msgid "Editorial groups"
+msgstr "Redaktionsteam"
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:35
+msgid "Staff roles"
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:56
+#: src/themes/clean/templates/core/accounts/public_profile.html:29
+#: src/themes/material/templates/core/accounts/public_profile.html:29
 msgid "Publications"
 msgstr "Publikationen"
 
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
+#: src/themes/OLH/templates/core/accounts/register.html:29
+#: src/themes/clean/templates/core/accounts/register.html:21
+#: src/themes/material/templates/core/accounts/register.html:19
 msgid "Register for an account with"
 msgstr "Accountregistrierung"
 
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
-msgid "account"
-msgstr "Accountregistrierung"
-
-#: src/themes/OLH/templates/core/accounts/register.html:26
-#: src/themes/OLH/templates/core/accounts/reset_password.html:27
-#: src/themes/clean/templates/core/accounts/register.html:18
-#: src/themes/clean/templates/core/accounts/reset_password.html:17
-#: src/themes/material/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/reset_password.html:17
-msgid "Password Rules"
-msgstr "Passwortrichtlinien"
-
-#: src/themes/OLH/templates/core/accounts/register.html:28
-#: src/themes/clean/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/register.html:22
-#: src/themes/material/templates/core/accounts/reset_password.html:19
-#: src/templates/common/elements/password_rules.html:2
-msgid "Your password should be %(password_length)s characters long."
-msgstr "Ihr Passwort sollte %(password_length)s Zeichen lang sein."
-
-#: src/themes/OLH/templates/core/accounts/register.html:29
-#: src/themes/OLH/templates/core/accounts/reset_password.html:30
-#: src/themes/clean/templates/core/accounts/register.html:21
-#: src/themes/clean/templates/core/accounts/reset_password.html:20
-#: src/themes/material/templates/core/accounts/register.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:20
-#: src/templates/common/elements/password_rules.html:7
-msgid "Your password should contain at least one upper case letter."
-msgstr "Ihr Passwort sollte mindestens einen Großbuchstaben enthalten."
-
-#: src/themes/OLH/templates/core/accounts/register.html:30
-#: src/themes/OLH/templates/core/accounts/reset_password.html:31
-#: src/themes/clean/templates/core/accounts/register.html:22
-#: src/themes/clean/templates/core/accounts/reset_password.html:21
-#: src/themes/material/templates/core/accounts/register.html:24
-#: src/themes/material/templates/core/accounts/reset_password.html:21
-#: src/templates/common/elements/password_rules.html:12
-#, python-format
-msgid "Your password should contain at least one number."
-msgstr "Ihr Passwort sollte mindestens eine Zahl enthalten."
-
-#: src/themes/OLH/templates/core/accounts/register.html:31
-#: src/themes/OLH/templates/core/accounts/reset_password.html:32
+#: src/themes/OLH/templates/core/accounts/register.html:35
+#: src/themes/OLH/templates/core/accounts/reset_password.html:36
 msgid ""
 "For more information read our <a href=\"#\" data-open=\"password-"
 "modal\">password guide</a>."
 msgstr ""
-"Für weitere Informationen lesen Sie <a href=\"#\" data-open=\"password-modal\">password guide</a>."
+"Für weitere Informationen lesen Sie <a href=\"#\" data-open=\"password-"
+"modal\">password guide</a>."
 
-#: src/themes/material/templates/core/accounts/register.html:25
-#: src/themes/material/templates/core/accounts/reset_password.html:22
-msgid ""
-"For more information read our <a href=\"#\" data-target=\"passwordmodal\" "
-"class=\"modal-trigger\">password guide</a>."
-msgstr ""
-"Für weitere Informationen lesen Sie <a href=\"#\" data-target=\"passwordmodal\" class=\"modal-trigger\">password guide</a>"
-
-
-#: src/themes/OLH/templates/core/accounts/register.html:83
-#: src/themes/clean/templates/core/accounts/register.html:27
-#: src/themes/material/templates/core/accounts/register.html:33
-msgid "By registering an account you agree to our"
-msgstr "Mit der Registrierung eines Kontos stimmen Sie unseren Bedingungen zu"
-
-#: src/themes/OLH/templates/core/accounts/register.html:85
-#: src/themes/OLH/templates/core/accounts/register.html:87
-#: src/themes/OLH/templates/elements/journal_footer.html:25
-#: src/themes/OLH/templates/elements/journal_footer.html:27
-#: src/themes/OLH/templates/press/elements/press_footer.html:9
-#: src/themes/OLH/templates/press/elements/press_footer.html:11
-#: src/themes/clean/templates/core/accounts/register.html:29
-#: src/themes/clean/templates/core/accounts/register.html:31
-#: src/themes/clean/templates/elements/journal_footer.html:33
-#: src/themes/clean/templates/elements/journal_footer.html:37
-#: src/themes/clean/templates/elements/press_footer.html:11
-#: src/themes/clean/templates/elements/press_footer.html:14
-#: src/themes/material/templates/core/accounts/register.html:35
-#: src/themes/material/templates/core/accounts/register.html:37
-#: src/themes/material/templates/elements/journal_footer.html:28
-msgid "Privacy Policy"
-msgstr "Datenschutzbestimmungen"
-
-#: src/themes/OLH/templates/core/accounts/register.html:106
-#: src/themes/OLH/templates/core/accounts/reset_password.html:48
-#: src/themes/clean/templates/core/accounts/register.html:54
-#: src/themes/clean/templates/core/accounts/reset_password.html:43
-#: src/themes/material/templates/core/accounts/register.html:53
-#: src/themes/material/templates/core/accounts/reset_password.html:41
-msgid "Password Guide"
-msgstr "Passwort-Anleitung"
-
-#: src/themes/OLH/templates/core/accounts/register.html:107
-#: src/themes/OLH/templates/core/accounts/reset_password.html:49
-#: src/themes/clean/templates/core/accounts/reset_password.html:49
+#: src/themes/OLH/templates/core/accounts/register.html:111
+#: src/themes/OLH/templates/core/accounts/reset_password.html:53
+#: src/themes/clean/templates/core/accounts/reset_password.html:53
 #: src/themes/material/templates/core/accounts/register.html:54
-#: src/themes/material/templates/core/accounts/reset_password.html:42
+#: src/themes/material/templates/core/accounts/reset_password.html:44
 msgid "When it comes to passwords, length is better than complexity."
 msgstr ""
 "Wenn es um die Sicherheit von Passwörter geht, ist Länge besser als "
 "Komplexität."
 
-#: src/themes/OLH/templates/core/accounts/register.html:108
-#: src/themes/OLH/templates/core/accounts/reset_password.html:50
+#: src/themes/OLH/templates/core/accounts/register.html:112
+#: src/themes/OLH/templates/core/accounts/reset_password.html:54
 #: src/themes/material/templates/core/accounts/register.html:55
-#: src/themes/material/templates/core/accounts/reset_password.html:43
+#: src/themes/material/templates/core/accounts/reset_password.html:45
 msgid ""
 "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
 "secure than a long and uncomplicated password (our awesome moon base rocks)."
@@ -3179,8 +3682,8 @@ msgstr ""
 "(Jfjfy&65^87) sicherer ist als ein langes und unkompliziertes Passwort "
 "(unsere fantastische Mondbasis)."
 
-#: src/themes/OLH/templates/core/accounts/register.html:109
-#: src/themes/OLH/templates/core/accounts/reset_password.html:51
+#: src/themes/OLH/templates/core/accounts/register.html:113
+#: src/themes/OLH/templates/core/accounts/reset_password.html:55
 msgid ""
 "We recommend selecting a long, but easy to remember password such as our "
 "awesome moon base rocks which would take an estimated septillion years to "
@@ -3193,44 +3696,28 @@ msgstr ""
 "- im Gegensatz zu einem komplexen wie \"Jfjfy&65^87\", welches auf einem "
 "Standardcomputer etwas über 600 Jahre für die Entschlüsselung brauchen würde."
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:6
-#: src/themes/OLH/templates/core/accounts/reset_password.html:38
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:4
-#: src/themes/clean/templates/core/accounts/reset_password.html:5
-#: src/themes/clean/templates/core/accounts/reset_password.html:29
-#: src/themes/material/templates/core/accounts/get_reset_token.html:4
-#: src/themes/material/templates/core/accounts/reset_password.html:5
-#: src/themes/material/templates/core/accounts/reset_password.html:29
+#: src/themes/OLH/templates/core/accounts/reset_password.html:10
+#: src/themes/OLH/templates/core/accounts/reset_password.html:42
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:8
+#: src/themes/clean/templates/core/accounts/reset_password.html:9
+#: src/themes/clean/templates/core/accounts/reset_password.html:33
+#: src/themes/hourglass/templates/core/accounts/get_reset_token.html:9
+#: src/themes/hourglass/templates/core/accounts/reset_password.html:10
+#: src/themes/material/templates/core/accounts/get_reset_token.html:8
+#: src/themes/material/templates/core/accounts/reset_password.html:9
+#: src/themes/material/templates/core/accounts/reset_password.html:31
 msgid "Reset Password"
 msgstr "Passwort zurücksetzen"
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:26
-#: src/themes/clean/templates/core/accounts/reset_password.html:16
-#: src/themes/material/templates/core/accounts/reset_password.html:16
+#: src/themes/OLH/templates/core/accounts/reset_password.html:30
+#: src/themes/clean/templates/core/accounts/reset_password.html:20
+#: src/themes/material/templates/core/accounts/reset_password.html:20
 msgid "Enter your new password twice to complete the reset process"
 msgstr ""
 "Geben Sie Ihr neues Passwort zweimal ein, um den Zurücksetzen-Vorgang "
 "abzuschließen"
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:29
-#: src/themes/clean/templates/core/accounts/reset_password.html:19
-#, python-format
-msgid ""
-"Your password should be %(request.press.password_length)s characters long."
-msgstr ""
-"Ihr Passwort sollte %(request.press.password_length)s Zeichen lang sein."
-
-#: src/themes/material/templates/core/accounts/register.html:26
-msgid ""
-"For more information read our\n"
-"                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-"\">password guide</a>\n"
-"                        ."
-msgstr ""
-"Für weitere Informationen lesen Sie <a href=\"#passwordmodal\" class=\"modal-"
-"trigger\">password guide</a>."
-
-#: src/themes/OLH/templates/core/base.html:60
+#: src/themes/OLH/templates/core/base.html:61
 #: src/themes/OLH/templates/core/nav.html:7
 #: src/themes/OLH/templates/press/nav.html:6
 #: src/themes/OLH/templates/press/press_index.html:5
@@ -3246,56 +3733,12 @@ msgstr ""
 msgid "Home"
 msgstr "Start"
 
-#: src/themes/OLH/templates/core/login.html:27
-#: src/themes/OLH/templates/press/core/login.html:25
-#: src/themes/clean/templates/core/login.html:14
-msgid "Log in with your account"
-msgstr "Melden Sie sich mit Ihrem Konto an"
-
-#: src/themes/OLH/templates/core/login.html:28
-#: src/themes/clean/templates/core/login.html:16
-#: src/themes/material/templates/core/login.html:18
-msgid "Log in with ORCiD"
-msgstr "Anmelden mit ORCiD"
-
 #: src/themes/OLH/templates/core/login.html:31
 #: src/themes/OLH/templates/press/core/login.html:28
 #: src/themes/clean/templates/core/login.html:20
 #: src/themes/material/templates/core/login.html:22
 msgid "Login with"
 msgstr "Einloggen mit"
-
-#: src/themes/OLH/templates/core/login.html:43
-#: src/themes/clean/templates/core/login.html:40
-msgid "Log in"
-msgstr "Anmelden"
-
-#: src/themes/OLH/templates/core/login.html:44
-#: src/themes/clean/templates/core/login.html:44
-msgid "Forgotten your password?"
-msgstr "Passwort vergessen?"
-
-#: src/themes/OLH/templates/core/login.html:45
-#: src/themes/clean/templates/core/login.html:48
-msgid "Register a new account"
-msgstr "Ein neues Konto eröffnen"
-
-#: src/themes/OLH/templates/core/nav.html:29
-#: src/themes/OLH/templates/core/nav.html:37
-#: src/themes/OLH/templates/journal/editorial_team.html:10
-#: src/themes/OLH/templates/journal/editorial_team.html:20
-#: src/themes/OLH/templates/press/nav.html:39
-#: src/themes/clean/templates/core/nav.html:32
-#: src/themes/clean/templates/core/nav.html:41
-#: src/themes/clean/templates/journal/editorial_team.html:4
-#: src/themes/clean/templates/journal/editorial_team.html:9
-#: src/themes/material/templates/core/nav.html:36
-#: src/themes/material/templates/core/nav.html:97
-#: src/themes/material/templates/journal/editorial_team.html:11
-#: src/themes/material/templates/preprints/editors.html:5
-#: src/themes/material/templates/preprints/editors.html:6
-msgid "Editorial Team"
-msgstr "Redaktionsteam"
 
 #: src/themes/OLH/templates/core/nav.html:44
 #: src/themes/OLH/templates/journal/become_reviewer.html:5
@@ -3374,13 +3817,13 @@ msgstr "Artikel bearbeiten"
 msgid "Edit Issue"
 msgstr "Ausgabe bearbeiten"
 
-#: src/themes/OLH/templates/core/nav.html:66
+#: src/themes/OLH/templates/core/nav.html:65
 #: src/themes/OLH/templates/elements/right_hand_menu.html:31
 #: src/themes/material/templates/core/nav.html:194
 msgid "Edit News Item"
 msgstr "Aktuelle Meldung bearbeiten"
 
-#: src/themes/OLH/templates/core/nav.html:70
+#: src/themes/OLH/templates/core/nav.html:69
 #: src/themes/OLH/templates/elements/right_hand_menu.html:35
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:8
 #: src/themes/OLH/templates/press/nav.html:51
@@ -3396,7 +3839,7 @@ msgstr "Aktuelle Meldung bearbeiten"
 msgid "Admin"
 msgstr "Administrator"
 
-#: src/themes/OLH/templates/core/nav.html:74
+#: src/themes/OLH/templates/core/nav.html:73
 #: src/themes/OLH/templates/elements/right_hand_menu.html:39
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:13
 #: src/themes/OLH/templates/press/nav.html:55
@@ -3412,64 +3855,59 @@ msgstr "Administrator"
 msgid "Logout"
 msgstr "Ausloggen"
 
-#: src/themes/OLH/templates/core/news/index.html:11
-#: src/themes/material/templates/core/news/index.html:11
+#: src/themes/OLH/templates/core/news/index.html:12
+#: src/themes/material/templates/core/news/index.html:12
 #: src/themes/material/templates/press/core/news/index.html:11
 msgid "Filtering tag"
 msgstr "Filter-Tag"
 
-#: src/themes/OLH/templates/core/news/index.html:24
-#: src/themes/OLH/templates/core/news/item.html:24
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:27
-#: src/themes/OLH/templates/press/core/news/index.html:22
-#: src/themes/OLH/templates/press/core/news/item.html:24
-#: src/themes/OLH/templates/press/core/news/item.html:33
-#: src/themes/material/templates/core/news/index.html:30
-#: src/themes/material/templates/core/news/item.html:30
+#: src/themes/OLH/templates/core/news/index.html:25
+#: src/themes/OLH/templates/core/news/item.html:25
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:28
+#: src/themes/OLH/templates/press/core/news/index.html:23
+#: src/themes/OLH/templates/press/core/news/item.html:25
+#: src/themes/OLH/templates/press/core/news/item.html:34
+#: src/themes/hourglass/templates/custom/news-item.html:16
+#: src/themes/material/templates/core/news/index.html:31
+#: src/themes/material/templates/core/news/item.html:31
 #: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
+#: src/themes/material/templates/press/core/news/item.html:18
 msgid "on"
 msgstr "an"
 
-#: src/themes/OLH/templates/core/news/index.html:26
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:29
-#: src/themes/OLH/templates/press/core/news/index.html:24
+#: src/themes/OLH/templates/core/news/index.html:27
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:30
+#: src/themes/OLH/templates/press/core/news/index.html:25
 #: src/themes/clean/templates/core/news/index.html:17
 #: src/themes/clean/templates/press/core/news/index.html:17
-#: src/themes/material/templates/core/news/index.html:34
-#: src/themes/material/templates/journal/homepage_elements/news.html:36
+#: src/themes/material/templates/core/news/index.html:35
+#: src/themes/material/templates/journal/homepage_elements/news.html:37
 #: src/themes/material/templates/press/core/news/index.html:25
 msgid "Read More"
 msgstr "Weiterlesen"
 
-#: src/themes/OLH/templates/core/news/index.html:33
+#: src/themes/OLH/templates/core/news/index.html:34
 #: src/themes/material/templates/press/core/news/index.html:30
 msgid "This journal currently has no news items to display."
 msgstr "Diese Zeitschrift hat momentan keine aktuellen Meldungen zum Anzeigen."
 
-#: src/themes/OLH/templates/core/news/item.html:40
+#: src/themes/OLH/templates/core/news/item.html:41
 #: src/themes/clean/templates/core/news/item.html:20
 #: src/themes/clean/templates/press/core/news/item.html:16
 msgid "Tags "
 msgstr "Tags"
 
-#: src/themes/OLH/templates/core/news/item.html:47
+#: src/themes/OLH/templates/core/news/item.html:48
 #: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
+#: src/themes/material/templates/core/news/item.html:44
 msgid "Back to"
 msgstr "Zurück zu"
 
-#: src/themes/OLH/templates/core/news/item.html:47
+#: src/themes/OLH/templates/core/news/item.html:48
 #: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
+#: src/themes/material/templates/core/news/item.html:44
 msgid "List"
 msgstr "Liste"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
-msgid "Change Your Email Address"
-msgstr "Ändern Sie Ihre Email-Adresse"
 
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:8
 msgid ""
@@ -3489,29 +3927,6 @@ msgstr ""
 "strong>Wenn Sie Ihre Mailadresse ändern wird sich auch Ihr Benutzername "
 "ändern, da diese ein und dasselbe sind.</p>"
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
-msgid "Current Email Address"
-msgstr "Aktuelle E-Mail-Adresse"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
-msgid "New Email Address"
-msgstr "Neue E-Mail-Adresse"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
-msgid "Update Email Address"
-msgstr "Aktualisierung der Email-Adresse"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
-msgid "Register for Article Notifications"
-msgstr "Für Artikelbenachrichtigungen anmelden"
-
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:31
 #: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:43
 msgid ""
@@ -3522,27 +3937,6 @@ msgstr ""
 "Artikel\n"
 "                            dieses Journals zu registrieren "
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
-msgid "Unsubscribe from Article Notifications"
-msgstr "Von Artikelbenachrichtigungen abmelden"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
-msgid "Subscribe to Article Notifications"
-msgstr "Artikelbenachrichtigungen aktivieren"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
-msgid "Update Password"
-msgstr "Passwort aktualisieren"
-
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:53
 #: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:66
 msgid ""
@@ -3552,34 +3946,11 @@ msgstr ""
 "Sie können Ihr Passwort aktualisieren, indem Sie Ihr vorhandenes und Ihr "
 "neues Passwort eingeben."
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
-msgid "Current Password"
-msgstr "Aktuelles Passwort"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
-msgid "New Password"
-msgstr "Neues Passwort"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
-msgid "Enter Password Again"
-msgstr "Passwort erneut eingeben"
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:41
-#: src/themes/clean/templates/elements/accounts/user_form.html:38
-#: src/themes/material/templates/elements/accounts/user_form.html:39
-msgid "Social Media and Accounts"
-msgstr "Social Media und Konten"
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:95
-#: src/themes/OLH/templates/journal/article.html:108
-#: src/themes/clean/templates/elements/accounts/user_form.html:92
-#: src/themes/material/templates/elements/accounts/user_form.html:93
-msgid "Options"
-msgstr "Optionen"
+#: src/themes/OLH/templates/elements/accounts/user_form.html:5
+#: src/themes/clean/templates/elements/accounts/user_form.html:5
+#: src/themes/material/templates/elements/accounts/user_form.html:6
+msgid "Core Data"
+msgstr "Kerndaten"
 
 #: src/themes/OLH/templates/elements/edit_author.html:5
 msgid "NB."
@@ -3625,13 +3996,13 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:26
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:34
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:35
 #: src/themes/OLH/templates/elements/journal/article_list_filters.html:6
 #: src/themes/OLH/templates/elements/journal/search_form.html:19
 #: src/themes/OLH/templates/press/press_journals.html:93
 #: src/themes/OLH/templates/press/press_journals.html:94
 #: src/themes/clean/templates/elements/journal/article_list_filters.html:7
-#: src/themes/clean/templates/journal/articles.html:81
+#: src/themes/clean/templates/journal/articles.html:82
 #: src/themes/clean/templates/journal/full-text-search.html:54
 #: src/themes/clean/templates/press/press_journals.html:56
 #: src/themes/material/templates/journal/articles.html:95
@@ -3641,16 +4012,11 @@ msgstr "Datum"
 msgid "Filter"
 msgstr "Filter"
 
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:36
-#: src/themes/clean/templates/journal/articles.html:84
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:37
+#: src/themes/clean/templates/journal/articles.html:85
 #: src/themes/material/templates/journal/articles.html:109
 msgid "Clear Filters"
 msgstr "Filter löschen"
-
-#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
-#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
-msgid "Apply"
-msgstr "Anwenden"
 
 #: src/themes/OLH/templates/elements/journal/authors_block.html:4
 #: src/themes/clean/templates/elements/article_listing.html:27
@@ -3667,7 +4033,7 @@ msgstr "Auch ein Teil von:"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:5
 #: src/themes/clean/templates/elements/journal/citation_modals.html:6
-#: src/themes/clean/templates/journal/article.html:294
+#: src/themes/clean/templates/journal/article.html:304
 msgid "Harvard-style Citation"
 msgstr "Zitierung im Harvard-Stil"
 
@@ -3680,37 +4046,37 @@ msgid "Preprints"
 msgstr "Preprints"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:19
-#: src/themes/OLH/templates/journal/article.html:135
+#: src/themes/OLH/templates/journal/article.html:137
 msgid "Vancouver Citation Style"
 msgstr "Vancouver Zitierstil"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:19
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:40
-#: src/themes/OLH/templates/journal/article.html:136
+#: src/themes/OLH/templates/journal/article.html:138
 msgid "APA Citation Style"
 msgstr "APA Zitierstil"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:27
 #: src/themes/clean/templates/elements/journal/citation_modals.html:28
-#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/clean/templates/journal/article.html:305
 msgid "Vancouver-style Citation"
 msgstr "Zitierung im Vancouver-Stil"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:40
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:63
-#: src/themes/OLH/templates/journal/article.html:134
+#: src/themes/OLH/templates/journal/article.html:136
 msgid "Harvard Citation Style"
 msgstr "Harvard Zitierstil"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:49
 #: src/themes/clean/templates/elements/journal/citation_modals.html:49
-#: src/themes/clean/templates/journal/article.html:296
+#: src/themes/clean/templates/journal/article.html:306
 msgid "APA-style Citation"
 msgstr "Zitierung im APA-Stil"
 
 #: src/themes/OLH/templates/elements/journal/editorial_social_content.html:4
 #: src/themes/clean/templates/elements/journal/editorial_social_content.html:4
-#: src/themes/clean/templates/journal/article.html:283
+#: src/themes/clean/templates/journal/article.html:293
 msgid "Twitter"
 msgstr "X"
 
@@ -3729,17 +4095,45 @@ msgstr "Github"
 msgid "Linkedin"
 msgstr "Linkedin"
 
+#: src/themes/OLH/templates/elements/journal/issue_list.html:16
+#: src/themes/clean/templates/elements/journal/issue_list.html:5
+#: src/themes/clean/templates/journal/issues.html:14
+#: src/themes/material/templates/elements/journal/issue_list.html:16
+#: src/themes/material/templates/elements/journal/issue_list.html:20
+msgid "items"
+msgstr "Elemente"
+
+#: src/themes/OLH/templates/elements/journal/issue_list.html:24
+msgid "There are no issues published in this journal yet."
+msgstr "In dieser Zeitschrift sind noch keine Ausgaben veröffentlicht."
+
+#: src/themes/OLH/templates/elements/journal/issue_list_by_decade.html:3
+#: src/themes/material/templates/elements/journal/issue_list_by_decade.html:3
+msgid ""
+"\n"
+"            Issues are grouped by decade. Select a decade to view the "
+"issues\n"
+"            published during that decade.\n"
+"        "
+msgstr ""
+
 #: src/themes/OLH/templates/elements/journal/issue_sidebar.html:7
-#: src/themes/OLH/templates/journal/article.html:208
-#: src/themes/OLH/templates/journal/article.html:263
+#: src/themes/OLH/templates/journal/article.html:210
+#: src/themes/OLH/templates/journal/article.html:246
+#: src/themes/OLH/templates/journal/article.html:334
 #: src/themes/OLH/templates/repository/preprint.html:114
+#: src/themes/OLH/templates/repository/preprint.html:152
 #: src/themes/clean/templates/elements/journal/issue_sidebar.html:6
-#: src/themes/clean/templates/journal/article.html:102
-#: src/themes/clean/templates/journal/article.html:281
+#: src/themes/clean/templates/journal/article.html:101
+#: src/themes/clean/templates/journal/article.html:184
+#: src/themes/clean/templates/journal/article.html:291
 #: src/themes/material/templates/elements/journal/issue_sidebar.html:5
-#: src/themes/material/templates/journal/article.html:188
+#: src/themes/material/templates/journal/article.html:123
+#: src/themes/material/templates/journal/article.html:169
+#: src/themes/material/templates/journal/article.html:273
 #: src/themes/material/templates/preprints/article.html:133
-#: src/themes/material/templates/repository/preprint.html:132
+#: src/themes/material/templates/repository/preprint.html:130
+#: src/themes/material/templates/repository/preprint.html:203
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -3795,11 +4189,11 @@ msgid "Sort articles by"
 msgstr "Artikel sortieren nach"
 
 #: src/themes/OLH/templates/elements/journal/summary_modal.html:3
-#: src/themes/OLH/templates/journal/article.html:437
+#: src/themes/OLH/templates/journal/article.html:428
 #: src/themes/clean/templates/elements/journal/summary_modal.html:6
-#: src/themes/clean/templates/journal/article.html:250
+#: src/themes/clean/templates/journal/article.html:260
 #: src/themes/material/templates/elements/summary_modal.html:5
-#: src/themes/material/templates/journal/article.html:380
+#: src/themes/material/templates/journal/article.html:382
 msgid "Non Specialist Summary"
 msgstr "Nichtfachliche Zusammenfassung"
 
@@ -3872,9 +4266,9 @@ msgid "Public Submissions"
 msgstr "Öffentliche Einreichungen"
 
 #: src/themes/OLH/templates/elements/section_block.html:12
-#: src/themes/OLH/templates/journal/article.html:298
+#: src/themes/OLH/templates/journal/article.html:279
 #: src/themes/clean/templates/elements/sections_block.html:9
-#: src/themes/clean/templates/journal/article.html:242
+#: src/themes/clean/templates/journal/article.html:252
 #: src/themes/material/templates/elements/sections_display.html:11
 msgid "Peer Reviewed"
 msgstr "Begutachtet"
@@ -3964,7 +4358,7 @@ msgstr "Artikel"
 
 #: src/themes/OLH/templates/journal/article.html:28
 #: src/themes/OLH/templates/journal/article.html:64
-#: src/themes/OLH/templates/journal/article.html:159
+#: src/themes/OLH/templates/journal/article.html:162
 #: src/themes/OLH/templates/journal/print.html:15
 #: src/themes/clean/templates/journal/article.html:38
 #: src/themes/clean/templates/journal/print.html:15
@@ -3972,39 +4366,84 @@ msgid "Author"
 msgstr "Autor*in"
 
 #: src/themes/OLH/templates/journal/article.html:115
-#: src/themes/material/templates/journal/article.html:250
+#: src/themes/clean/templates/journal/article.html:172
+#: src/themes/material/templates/journal/article.html:231
 msgid "Share"
 msgstr "Teilen"
 
+#: src/themes/OLH/templates/journal/article.html:116
+#: src/themes/clean/templates/journal/article.html:176
+#: src/themes/material/templates/journal/article.html:236
+#, fuzzy
+#| msgid "Facebook"
+msgid "Share on Facebook"
+msgstr "Facebook"
+
+#: src/themes/OLH/templates/journal/article.html:118
+#: src/themes/clean/templates/journal/article.html:179
+#: src/themes/material/templates/journal/article.html:239
+#, fuzzy
+#| msgid "Share"
+msgid "Share on X"
+msgstr "Teilen"
+
+#: src/themes/OLH/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:182
+#: src/themes/material/templates/journal/article.html:242
+msgid "Share on LinkedIn"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:128
+#, fuzzy
+#| msgid "Edit Article"
+msgid "print article"
+msgstr "Artikel bearbeiten"
+
+#: src/themes/OLH/templates/journal/article.html:129
+msgid "decrease text size"
+msgstr ""
+
 #: src/themes/OLH/templates/journal/article.html:130
+msgid "increase text size"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:132
+#, fuzzy
+#| msgid "Dyslexia"
+msgid "Dyslexia mode"
+msgstr "Legasthenie"
+
+#: src/themes/OLH/templates/journal/article.html:132
 msgid "Dyslexia"
 msgstr "Legasthenie"
 
-#: src/themes/OLH/templates/journal/article.html:137
-#: src/themes/OLH/templates/journal/article.html:210
-#: src/themes/OLH/templates/journal/article.html:353
-#: src/themes/OLH/templates/journal/article.html:357
+#: src/themes/OLH/templates/journal/article.html:134
+#, fuzzy
+#| msgid "Edit Article"
+msgid "Cite article"
+msgstr "Artikel bearbeiten"
+
+#: src/themes/OLH/templates/journal/article.html:139
+#: src/themes/OLH/templates/journal/article.html:213
+#: src/themes/OLH/templates/journal/article.html:339
 #: src/themes/clean/templates/journal/article.html:104
-#: src/themes/clean/templates/journal/article.html:186
-#: src/themes/clean/templates/journal/article.html:191
-#: src/themes/clean/templates/journal/article.html:298
-#: src/themes/clean/templates/journal/article.html:301
+#: src/themes/clean/templates/journal/article.html:190
+#: src/themes/clean/templates/journal/article.html:308
+#: src/themes/clean/templates/journal/article.html:311
 #: src/themes/material/templates/elements/journal/issue_sidebar.html:8
-#: src/themes/material/templates/journal/article.html:124
 #: src/themes/material/templates/journal/article.html:127
-#: src/themes/material/templates/journal/article.html:293
-#: src/themes/material/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:279
 #: src/themes/material/templates/preprints/article.html:113
 #: src/themes/material/templates/preprints/article.html:117
 #: src/themes/material/templates/preprints/article.html:139
 msgid "Download"
 msgstr "Herunterladen"
 
-#: src/themes/OLH/templates/journal/article.html:138
+#: src/themes/OLH/templates/journal/article.html:140
 msgid " Download"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:183
+#: src/themes/OLH/templates/journal/article.html:186
 #: src/themes/OLH/templates/journal/print.html:35
 #: src/themes/clean/templates/journal/article.html:89
 #: src/themes/clean/templates/journal/print.html:35
@@ -4012,134 +4451,158 @@ msgstr ""
 msgid "How to Cite"
 msgstr "Zitation"
 
-#: src/themes/OLH/templates/journal/article.html:190
+#: src/themes/OLH/templates/journal/article.html:193
 #: src/themes/clean/templates/journal/article.html:95
 #: src/themes/material/templates/journal/article.html:101
 msgid "Rights"
 msgstr "Rechte"
 
-#: src/themes/OLH/templates/journal/article.html:195
-#: src/themes/clean/templates/journal/article.html:143
+#: src/themes/OLH/templates/journal/article.html:198
+#: src/themes/clean/templates/journal/article.html:129
 #: src/themes/material/templates/journal/article.html:110
 msgid "Publisher Notes"
 msgstr "Hinweise der Herausgeber*innen"
 
-#: src/themes/OLH/templates/journal/article.html:213
-#: src/themes/OLH/templates/journal/article.html:361
+#: src/themes/OLH/templates/journal/article.html:216
+#: src/themes/OLH/templates/journal/article.html:343
 msgid "View PDF"
 msgstr "PDF ansehen"
 
-#: src/themes/OLH/templates/journal/article.html:239
-#, python-format
-msgid ""
-"\n"
-"                                                        (grant %(id)s)\n"
-"                                                    "
+#: src/themes/OLH/templates/journal/article.html:227
+#: src/themes/OLH/templates/journal/article.html:356
+#: src/themes/clean/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:207
+#: src/themes/material/templates/journal/article.html:143
+#: src/themes/material/templates/journal/article.html:298
+#, fuzzy
+#| msgid "Downloads are not available until this article is published "
+msgid "Downloads are not available for this article."
 msgstr ""
-"\n"
-"                                                        (grant %(id)s)\n"
-"                                                    "
+"Das Herunterladen ist nicht verfügbar, bis dieser Artikel veröffentlicht "
+"wurde"
 
-#: src/themes/OLH/templates/journal/article.html:257
-#: src/themes/clean/templates/journal/article.html:280
-#: src/themes/material/templates/journal/article.html:182
+#: src/themes/OLH/templates/journal/article.html:240
+#: src/themes/OLH/templates/repository/preprint.html:151
+#: src/themes/clean/templates/journal/article.html:290
+#: src/themes/material/templates/journal/article.html:163
 #: src/themes/material/templates/preprints/article.html:132
+#: src/themes/material/templates/repository/preprint.html:202
 msgid "Views"
 msgstr "Ansichten"
 
-#: src/themes/OLH/templates/journal/article.html:269
-#: src/themes/clean/templates/journal/article.html:289
-#: src/themes/material/templates/journal/article.html:220
+#: src/themes/OLH/templates/journal/article.html:253
+#: src/themes/clean/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:201
 msgid "Citations"
 msgstr "Zitierungen"
 
-#: src/themes/OLH/templates/journal/article.html:283
-#: src/themes/clean/templates/journal/article.html:221
+#: src/themes/OLH/templates/journal/article.html:267
+#: src/themes/clean/templates/journal/article.html:233
+#: src/themes/material/templates/journal/article.html:354
 #: src/themes/material/templates/preprints/article.html:123
 msgid "Published on"
 msgstr "Veröffentlicht"
 
 #: src/themes/OLH/templates/journal/article.html:287
-#: src/themes/clean/templates/journal/article.html:224
-msgid "Accepted on"
-msgstr "Akzeptiert am"
-
-#: src/themes/OLH/templates/journal/article.html:306
-#: src/themes/OLH/templates/repository/preprint.html:126
-#: src/themes/clean/templates/journal/article.html:245
+#: src/themes/OLH/templates/repository/preprint.html:127
+#: src/themes/clean/templates/journal/article.html:255
 #: src/themes/material/templates/preprints/article.html:124
-#: src/themes/material/templates/repository/preprint.html:190
+#: src/themes/material/templates/repository/preprint.html:189
 msgid "License"
 msgstr "Lizenz"
 
-#: src/themes/OLH/templates/journal/article.html:374
+#: src/themes/OLH/templates/journal/article.html:359
 msgid "Downloads are not available until this article is published "
 msgstr ""
 "Das Herunterladen ist nicht verfügbar, bis dieser Artikel veröffentlicht "
 "wurde"
 
-#: src/themes/OLH/templates/journal/article.html:383
-#: src/themes/material/templates/journal/article.html:434
+#: src/themes/OLH/templates/journal/article.html:368
+#: src/themes/material/templates/journal/article.html:410
 msgid "Identifiers"
 msgstr "Identifikatoren"
 
-#: src/themes/OLH/templates/journal/article.html:393
-#: src/themes/material/templates/journal/article.html:326
+#: src/themes/OLH/templates/journal/article.html:378
+#: src/themes/material/templates/journal/article.html:308
 msgid "Publication details"
 msgstr "Veröffentlichungsdetails"
 
-#: src/themes/OLH/templates/journal/article.html:396
-#: src/themes/clean/templates/journal/article.html:227
-#: src/themes/material/templates/journal/article.html:330
+#: src/themes/OLH/templates/journal/article.html:381
+#: src/themes/clean/templates/journal/article.html:237
+#: src/themes/material/templates/journal/article.html:312
 msgid "Pages"
 msgstr "Seiten"
 
-#: src/themes/OLH/templates/journal/article.html:399
-#: src/themes/clean/templates/journal/article.html:230
+#: src/themes/OLH/templates/journal/article.html:384
+#: src/themes/clean/templates/journal/article.html:240
 msgid "Article Number"
 msgstr "Artikelnummer"
 
-#: src/themes/OLH/templates/journal/article.html:402
-#: src/themes/clean/templates/journal/article.html:233
-#: src/themes/material/templates/journal/article.html:342
+#: src/themes/OLH/templates/journal/article.html:387
+#: src/themes/clean/templates/journal/article.html:243
+#: src/themes/material/templates/journal/article.html:324
 msgid "Publisher"
 msgstr "Herausgeber"
 
-#: src/themes/OLH/templates/journal/article.html:405
-#: src/themes/clean/templates/journal/article.html:236
+#: src/themes/OLH/templates/journal/article.html:390
+#: src/themes/clean/templates/journal/article.html:246
 msgid "Original Publication"
 msgstr "Erstveröffentlichung"
 
-#: src/themes/OLH/templates/journal/article.html:408
-#: src/themes/clean/templates/journal/article.html:239
-#: src/themes/material/templates/journal/article.html:354
+#: src/themes/OLH/templates/journal/article.html:393
+#: src/themes/clean/templates/journal/article.html:249
+#: src/themes/material/templates/journal/article.html:336
 msgid "Original ISSN"
 msgstr "Originale ISSN"
 
-#: src/themes/OLH/templates/journal/article.html:416
-#: src/themes/clean/templates/journal/article.html:209
-#: src/themes/material/templates/journal/article.html:366
-#: src/themes/material/templates/repository/preprint.html:140
+#: src/themes/OLH/templates/journal/article.html:396
+#: src/themes/clean/templates/journal/article.html:223
+#: src/themes/material/templates/journal/article.html:342
+#, fuzzy
+#| msgid "D/T Submitted"
+msgid "Submitted on"
+msgstr "Datum und Uhrzeit eingereicht"
+
+#: src/themes/OLH/templates/journal/article.html:399
+#: src/themes/clean/templates/journal/article.html:228
+#: src/themes/material/templates/journal/article.html:348
+msgid "Accepted on"
+msgstr "Akzeptiert am"
+
+#: src/themes/OLH/templates/journal/article.html:407
+#: src/themes/clean/templates/journal/article.html:211
+#: src/themes/material/templates/journal/article.html:368
+#: src/themes/material/templates/repository/preprint.html:138
 msgid "Supplementary Files"
 msgstr "Zusätzliche Dateien"
 
-#: src/themes/OLH/templates/journal/article.html:439
-#: src/themes/material/templates/journal/article.html:381
+#: src/themes/OLH/templates/journal/article.html:430
+#: src/themes/material/templates/journal/article.html:383
 msgid "View Summary"
 msgstr "Zusammenfassung anzeigen"
 
-#: src/themes/OLH/templates/journal/article.html:446
+#: src/themes/OLH/templates/journal/article.html:437
 msgid "Jump to"
 msgstr "Gehe zu"
 
-#: src/themes/OLH/templates/journal/article.html:472
-#: src/themes/clean/templates/journal/article.html:305
-#: src/themes/material/templates/journal/article.html:478
+#: src/themes/OLH/templates/journal/article.html:463
+#: src/themes/clean/templates/journal/article.html:324
+#: src/themes/material/templates/journal/article.html:464
 msgid "File Checksums"
 msgstr "Dateiprüfsummen"
 
-#: src/themes/OLH/templates/journal/article.html:485
-#: src/themes/material/templates/journal/article.html:446
+#: src/themes/OLH/templates/journal/article.html:473
+#: src/themes/clean/templates/journal/article.html:334
+#: src/themes/material/templates/journal/article.html:475
+#, fuzzy
+#| msgid "Downloads are not available until this article is published "
+msgid "File Checksums are not available for this article."
+msgstr ""
+"Das Herunterladen ist nicht verfügbar, bis dieser Artikel veröffentlicht "
+"wurde"
+
+#: src/themes/OLH/templates/journal/article.html:480
+#: src/themes/material/templates/journal/article.html:422
 msgid "Peer Review"
 msgstr "Peer Review"
 
@@ -4175,7 +4638,6 @@ msgstr "Sammlung"
 
 #: src/themes/OLH/templates/journal/collections.html:29
 #: src/themes/OLH/templates/repository/preprint.html:124
-#: src/themes/material/templates/journal/article.html:400
 msgid "Published"
 msgstr "Veröffentlicht"
 
@@ -4208,19 +4670,19 @@ msgstr "Vorgestellte Zeitschriften"
 msgid "Unnamed Journal"
 msgstr "Unbenannte Zeitschrift"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
 #: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
 msgid "Latest"
 msgstr "Neuste"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
 #: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
 msgid "Posts"
 msgstr "Beiträge"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:35
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:36
 #: src/themes/clean/templates/press/core/news/index.html:21
 msgid "This journal currently has no news items to display"
 msgstr "Diese Zeitschrift hat derzeit keine aktuellen Meldungen zum Anzeigen"
@@ -4235,18 +4697,6 @@ msgstr "Beliebteste Artikel"
 #: src/themes/clean/templates/journal/homepage_elements/preprints.html:6
 msgid "Featured Preprints"
 msgstr "Vorgestellte Preprints"
-
-#: src/themes/OLH/templates/journal/issues.html:31
-#: src/themes/clean/templates/journal/issues.html:19
-#: src/themes/clean/templates/journal/issues.html:28
-#: src/themes/material/templates/journal/issues.html:29
-#: src/themes/material/templates/journal/issues.html:31
-msgid "items"
-msgstr "Elemente"
-
-#: src/themes/OLH/templates/journal/issues.html:39
-msgid "There are no issues published in this journal yet."
-msgstr "In dieser Zeitschrift sind noch keine Ausgaben veröffentlicht."
 
 #: src/themes/OLH/templates/journal/keyword.html:6
 #: src/themes/OLH/templates/journal/keyword.html:12
@@ -4292,37 +4742,38 @@ msgstr "Einreichungen"
 msgid "Login with ORCiD"
 msgstr "Einloggen mit ORCiD"
 
-#: src/themes/OLH/templates/press/core/news/index.html:5
-#: src/themes/OLH/templates/press/core/news/index.html:10
-#: src/themes/OLH/templates/press/core/news/item.html:5
+#: src/themes/OLH/templates/press/core/news/index.html:6
+#: src/themes/OLH/templates/press/core/news/index.html:11
+#: src/themes/OLH/templates/press/core/news/item.html:6
 #: src/themes/clean/templates/press/core/news/index.html:9
 #: src/themes/clean/templates/press/nav.html:16
+#: src/themes/hourglass/templates/press/news/index.html:4
 #: src/themes/material/templates/core/nav.html:88
 #: src/themes/material/templates/press/core/news/index.html:5
 #: src/themes/material/templates/press/core/news/index.html:10
-#: src/themes/material/templates/press/core/news/item.html:5
+#: src/themes/material/templates/press/core/news/item.html:6
 msgid "News"
 msgstr "Aktuelles"
 
-#: src/themes/OLH/templates/press/core/news/index.html:31
+#: src/themes/OLH/templates/press/core/news/index.html:32
 msgid "This press currently has no news items to display."
 msgstr "Diese Seite hat derzeit keine aktuellen Meldungen zum Anzeigen."
 
-#: src/themes/OLH/templates/press/core/news/item.html:33
+#: src/themes/OLH/templates/press/core/news/item.html:34
 #: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
+#: src/themes/material/templates/press/core/news/item.html:18
 msgid "Posted by"
 msgstr "Erstellt von"
 
-#: src/themes/OLH/templates/press/core/news/item.html:40
-#: src/themes/material/templates/core/news/item.html:35
-#: src/themes/material/templates/press/core/news/item.html:22
+#: src/themes/OLH/templates/press/core/news/item.html:41
+#: src/themes/material/templates/core/news/item.html:36
+#: src/themes/material/templates/press/core/news/item.html:23
 msgid "Tags"
 msgstr "Tags"
 
-#: src/themes/OLH/templates/press/core/news/item.html:45
+#: src/themes/OLH/templates/press/core/news/item.html:46
 #: src/themes/clean/templates/press/core/news/item.html:18
-#: src/themes/material/templates/press/core/news/item.html:30
+#: src/themes/material/templates/press/core/news/item.html:31
 msgid "Back to News List"
 msgstr "Zurück zu den aktuellen Meldungen"
 
@@ -4335,6 +4786,7 @@ msgstr "Sitemap"
 #: src/themes/OLH/templates/press/press_journals.html:5
 #: src/themes/clean/templates/press/nav.html:37
 #: src/themes/clean/templates/press/press_journals.html:10
+#: src/themes/hourglass/templates/press/press_journals.html:9
 #: src/themes/material/templates/press/press_journals.html:9
 msgid "Journals"
 msgstr "Zeitschriften"
@@ -4350,16 +4802,22 @@ msgstr "Konferenzen"
 msgid "Repositories"
 msgstr "Repositorien"
 
+#: src/themes/OLH/templates/press/nav.html:39
+#: src/themes/material/templates/preprints/editors.html:5
+#: src/themes/material/templates/preprints/editors.html:6
+msgid "Editorial Team"
+msgstr "Redaktionsteam"
+
 #: src/themes/OLH/templates/press/press_journals.html:48
 msgid "Disciplines"
 msgstr "Disziplinen"
 
 #: src/themes/OLH/templates/press/press_journals.html:61
 #: src/themes/OLH/templates/press/press_journals.html:68
-#: src/themes/clean/templates/journal/article.html:195
+#: src/themes/clean/templates/journal/article.html:194
 #: src/themes/clean/templates/press/press_journals.html:32
 #: src/themes/clean/templates/press/press_journals.html:39
-#: src/themes/material/templates/journal/article.html:303
+#: src/themes/material/templates/journal/article.html:283
 #: src/themes/material/templates/press/press_journals.html:36
 #: src/themes/material/templates/press/press_journals.html:43
 msgid "View"
@@ -4415,7 +4873,7 @@ msgstr "Zugehörigkeit Autor*in"
 #: src/themes/OLH/templates/repository/nav.html:6
 #: src/themes/material/templates/repository/nav.html:21
 #: src/themes/material/templates/repository/nav.html:45
-#: src/themes/material/templates/repository/preprint.html:168
+#: src/themes/material/templates/repository/preprint.html:166
 msgid "Subjects"
 msgstr "Themen"
 
@@ -4426,7 +4884,7 @@ msgstr "Preprint Gremium"
 
 #: src/themes/OLH/templates/repository/preprint.html:60
 #: src/themes/material/templates/preprints/article.html:63
-#: src/themes/material/templates/repository/preprint.html:87
+#: src/themes/material/templates/repository/preprint.html:85
 msgid "Comments"
 msgstr "Kommentare"
 
@@ -4446,16 +4904,23 @@ msgstr ""
 msgid "Last Updated"
 msgstr "Zuletzt aktualisiert"
 
-#: src/themes/OLH/templates/repository/preprint.html:134
+#: src/themes/OLH/templates/repository/preprint.html:138
 #: src/themes/material/templates/preprints/article.html:135
 msgid "Versions"
 msgstr "Versionen"
 
-#: src/themes/OLH/templates/repository/preprint.html:139
+#: src/themes/OLH/templates/repository/preprint.html:143
 msgid "This is the only version of the preprint."
 msgstr "Dies ist die einzige Version des Preprints."
 
-#: src/themes/OLH/templates/repository/preprint.html:143
+#: src/themes/OLH/templates/repository/preprint.html:149
+#: src/themes/clean/templates/journal/article.html:288
+#: src/themes/material/templates/preprints/article.html:130
+#: src/themes/material/templates/repository/preprint.html:201
+msgid "Metrics"
+msgstr "Metriken"
+
+#: src/themes/OLH/templates/repository/preprint.html:156
 #: src/themes/material/templates/preprints/article.html:152
 #: src/themes/material/templates/preprints/list.html:6
 #: src/themes/material/templates/preprints/list.html:14
@@ -4466,16 +4931,11 @@ msgstr "Alle Preprints"
 msgid "You do not have permission to view this page"
 msgstr "Sie haben nicht die Berechtigung um sich diese Seite anzusehen"
 
-#: src/themes/clean/templates/500.html:21
-#: src/themes/clean/templates/core/base.html:37
-msgid "Skip to main content"
-msgstr "Zum Hauptinhalt springen"
-
 #: src/themes/clean/templates/500.html:27
 msgid "A server error has occurred."
 msgstr "Ein Server-Fehler ist aufgetreten."
 
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:10
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:14
 msgid ""
 "The ORCiD you logged in with is not currently linked with an account in our "
 "system. You can either\n"
@@ -4487,15 +4947,12 @@ msgstr ""
 "sich mit einem bestehenden Konto anmelden und die ORCiD mit diesem für die "
 "Zukunft verknüpfen."
 
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:34
 msgid "Forgot your password"
 msgstr "Passwort vergessen"
 
-#: src/themes/clean/templates/core/accounts/public_profile.html:10
-msgid "profile photo"
-msgstr "Profilbild"
-
-#: src/themes/clean/templates/core/accounts/register.html:24
+#: src/themes/clean/templates/core/accounts/register.html:26
+#: src/themes/clean/templates/core/accounts/reset_password.html:26
 msgid ""
 "For more information read our <a href=\"#\" data-toggle=\"modal\" data-"
 "target=\"#passwordmodal\">password guide</a>."
@@ -4534,19 +4991,7 @@ msgstr ""
 "Jahre für die Entschlüsselung brauchen würde.</p>\n"
 "                    "
 
-#: src/themes/clean/templates/core/accounts/reset_password.html:23
-msgid ""
-"For more information read our\n"
-"                                    <a href=\"#passwordmodal\" class=\"modal-"
-"trigger\">password guide</a>\n"
-"                                    ."
-msgstr ""
-"Für mehr Informationen lesen Sie die\n"
-"                                    <a href=\"#passwordmodal\" class=\"modal-"
-"trigger\">Passwortrichtlinie</a>\n"
-"                                    ."
-
-#: src/themes/clean/templates/core/accounts/reset_password.html:50
+#: src/themes/clean/templates/core/accounts/reset_password.html:54
 msgid ""
 "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
 "secure than a long and\n"
@@ -4556,7 +5001,7 @@ msgstr ""
 "(Jfjfy & 65 ^ 87) sicherer ist als ein langes und unkompliziertes Passwort "
 "(unsere fantastische Mondbasis)."
 
-#: src/themes/clean/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/reset_password.html:56
 msgid ""
 "We recommend selecting a long, but easy to remember password such as <em>our "
 "awesome moon base\n"
@@ -4620,10 +5065,22 @@ msgstr "Neues Kennwort eingeben"
 msgid "Enter New Password Again"
 msgstr "Neues Kennwort wiederholen"
 
+#: src/themes/clean/templates/elements/journal/issue_list.html:8
+msgid "This journal has no issues"
+msgstr "Diese Zeitschrift verfügt über keine Ausgaben"
+
+#: src/themes/clean/templates/elements/journal/issue_list_by_decade.html:2
+msgid ""
+"\n"
+"        Issues are grouped by decade. Select a decade to view the issues\n"
+"        published during that decade.\n"
+"    "
+msgstr ""
+
 #: src/themes/clean/templates/elements/journal/table_modal.html:12
 #: src/themes/clean/templates/elements/public_reviews.html:35
 #: src/themes/material/templates/core/accounts/register.html:61
-#: src/themes/material/templates/core/accounts/reset_password.html:49
+#: src/themes/material/templates/core/accounts/reset_password.html:51
 #: src/themes/material/templates/elements/summary_modal.html:13
 msgid "Close"
 msgstr "Schließen"
@@ -4663,48 +5120,26 @@ msgstr ""
 msgid "Sections submission information"
 msgstr "Einreichungsinformationen für die Rubriken"
 
-#: src/themes/clean/templates/journal/article.html:133
-#, python-format
-msgid ""
-"\n"
-"                                        (grant %(id)s)\n"
-"                                    "
-msgstr ""
-"\n"
-"                                        (grant %(id)s)\n"
-"                                    "
-
-#: src/themes/clean/templates/journal/article.html:268
+#: src/themes/clean/templates/journal/article.html:278
 msgid "Open Peer Reviews"
 msgstr "Open Peer Reviews"
 
-#: src/themes/clean/templates/journal/article.html:278
-#: src/themes/material/templates/preprints/article.html:130
-msgid "Metrics"
-msgstr "Metriken"
-
-#: src/themes/clean/templates/journal/article.html:285
-#: src/themes/material/templates/journal/article.html:203
+#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/material/templates/journal/article.html:184
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: src/themes/clean/templates/journal/article.html:287
-#: src/themes/material/templates/journal/article.html:211
+#: src/themes/clean/templates/journal/article.html:297
+#: src/themes/material/templates/journal/article.html:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/themes/clean/templates/journal/article.html:292
+#: src/themes/clean/templates/journal/article.html:302
 #: src/themes/material/templates/preprints/article.html:145
 msgid "Citation"
 msgstr "Zitation"
 
-#: src/themes/clean/templates/journal/article.html:317
-#: src/themes/material/templates/journal/article.html:494
-#: src/themes/material/templates/journal/submissions.html:72
-msgid "Table of Contents"
-msgstr "Inhaltsverzeichnis"
-
-#: src/themes/clean/templates/journal/article.html:343
+#: src/themes/clean/templates/journal/article.html:366
 msgid "View Larger Table"
 msgstr "Tabelle vergrößern"
 
@@ -4718,7 +5153,7 @@ msgstr "Rubrik-Filter"
 
 #: src/themes/clean/templates/journal/authors.html:26
 #: src/themes/material/templates/journal/authors.html:31
-#: src/themes/material/templates/journal/editorial_team.html:36
+#: src/themes/material/templates/journal/editorial_team.html:34
 msgid "View Profile"
 msgstr "Profil ansehen"
 
@@ -4748,13 +5183,9 @@ msgstr "Nächste"
 msgid "Play"
 msgstr "Abspielen"
 
-#: src/themes/clean/templates/journal/issues.html:16
+#: src/themes/clean/templates/journal/issues.html:14
 msgid "The current issue is"
 msgstr "Die aktuelle Ausgabe ist"
-
-#: src/themes/clean/templates/journal/issues.html:30
-msgid "This journal has no issues"
-msgstr "Diese Zeitschrift verfügt über keine Ausgaben"
 
 #: src/themes/clean/templates/press/press_journals.html:52
 msgid "No journals to list"
@@ -4765,7 +5196,65 @@ msgstr "Keine Zeitschriften zum auflisten"
 msgid "Start typing to filter."
 msgstr "Zum filtern, tippen starten"
 
-#: src/themes/material/templates/core/accounts/activate_account.html:25
+#: src/themes/hourglass/templates/core/accounts/orcid_registration.html:10
+#, fuzzy
+#| msgid "Unregistered ORCiD"
+msgid "Unregistered ORCID"
+msgstr "Nicht registrierte ORCiD"
+
+#: src/themes/hourglass/templates/custom/get-reset-token.html:27
+#, fuzzy
+#| msgid "Enter your email address to begin the reset process"
+msgid ""
+"\n"
+"                  Enter your email address to begin the reset process\n"
+"                "
+msgstr "Geben Sie Ihre E-Mail-Adresse ein, um mit dem Zurücksetzen zu beginnen"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:19
+#, fuzzy
+#| msgid ""
+#| "The ORCiD you logged in with is not currently linked with an account in "
+#| "our system. You can either register a new account, or login with an "
+#| "existing account to link your ORCiD for future use."
+msgid ""
+"\n"
+"          <p>The ORCiD you logged in with is not currently linked with\n"
+"          an account in our system. You can either register a new account, "
+"or\n"
+"          login with an existing account to link your ORCiD for future use.</"
+"p>\n"
+"        "
+msgstr ""
+"Sie haben sich mit einer ORCiD angemeldet, die derzeit in unserem System "
+"nicht mit einem Konto verknüpft ist. Sie können ein neues Konto anlegen oder "
+"sich mit einem bestehenden Konto anmelden und die ORCiD mit diesem für die "
+"Zukunft verknüpfen."
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:43
+#, fuzzy
+#| msgid "Register an Account"
+msgid "Register an account"
+msgstr "Ein Konto registrieren"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:46
+#, fuzzy
+#| msgid "Reset Your Password"
+msgid "Reset your password"
+msgstr "Passwort zurücksetzen"
+
+#: src/themes/hourglass/templates/custom/profile.html:40
+msgid ""
+"\n"
+"                    Please note: If you update your email,\n"
+"                    You will be logged out, and you won't be\n"
+"                    able to log in again until you follow\n"
+"                    the verification link in an email\n"
+"                    sent to your new email address.\n"
+"                  "
+msgstr ""
+
+#: src/themes/material/templates/core/accounts/activate_account.html:29
 msgid ""
 "There was no inactive account with this activation code found. It is "
 "possible that your account is already active, you can check by attempting to "
@@ -4774,8 +5263,17 @@ msgstr ""
 "möglich, dass das Konto bereits aktiv ist. Sie können das überprüfen, indem "
 "Sie"
 
+#: src/themes/material/templates/core/accounts/register.html:29
+#: src/themes/material/templates/core/accounts/reset_password.html:26
+msgid ""
+"For more information read our <a href=\"#\" data-target=\"passwordmodal\" "
+"class=\"modal-trigger\">password guide</a>."
+msgstr ""
+"Für weitere Informationen lesen Sie <a href=\"#\" data-"
+"target=\"passwordmodal\" class=\"modal-trigger\">password guide</a>"
+
 #: src/themes/material/templates/core/accounts/register.html:56
-#: src/themes/material/templates/core/accounts/reset_password.html:44
+#: src/themes/material/templates/core/accounts/reset_password.html:46
 msgid ""
 "We recommend selecting a long, but easy to remember password such as <i>our "
 "awesome moon base\n"
@@ -4803,7 +5301,7 @@ msgstr "Ein Konto registrieren"
 msgid "Reset Your Password"
 msgstr "Passwort zurücksetzen"
 
-#: src/themes/material/templates/core/news/index.html:39
+#: src/themes/material/templates/core/news/index.html:40
 msgid "This journal currently has no items to display."
 msgstr "Dieses Journal hat zurzeit noch keine Meldungen."
 
@@ -4851,39 +5349,31 @@ msgstr ""
 msgid "Export"
 msgstr "Export"
 
+#: src/themes/material/templates/elements/journal/issue_list.html:26
+msgid "close"
+msgstr "schließen"
+
+#: src/themes/material/templates/elements/journal/issue_list.html:30
+msgid "View Issue"
+msgstr "Ausgabe anzeigen"
+
 #: src/themes/material/templates/elements/license_block.html:4
 msgid "More Information "
 msgstr "Mehr Informationen"
 
-#: src/themes/material/templates/journal/article.html:161
-#, python-format
-msgid ""
-"\n"
-"                                                (grant %(id)s)\n"
-"                                            "
-msgstr ""
-"\n"
-"\n"
-"                                                (grant %(id)s)\n"
-"                                            "
-
-#: src/themes/material/templates/journal/article.html:195
+#: src/themes/material/templates/journal/article.html:176
 msgid "Tweets"
 msgstr "Tweets"
 
-#: src/themes/material/templates/journal/article.html:336
+#: src/themes/material/templates/journal/article.html:318
 msgid "Article No."
 msgstr "Artikel Nr."
 
-#: src/themes/material/templates/journal/article.html:348
+#: src/themes/material/templates/journal/article.html:330
 msgid "Publication"
 msgstr "Publikation"
 
-#: src/themes/material/templates/journal/article.html:389
-msgid "Dates"
-msgstr "Termine"
-
-#: src/themes/material/templates/journal/article.html:450
+#: src/themes/material/templates/journal/article.html:426
 msgid "This article has been peer reviewed."
 msgstr ""
 "Dieser Artikel wurde im Rahmen eines Peer-Review Prozesses begutachtet."
@@ -4891,14 +5381,6 @@ msgstr ""
 #: src/themes/material/templates/journal/collections.html:33
 msgid "View Collection"
 msgstr "Sammlung anzeigen"
-
-#: src/themes/material/templates/journal/issues.html:35
-msgid "close"
-msgstr "schließen"
-
-#: src/themes/material/templates/journal/issues.html:39
-msgid "View Issue"
-msgstr "Ausgabe anzeigen"
 
 #: src/themes/material/templates/journal/new_search.html:26
 #: src/themes/material/templates/journal/search.html:28
@@ -4956,27 +5438,162 @@ msgstr "Autor*in Institution"
 msgid "Start New Submission"
 msgstr "Eine neue Einreichung beginnen"
 
-#: src/themes/material/templates/repository/preprint.html:70
+#: src/themes/material/templates/repository/preprint.html:68
 msgid "Add a Comment"
 msgstr "Einen Kommentar hinzufügen"
 
-#: src/utils/forms.py:102
+#: src/utils/forms.py:107
 #, fuzzy, python-format
 #| msgid "What is %(num1)i %(operator)s %(num2)i? "
 msgid "What is %(num1)i %(operator)s %(num2)i? "
 msgstr "Was ist% (num1) i% (Operator) s% (num2) i?"
 
-#: src/utils/forms.py:103
+#: src/utils/forms.py:108
 msgid "Answer this question: "
 msgstr "Beantworten Sie diese Frage:"
 
-#: src/utils/transactional_emails.py:370
+#: src/utils/forms.py:153
+msgid "HTML is not allowed in this field"
+msgstr ""
+
+#: src/utils/transactional_emails.py:385
 msgid "accepted"
 msgstr "akzeptiert"
 
-#: src/utils/transactional_emails.py:380
+#: src/utils/transactional_emails.py:395
 msgid "declined"
 msgstr "abgelehnt"
+
+#~ msgid "Password 1"
+#~ msgstr "Passwort 1"
+
+#~ msgid "Password 2"
+#~ msgstr "Passwort 2"
+
+#~ msgid "Are you sure you want to create a typesetting assignment?"
+#~ msgstr ""
+#~ "Sind Sie sicher, dass Sie einen Typesettingauftrag erstellen möchten?"
+
+#~ msgid "Are you sure you want to create a proofreading assignment?"
+#~ msgstr "Sind Sie sicher, dass sie einen Lektoratsauftrag erstellen möchten?"
+
+#~ msgid "Text to show as the download link on the article page"
+#~ msgstr ""
+#~ "Text, der als Download-Link auf der Artikelseite angezeigt werden soll"
+
+#~ msgid "Are you sure you want to complete the proofreading task?"
+#~ msgstr "Sind Sie sicher, dass sie den Lektoratsauftrag abschließen möchten?"
+
+#~ msgid "You have not proofed some galleys:"
+#~ msgstr "Sie haben einige Galleys noch nicht geprüft:"
+
+#~ msgid "Article has no typeset files"
+#~ msgstr "Der Artikel hat keine Dateien für das Typesetting"
+
+#~ msgid "One or more typeset files are missing images"
+#~ msgstr ""
+#~ "Eine oder mehrere Dateien für das Typesetting enthalten keine Bilder"
+
+#~ msgid "One or more typesetting or proofing tasks haven't been completed"
+#~ msgstr ""
+#~ "Eine oder mehrere Typesetting- oder Lektoratsarbeiten wurden nicht "
+#~ "abgeschlossen"
+
+#~ msgid "Mark Task as Complete"
+#~ msgstr "Aufgabe als Erledigt markieren"
+
+#~ msgid "Copying and pasting from word processors is supported."
+#~ msgstr ""
+#~ "Das Kopieren und Einfügen aus Textverarbeitungsprogrammen wird "
+#~ "unterstützt."
+
+#~ msgid ""
+#~ "Please avoid pasting content from word processors as they can add "
+#~ "unwanted styling to the abstract. You can retype the abstract here or "
+#~ "copy and paste it into notepad/a plain text editor before pasting here."
+#~ msgstr ""
+#~ "Bitte vermeiden Sie es, das Abstract aus einem Textverarbeitungsprogramm "
+#~ "hierher zu kopieren, da dies zu ungewünschten Formatierungen führen kann. "
+#~ "Sie können den Text hier neu tippen oder zunächst in Notepad oder einen "
+#~ "Plain Text Editor kopieren, bevor Sie ihn hier einfügen. "
+
+#~ msgid "Email Options"
+#~ msgstr "E-Mail Optionen"
+
+#~ msgid "Submission Complete"
+#~ msgstr "Einreichung abgeschlossen"
+
+#~ msgid "allows the following licenses for submission"
+#~ msgstr "Erlaubt die folgenden Lizenzen für die Einreichung"
+
+#~ msgid "somebody"
+#~ msgstr "jemand"
+
+#~ msgid "account"
+#~ msgstr "Accountregistrierung"
+
+#, python-format
+#~ msgid ""
+#~ "Your password should be %(request.press.password_length)s characters long."
+#~ msgstr ""
+#~ "Ihr Passwort sollte %(request.press.password_length)s Zeichen lang sein."
+
+#~ msgid ""
+#~ "For more information read our\n"
+#~ "                        <a href=\"#passwordmodal\" class=\"modal-"
+#~ "trigger\">password guide</a>\n"
+#~ "                        ."
+#~ msgstr ""
+#~ "Für weitere Informationen lesen Sie <a href=\"#passwordmodal\" "
+#~ "class=\"modal-trigger\">password guide</a>."
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                                                        (grant %(id)s)\n"
+#~ "                                                    "
+#~ msgstr ""
+#~ "\n"
+#~ "                                                        (grant %(id)s)\n"
+#~ "                                                    "
+
+#~ msgid "profile photo"
+#~ msgstr "Profilbild"
+
+#~ msgid ""
+#~ "For more information read our\n"
+#~ "                                    <a href=\"#passwordmodal\" "
+#~ "class=\"modal-trigger\">password guide</a>\n"
+#~ "                                    ."
+#~ msgstr ""
+#~ "Für mehr Informationen lesen Sie die\n"
+#~ "                                    <a href=\"#passwordmodal\" "
+#~ "class=\"modal-trigger\">Passwortrichtlinie</a>\n"
+#~ "                                    ."
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                                        (grant %(id)s)\n"
+#~ "                                    "
+#~ msgstr ""
+#~ "\n"
+#~ "                                        (grant %(id)s)\n"
+#~ "                                    "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                                                (grant %(id)s)\n"
+#~ "                                            "
+#~ msgstr ""
+#~ "\n"
+#~ "\n"
+#~ "                                                (grant %(id)s)\n"
+#~ "                                            "
+
+#~ msgid "Dates"
+#~ msgstr "Termine"
 
 #~ msgid "Subtitle of the article display format; Title: Subtitle"
 #~ msgstr "Anzeigeformat des Artikeluntertitels; Titel: Untertitel"
@@ -4998,8 +5615,9 @@ msgstr "abgelehnt"
 #~ "(label, description etc.)"
 #~ msgstr ""
 #~ "Um eine Datei hochzuladen, wählen Sie sie aus\n"
-#~ "                    Verwenden Sie eine der Schaltflächen \"Datei auswählen"
-#~ "\" und laden Sie sie mit der Schaltfläche \"Datei hochladen\" hoch. Sie\n"
+#~ "                    Verwenden Sie eine der Schaltflächen \"Datei "
+#~ "auswählen\" und laden Sie sie mit der Schaltfläche \"Datei hochladen\" "
+#~ "hoch. Sie\n"
 #~ "                    wird dann nach zusätzlichen Informationen gefragt "
 #~ "(Label, Beschreibung etc.)"
 
@@ -5026,8 +5644,8 @@ msgstr "abgelehnt"
 #~ msgstr ""
 #~ "Ihr Passwort sollte mindestens 12 Zeichen lang sein. Es muss nicht "
 #~ "bestimmte Zeichen enthalten, aber Sie sollten es so lange wie möglich "
-#~ "machen. Weitere Informationen finden Sie auf der <a href=\"#\" data-open="
-#~ "\"password-modal\">Kennwort-Anleitung.</a>"
+#~ "machen. Weitere Informationen finden Sie auf der <a href=\"#\" data-"
+#~ "open=\"password-modal\">Kennwort-Anleitung.</a>"
 
 #~ msgid "Sorry, there was a server error. Our team has been notified."
 #~ msgstr ""
@@ -5040,13 +5658,13 @@ msgstr "abgelehnt"
 #~ "                            contain specific\n"
 #~ "                            characters but you should make it as long as "
 #~ "possible. For more information read our\n"
-#~ "                            <a href=\"#\" data-open=\"password-modal"
-#~ "\">password guide</a>"
+#~ "                            <a href=\"#\" data-open=\"password-"
+#~ "modal\">password guide</a>"
 #~ msgstr ""
 #~ "Ihr Passwort sollte mindestens 12 Zeichen lang sein. Es muss nicht "
 #~ "bestimmte Zeichen enthalten, aber Sie sollten es so lange wie möglich "
-#~ "machen. Weitere Informationen finden Sie auf der <a href=\"#\" data-open="
-#~ "\"password-modal\">Kennwort-Anleitung.</a>"
+#~ "machen. Weitere Informationen finden Sie auf der <a href=\"#\" data-"
+#~ "open=\"password-modal\">Kennwort-Anleitung.</a>"
 
 #~ msgid "File Checksums (MD5)"
 #~ msgstr "Dateiprüfsummen (MD5)"
@@ -5151,9 +5769,6 @@ msgstr "abgelehnt"
 #~ "Zum Einreichen des Artikels bei  %(request.journal.name)s müssen alle "
 #~ "Autor*innen den untengenannten Erklärungen zustimmen.\n"
 #~ "Bei Nichtzustimmung können Sie die Einreichung leider nicht forsetzen. "
-
-#~ msgid "Funder DOI"
-#~ msgstr "DOI der Fördermittelquelle"
 
 #~ msgid "(optional)"
 #~ msgstr "(optional)"

--- a/src/core/locales/es/LC_MESSAGES/django.po
+++ b/src/core/locales/es/LC_MESSAGES/django.po
@@ -1,32 +1,88 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: Janeway\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-12-05 10:48+0000\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
-"Project-Id-Version: Janeway\n"
-"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/core/janeway_global_settings.py:252
-msgid "English"
-msgstr "Inglés"
+#: src/comms/models.py:119
+#, python-brace-format
+msgid "Posted by {byline}"
+msgstr ""
 
-#: src/core/janeway_global_settings.py:254
-msgid "French"
-msgstr "Francés"
+#: src/comms/models.py:120
+#, python-brace-format
+msgid "Posted by  {byline}"
+msgstr ""
 
-#: src/core/janeway_global_settings.py:255
-msgid "German"
-msgstr "Alemán"
+#: src/copyediting/forms.py:17
+msgid "Are you sure you want to create a copyediting assignment?"
+msgstr ""
 
-#: src/core/forms/forms.py:110
-msgid "Password 1"
-msgstr "Contraseña 1"
+#: src/copyediting/forms.py:104
+msgid "Are you sure you want to ask the author to review copyedits?"
+msgstr ""
 
-#: src/core/forms/forms.py:111
-msgid "Password 2"
-msgstr "Contraseña 2"
+#: src/copyediting/forms.py:151
+msgid "Are you sure you want to complete the copyedit task?"
+msgstr ""
+
+#: src/core/forms/forms.py:114 src/core/forms/forms.py:162
+#: src/templates/admin/core/accounts/orcid_registration.html:29
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
+#: src/themes/OLH/templates/press/core/login.html:33
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:28
+#: src/themes/clean/templates/core/login.html:34
+#: src/themes/hourglass/templates/custom/orcid-registration.html:32
+msgid "Password"
+msgstr "Contraseña"
+
+#: src/core/forms/forms.py:123 src/core/forms/forms.py:170
+msgid "Repeat Password"
+msgstr "Repite la contraseña"
+
+#: src/core/forms/forms.py:148 src/core/models.py:235
+#: src/templates/admin/core/accounts/orcid_registration.html:25
+#: src/templates/admin/repository/article.html:213
+#: src/templates/admin/repository/author_article.html:92
+#: src/templates/admin/repository/submit/authors.html:77
+#: src/templates/admin/submission/submit_authors.html:70
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:33
+#: src/themes/OLH/templates/press/core/login.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:25
+#: src/themes/hourglass/templates/custom/orcid-registration.html:28
+msgid "Email"
+msgstr "Email"
+
+#: src/core/forms/forms.py:179
+msgid ""
+"Check this box if you would like to receive notifications of new articles "
+"published in this journal"
+msgstr ""
+
+#: src/core/forms/forms.py:578
+msgid "E-mail"
+msgstr ""
+
+#: src/core/forms/forms.py:783
+msgid "Are you sure?"
+msgstr ""
+
+#: src/core/forms/forms.py:814
+#, python-format
+msgid ""
+"The account belonging to %(email)s has not yet been activated, so the "
+"recipient of this assignment may not be able to log in and view it."
+msgstr ""
+
+#: src/core/homepage_elements/about/hooks.py:23
+msgid "About this Journal"
+msgstr "Acerca de esta revista"
 
 #: src/core/homepage_elements/carousel/models.py:9
 msgid "Off"
@@ -36,17 +92,9 @@ msgstr "Apagado"
 msgid "Latest Articles"
 msgstr "últimos artículos"
 
-#: src/themes/OLH/templates/press/core/news/index.html:5
-#: src/themes/OLH/templates/press/core/news/index.html:10
-#: src/themes/OLH/templates/press/core/news/item.html:5
-#: src/themes/clean/templates/press/core/news/index.html:9
-#: src/themes/clean/templates/press/nav.html:16
-#: src/themes/material/templates/core/nav.html:88
-#: src/themes/material/templates/press/core/news/index.html:5
-#: src/themes/material/templates/press/core/news/index.html:10
-#: src/themes/material/templates/press/core/news/item.html:5
-msgid "News"
-msgstr "Noticias"
+#: src/core/homepage_elements/carousel/models.py:11
+msgid "Latest News"
+msgstr "Últimas noticias"
 
 #: src/core/homepage_elements/carousel/models.py:12
 msgid "Selected Articles"
@@ -60,117 +108,663 @@ msgstr "Últimos artículos y noticias"
 msgid "Selected Articles and News"
 msgstr "Artículos seleccionados y noticias"
 
-#: src/core/models.py:208 src/templates/admin/repository/article.html:213
-#: src/templates/admin/repository/author_article.html:92
-#: src/templates/admin/repository/submit/authors.html:80
-#: src/templates/admin/submission/submit_authors.html:65
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:26
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:29
-#: src/themes/OLH/templates/press/core/login.html:30
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:16
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:18
-msgid "Email"
-msgstr "Email"
+#: src/core/homepage_elements/carousel/models.py:30
+msgid "If enabled, the selectors below will behave as an exclusion list"
+msgstr ""
 
-#: src/core/models.py:209
+#: src/core/homepage_elements/carousel/models.py:70
+msgid "Issues and Collections"
+msgstr ""
+
+#: src/core/janeway_global_settings.py:254
+msgid "English"
+msgstr "Inglés"
+
+#: src/core/janeway_global_settings.py:255
+msgid "English (US)"
+msgstr ""
+
+#: src/core/janeway_global_settings.py:256
+msgid "French"
+msgstr "Francés"
+
+#: src/core/janeway_global_settings.py:257
+msgid "German"
+msgstr "Alemán"
+
+#: src/core/janeway_global_settings.py:258
+msgid "Dutch"
+msgstr ""
+
+#: src/core/janeway_global_settings.py:259
+msgid "Welsh"
+msgstr ""
+
+#: src/core/logic.py:833
+msgid "Your password must be {} characters long"
+msgstr ""
+
+#: src/core/logic.py:837
+msgid "An uppercase character is required"
+msgstr ""
+
+#: src/core/logic.py:840
+msgid "A number is required"
+msgstr ""
+
+#: src/core/models.py:77
+msgid "Miss"
+msgstr ""
+
+#: src/core/models.py:78
+msgid "Ms"
+msgstr ""
+
+#: src/core/models.py:79
+msgid "Mrs"
+msgstr ""
+
+#: src/core/models.py:80
+msgid "Mr"
+msgstr ""
+
+#: src/core/models.py:81
+msgid "Mx"
+msgstr ""
+
+#: src/core/models.py:82
+msgid "Dr"
+msgstr ""
+
+#: src/core/models.py:83
+msgid "Prof."
+msgstr ""
+
+#: src/core/models.py:236
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: src/core/models.py:211
+#: src/core/models.py:242
 msgid "First name"
 msgstr "Nombre de pila"
 
-#: src/core/models.py:212 src/submission/forms.py:271
+#: src/core/models.py:248 src/submission/forms.py:286
 msgid "Middle name"
 msgstr "Segundo nombre"
 
-#: src/core/models.py:213 src/submission/forms.py:272
+#: src/core/models.py:254 src/submission/forms.py:287
 msgid "Last name"
 msgstr "Apellidos"
 
-#: src/core/models.py:217
+#: src/core/models.py:263
 msgid "Salutation"
 msgstr "Saludo"
 
-#: src/core/models.py:224
-#: src/themes/OLH/templates/core/accounts/public_profile.html:19
-#: src/themes/clean/templates/core/accounts/public_profile.html:19
-#: src/themes/material/templates/core/accounts/public_profile.html:19
+#: src/core/models.py:269
+msgid "Name suffix"
+msgstr ""
+
+#: src/core/models.py:274
+#: src/themes/OLH/templates/core/accounts/public_profile.html:50
+#: src/themes/clean/templates/core/accounts/public_profile.html:23
+#: src/themes/material/templates/core/accounts/public_profile.html:23
 msgid "Biography"
 msgstr "Biografía"
 
-#: src/core/models.py:225 src/submission/models.py:1943
+#: src/core/models.py:276 src/submission/models.py:2014
 msgid "ORCiD"
 msgstr "ORCiD"
 
-#: src/core/models.py:226 src/submission/forms.py:275
+#: src/core/models.py:280 src/submission/forms.py:290
 msgid "Institution"
 msgstr "Institución"
 
-#: src/core/models.py:227 src/submission/forms.py:276
+#: src/core/models.py:286 src/submission/forms.py:291
 msgid "Department"
 msgstr "Departamento"
 
-#: src/core/models.py:243
-#: src/themes/OLH/templates/core/accounts/public_profile.html:15
-#: src/themes/clean/templates/core/accounts/public_profile.html:15
-#: src/themes/material/templates/core/accounts/public_profile.html:15
+#: src/core/models.py:289
+msgid "Twitter Handle"
+msgstr ""
+
+#: src/core/models.py:290
+msgid "Facebook Handle"
+msgstr ""
+
+#: src/core/models.py:291
+msgid "Linkedin Profile"
+msgstr ""
+
+#: src/core/models.py:292
+#: src/themes/OLH/templates/elements/journal/editorial_social_content.html:3
+#: src/themes/clean/templates/elements/journal/editorial_social_content.html:3
+msgid "Website"
+msgstr ""
+
+#: src/core/models.py:293
+msgid "Github Username"
+msgstr ""
+
+#: src/core/models.py:297
+msgid "Confirmation Code"
+msgstr ""
+
+#: src/core/models.py:300
+msgid "Signature"
+msgstr ""
+
+#: src/core/models.py:307
+#: src/themes/OLH/templates/core/accounts/public_profile.html:45
+#: src/themes/clean/templates/core/accounts/public_profile.html:19
+#: src/themes/material/templates/core/accounts/public_profile.html:19
 msgid "Country"
 msgstr "País"
 
-#: src/core/models.py:845 src/core/models.py:1123 src/repository/models.py:838
-#: src/templates/admin/elements/submit/file.html:24
-#: src/templates/admin/submission/submit_files.html:40
-#: src/templates/admin/submission/submit_files.html:80
-#: src/templates/admin/submission/submit_review.html:120
+#: src/core/models.py:314
+msgid "Preferred Timezone"
+msgstr ""
+
+#: src/core/models.py:323
+msgid "Enable Digest"
+msgstr ""
+
+#: src/core/models.py:328
+msgid "If enabled, your basic profile will be available to the public."
+msgstr ""
+
+#: src/core/models.py:330
+msgid "Enable public profile"
+msgstr ""
+
+#: src/core/models.py:639 src/core/models.py:651
+msgid "Expires on"
+msgstr ""
+
+#: src/core/models.py:915 src/core/models.py:1193
+msgid "Article PK"
+msgstr ""
+
+#: src/core/models.py:920 src/core/models.py:1198 src/repository/models.py:848
+#: src/templates/admin/submission/submit_files.html:46
+#: src/templates/admin/submission/submit_files.html:86
+#: src/templates/admin/submission/submit_review.html:136
 msgid "Label"
 msgstr "Etiqueta"
 
-#: src/core/models.py:846 src/core/models.py:1124
-#: src/templates/admin/elements/submit/file.html:31
+#: src/core/models.py:921 src/core/models.py:1199
 msgid "Description"
 msgstr "Descripción"
 
-#: src/core/models.py:1493
+#: src/core/models.py:932
+msgid "Remote URL of file"
+msgstr ""
+
+#: src/core/models.py:1225
+msgid "Other"
+msgstr ""
+
+#: src/core/models.py:1226
+msgid "Image"
+msgstr ""
+
+#: src/core/models.py:1594 src/templates/admin/journal/contact.html:38
+#: src/themes/OLH/templates/journal/contact.html:30
+#: src/themes/OLH/templates/press/journal/contact.html:22
+#: src/themes/clean/templates/journal/contact.html:27
+msgid "Who would you like to contact?"
+msgstr "¿A quien te gustaría contactar?"
+
+#: src/core/models.py:1595
 msgid "Your contact email address"
 msgstr "Su dirección de correo electrónico de contacto"
 
-#: src/core/models.py:1494
+#: src/core/models.py:1596
 msgid "Subject"
 msgstr "Tema"
 
-#: src/core/models.py:1495
+#: src/core/models.py:1597
 msgid "Your message"
 msgstr "Tu mensaje"
 
-#: src/utils/forms.py:102
-msgid "What is %(num1)i %(operator)s %(num2)i? "
-msgstr "¿Cual es el resultado de la siguiente operacion: %(num1)i %(operator)s %(num2)i?"
+#: src/core/validators.py:15
+#, python-brace-format
+msgid ""
+"Extension {extension} is not allowed. Allowed extensions are: {validator."
+"extensions}"
+msgstr ""
 
-#: src/utils/forms.py:103
-msgid "Answer this question: "
-msgstr "Responda a esta pregunta:"
+#: src/core/validators.py:17
+#, python-brace-format
+msgid ""
+"MIME type {mimetype} is not valid. Valid types are: {validator.mimetypes}"
+msgstr ""
 
-#: src/journal/views.py:1823
-msgid "You must login before you can become a reviewer. Click the button below to login."
-msgstr "Debes iniciar sesión antes de poder convertirte en revisor. Haz clic en el botón de abajo para iniciar sesión."
+#: src/core/views.py:80
+msgid "You have been banned from logging in due to failed attempts."
+msgstr ""
 
-#: src/journal/views.py:1828
-msgid "You are not yet a reviewer for this journal. Click the button below to become a reviewer."
-msgstr "Aún no eres un revisor de esta revista. Haga clic en el botón de abajo para convertirse en un revisor."
+#: src/core/views.py:124
+msgid ""
+"Password reset process has been initiated, please check your inbox for a "
+"reset request link."
+msgstr ""
 
-#: src/journal/views.py:1833
+#: src/core/views.py:134
+msgid ""
+"Wrong email/password combination or your email address has not been "
+"confirmed yet."
+msgstr ""
+
+#: src/core/views.py:226
+msgid "You have been logged out."
+msgstr ""
+
+#: src/core/views.py:249
+msgid "If your account was found, an email has been sent to you."
+msgstr ""
+
+#: src/core/views.py:377
+msgid ""
+"Your account has been created. Please follow the instructions in the email "
+"that has been sent to you."
+msgstr ""
+
+#: src/core/views.py:420
+msgid "Account activated"
+msgstr ""
+
+#: src/core/views.py:469
+msgid "An account with that email address already exists."
+msgstr ""
+
+#: src/core/views.py:475
+msgid "Email address is not valid."
+msgstr ""
+
+#: src/core/views.py:490
+msgid "Password updated."
+msgstr ""
+
+#: src/core/views.py:494
+msgid "Passwords do not match"
+msgstr ""
+
+#: src/core/views.py:497
+msgid "Old password is not correct."
+msgstr ""
+
+#: src/core/views.py:507
+msgid "Successfully subscribed to article notifications."
+msgstr ""
+
+#: src/core/views.py:518
+msgid "Successfully unsubscribed from article notifications."
+msgstr ""
+
+#: src/core/views.py:2079
+msgid ""
+"You cannot remove a section that contains articles. Remove articles from the "
+"section if you want to delete it."
+msgstr ""
+
+#: src/core/views.py:2711 src/journal/forms.py:24 src/journal/views.py:2866
+msgid "Newest"
+msgstr ""
+
+#: src/core/views.py:2712 src/journal/forms.py:25 src/journal/views.py:2867
+msgid "Oldest"
+msgstr ""
+
+#: src/core/views.py:2713
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name A-Z"
+msgstr "Apellidos"
+
+#: src/core/views.py:2714
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name Z-A"
+msgstr "Apellidos"
+
+#: src/discussion/models.py:27
+msgid "Max. 300 characters."
+msgstr ""
+
+#. Translators: Search order options
+#: src/journal/forms.py:21
+msgid "Relevance"
+msgstr ""
+
+#: src/journal/forms.py:22 src/journal/views.py:2868
+msgid "Titles A-Z"
+msgstr ""
+
+#: src/journal/forms.py:23 src/journal/views.py:2869
+msgid "Titles Z-A"
+msgstr ""
+
+#: src/journal/forms.py:98
+#: src/themes/clean/templates/core/homepage_elements/search_bar.html:20
+msgid "Search term"
+msgstr ""
+
+#: src/journal/forms.py:99
+msgid "Search Titles"
+msgstr ""
+
+#: src/journal/forms.py:100
+msgid "Search Abstract"
+msgstr ""
+
+#: src/journal/forms.py:101
+msgid "Search Authors"
+msgstr ""
+
+#: src/journal/forms.py:102
+msgid "Search Keywords"
+msgstr ""
+
+#: src/journal/forms.py:103
+msgid "Search Full Text"
+msgstr ""
+
+#: src/journal/forms.py:104
+msgid "Search ORCIDs"
+msgstr ""
+
+#: src/journal/forms.py:105 src/templates/common/elements/sorting.html:16
+#: src/themes/clean/templates/elements/sorting.html:17
+#: src/themes/material/templates/elements/sorting.html:31
+msgid "Sort results by"
+msgstr ""
+
+#: src/journal/logic.py:216
+msgid "Articles without a section cannot be added to an issue."
+msgstr ""
+
+#: src/journal/models.py:101
+msgid ""
+"Short acronym for the journal. Used as part of the journal URLin path mode "
+"and to uniquely identify the journal"
+msgstr ""
+
+#: src/journal/models.py:119
+msgid ""
+"The default thumbnail for articles, not to be confused with 'Default cover "
+"image'."
+msgstr ""
+
+#: src/journal/models.py:127
+msgid "Replaces the press logo in the footer."
+msgstr ""
+
+#: src/journal/models.py:134
+msgid ""
+"The default cover image for journal issues and for the journal's listing on "
+"the press-level website."
+msgstr ""
+
+#: src/journal/models.py:142
+msgid "The default background image for article openers and carousel items."
+msgstr ""
+
+#: src/journal/models.py:150
+msgid ""
+"The logo-sized image at the top of all pages, typically used for journal "
+"logos."
+msgstr ""
+
+#: src/journal/models.py:158
+msgid ""
+"The tiny round or square image appearing in browser tabs before the webpage "
+"title"
+msgstr ""
+
+#: src/journal/models.py:166
+msgid ""
+"A default image displayed on the profile and editorial team pages when the "
+"user has no set profile image."
+msgstr ""
+
+#: src/journal/models.py:183
+msgid "This field has been deprecated in v1.4.3"
+msgstr ""
+
+#: src/journal/models.py:193
+msgid "When enabled, the journal is marked as not hosted in Janeway."
+msgstr ""
+
+#: src/journal/models.py:204
+msgid "If the journal is remote you can link to its submission page."
+msgstr ""
+
+#: src/journal/models.py:209
+msgid "If the journal is remote you can link to its home page."
+msgstr ""
+
+#: src/journal/models.py:213
+msgid "Enables a \"View PDF\" link on article pages."
+msgstr ""
+
+#: src/journal/models.py:255
+msgid ""
+"Whether to display article numbers. Article numbers are distinct from "
+"article ID and can be set in Edit Metadata."
+msgstr ""
+
+#: src/journal/models.py:600
+msgid "Please add as much detail as you can."
+msgstr ""
+
+#: src/journal/models.py:724
+msgid "Autogenerated cache of the display format of an issue title"
+msgstr ""
+
+#: src/journal/models.py:739
+msgid "Image representing the cover of a printed issue or volume"
+msgstr ""
+
+#: src/journal/models.py:745
+msgid "landscape hero image used in the carousel and issue page"
+msgstr ""
+
+#: src/journal/models.py:764
+msgid ""
+"An optional alphanumeric code (Slug) used to generate a verbose  url for "
+"this issue. e.g: 'winter-special-issue'."
+msgstr ""
+
+#: src/journal/models.py:786
+msgid ""
+"An ISBN is relevant for non-serial collections such as conference proceedings"
+msgstr ""
+
+#: src/journal/models.py:827
+#: src/themes/OLH/templates/press/press_journals.html:71
+#: src/themes/clean/templates/press/press_journals.html:42
+#: src/themes/material/templates/press/press_journals.html:46
+msgid "Current Issue"
+msgstr ""
+
+#: src/journal/models.py:885
+msgid "pages"
+msgstr ""
+
+#: src/journal/models.py:887
+msgid "page"
+msgstr ""
+
+#: src/journal/views.py:771
+msgid "No file uploaded"
+msgstr ""
+
+#: src/journal/views.py:1097
+msgid "Issue not in this journal’s issue list."
+msgstr ""
+
+#: src/journal/views.py:1143
+msgid ""
+"Publication date set to { article.date_published.strftime(\"%Y-%m-%d %H:%M "
+"%Z\") } "
+msgstr ""
+
+#: src/journal/views.py:1150
+#, fuzzy
+#| msgid "Publication Fees"
+msgid "Publication date unset"
+msgstr "Tasas de publicación"
+
+#: src/journal/views.py:1156
+msgid "Something went wrong when trying to save the form. "
+msgstr ""
+
+#: src/journal/views.py:1241
+msgid "Article set for publication."
+msgstr ""
+
+#: src/journal/views.py:1516
+msgid "You cannot move the first section up the order list"
+msgstr ""
+
+#: src/journal/views.py:1548
+msgid "You cannot move the last section down the order list"
+msgstr ""
+
+#: src/journal/views.py:1555
+msgid "This page accepts post requests only."
+msgstr ""
+
+#: src/journal/views.py:1626
+msgid "User is already a guest editor."
+msgstr ""
+
+#: src/journal/views.py:1632
+msgid "This user is not a member of this journal."
+msgstr ""
+
+#: src/journal/views.py:1685
+msgid "Editor removed from Issue."
+msgstr ""
+
+#: src/journal/views.py:1691
+msgid "Issue Editor not found."
+msgstr ""
+
+#: src/journal/views.py:1697
+msgid "No Issue Editor ID supplied."
+msgstr ""
+
+#: src/journal/views.py:1851
+msgid "Uploaded file is not UTF-8 encoded"
+msgstr ""
+
+#: src/journal/views.py:1945
+msgid ""
+"You must login before you can become a reviewer. Click the button below to "
+"login."
+msgstr ""
+"Debes iniciar sesión antes de poder convertirte en revisor. Haz clic en el "
+"botón de abajo para iniciar sesión."
+
+#: src/journal/views.py:1950
+msgid ""
+"You are not yet a reviewer for this journal. Click the button below to "
+"become a reviewer."
+msgstr ""
+"Aún no eres un revisor de esta revista. Haga clic en el botón de abajo para "
+"convertirse en un revisor."
+
+#: src/journal/views.py:1955
 msgid "You are already a reviewer."
 msgstr "Ya eres revisor."
 
-#: src/journal/views.py:1840
+#: src/journal/views.py:1962
 msgid "You are now a reviewer"
 msgstr "Ahora eres revisor"
 
-#: src/repository/forms.py:44 src/submission/forms.py:75
+#: src/journal/views.py:2001
+msgid "Your message has been sent."
+msgstr ""
+
+#: src/journal/views.py:2478
+#, fuzzy
+#| msgid "Manuscript File"
+msgid "Manuscript file uploaded."
+msgstr "Manuscrito"
+
+#: src/journal/views.py:2495
+#, fuzzy
+#| msgid "No files uploaded"
+msgid "Data/figure file uploaded."
+msgstr "No hay archivos subidos"
+
+#: src/journal/views.py:2506
+msgid "Production file uploaded."
+msgstr ""
+
+#: src/journal/views.py:2516
+#, fuzzy
+#| msgid "No files uploaded"
+msgid "Galley file uploaded."
+msgstr "No hay archivos subidos"
+
+#: src/journal/views.py:2552
+msgid "Proofing file uploaded."
+msgstr ""
+
+#: src/journal/views.py:2558
+#, fuzzy
+#| msgid "Upload files"
+msgid "Saved file."
+msgstr "Subir archivos"
+
+#: src/journal/views.py:2568
+#, fuzzy
+#| msgid "Supplementary Files"
+msgid "Supplementary file uploaded."
+msgstr "Archivos suplementarios"
+
+#: src/journal/views.py:2578
+#, fuzzy
+#| msgid "No files uploaded"
+msgid "Typesetting source file uploaded."
+msgstr "No hay archivos subidos"
+
+#: src/journal/views.py:2849
+msgid "Published after"
+msgstr ""
+
+#: src/journal/views.py:2853
+msgid "Published before"
+msgstr ""
+
+#: src/journal/views.py:2858
+#: src/templates/admin/submission/submit_review.html:75
+msgid "Section"
+msgstr "Sección"
+
+#: src/journal/views.py:2870 src/themes/OLH/templates/repository/list.html:77
+#: src/themes/material/templates/preprints/list.html:80
+#: src/themes/material/templates/repository/list.html:61
+msgid "Author Name"
+msgstr "Nombre del autor"
+
+#: src/journal/views.py:2871
+msgid "Volume"
+msgstr ""
+
+#: src/press/views.py:405
+msgid "Description deleted."
+msgstr ""
+
+#: src/press/views.py:418
+msgid "Description saved."
+msgstr ""
+
+#: src/repository/forms.py:42 src/submission/forms.py:87
 #: src/templates/admin/core/manager/sections/section_articles.html:30
-#: src/templates/admin/submission/submit_review.html:46
+#: src/templates/admin/submission/submit_review.html:51
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:21
 #: src/themes/OLH/templates/repository/list.html:75
 #: src/themes/clean/templates/journal/articles.html:65
@@ -180,77 +774,716 @@ msgstr "Ahora eres revisor"
 msgid "Title"
 msgstr "Título"
 
-#: src/submission/forms.py:76
-#: src/templates/admin/submission/submit_review.html:48
-msgid "Subtitle"
-msgstr "Subtítulo"
-
-#: src/repository/forms.py:47 src/submission/forms.py:79
+#: src/repository/forms.py:45
 msgid "Enter your article's abstract here"
 msgstr "Introduce el resumen de tu artículo aquí"
 
-#: src/repository/models.py:396 src/repository/models.py:983
-#: src/repository/models.py:1140 src/submission/models.py:632
+#: src/repository/models.py:140
+msgid "Used for outputs including DC and Citation metadata"
+msgstr ""
+
+#: src/repository/models.py:145
+msgid ""
+"The contents of this field are output into the JS areaat the foot of every "
+"Repository page."
+msgstr ""
+
+#: src/repository/models.py:154
+msgid ""
+"If set to True, this will require all file uploads fromauthors to be PDF "
+"files."
+msgstr ""
+
+#: src/repository/models.py:375
+msgid ""
+"If this field is to be output as a dc metadata field you can addthe type "
+"here."
+msgstr ""
+
+#: src/repository/models.py:421 src/repository/models.py:993
+#: src/repository/models.py:1144 src/submission/models.py:622
 msgid "Your article title"
 msgstr "Título de tu artículo"
 
-#: src/submission/models.py:388
-msgid "Subtitle of the article display format; Title: Subtitle"
-msgstr "Subtítulo del artículo (formato final: Título: Subtítulo)"
+#: src/repository/models.py:959
+#: src/templates/admin/submission/submit_review.html:117
+msgid "ORCID"
+msgstr ""
 
-#: src/submission/models.py:654
+#: src/repository/models.py:1206
+msgid "Approved"
+msgstr ""
+
+#: src/repository/models.py:1208
+msgid "Under Review"
+msgstr ""
+
+#: src/repository/models.py:1210 src/templates/admin/review/view_review.html:64
+msgid "Declined"
+msgstr ""
+
+#: src/repository/views.py:1097
+msgid "Author information saved"
+msgstr ""
+
+#: src/review/forms.py:242
+msgid "Are you sure you want to request revisions?"
+msgstr ""
+
+#: src/review/forms.py:292
+msgid "Are you sure you want to complete the revision request?"
+msgstr ""
+
+#: src/review/forms.py:415
+msgid "Author can access this review"
+msgstr ""
+
+#: src/review/forms.py:416
+msgid "Author can access review file"
+msgstr ""
+
+#: src/review/forms.py:436
+#, python-format
+msgid "Author can see ‘%(name)s’"
+msgstr ""
+
+#: src/review/models.py:198
+msgid "Anonymity"
+msgstr ""
+
+#: src/review/models.py:334
+msgid "available for the author to access"
+msgstr ""
+
+#: src/review/models.py:335
+msgid "not available for the author to access"
+msgstr ""
+
+#: src/review/views.py:1664
+msgid "This article has already been accepted or declined."
+msgstr ""
+
+#: src/security/templatetags/securitytags.py:102
+msgid "[Anonymised data]"
+msgstr ""
+
+#: src/submission/decorators.py:22
+msgid "This page can only be accessed on Journals."
+msgstr ""
+
+#: src/submission/decorators.py:30
+msgid "Submission is disabled for this journal."
+msgstr ""
+
+#: src/submission/forms.py:88
+#: src/templates/admin/submission/submit_review.html:53
+msgid "Subtitle"
+msgstr "Subtítulo"
+
+#: src/submission/forms.py:289
+msgid "Enter biography here"
+msgstr ""
+
+#: src/submission/forms.py:292
+msgid "Twitter handle"
+msgstr ""
+
+#: src/submission/forms.py:293
+msgid "LinkedIn profile"
+msgstr ""
+
+#: src/submission/forms.py:294
+msgid "ImpactStory profile"
+msgstr ""
+
+#: src/submission/forms.py:295
+msgid "ORCID ID"
+msgstr ""
+
+#: src/submission/forms.py:296
+msgid "Email address"
+msgstr ""
+
+#: src/submission/forms.py:352
+#, python-format
+msgid "Currently linked to %s, leave blank to use this address"
+msgstr ""
+
+#: src/submission/forms.py:357
+#, python-format
+msgid "If left blank, the account ORCiD will be used (%s)"
+msgstr ""
+
+#: src/submission/logic.py:99
+msgid "You must upload a file that is either a Doc, Docx, RTF or ODT."
+msgstr ""
+
+#: src/submission/models.py:347
+msgid "Additional information regarding this funding entry"
+msgstr ""
+
+#: src/submission/models.py:629
+msgid "Do not use--deprecated in version 1.4.1 and later."
+msgstr ""
+
+#: src/submission/models.py:644
 msgid "The primary language of the article"
 msgstr "Lenguaje principal del artículo."
 
-#: src/templates/admin/elements/publisher_notes.html:34
-msgid "Add A Publisher Note"
-msgstr "Añadir una nota editorial"
+#: src/submission/models.py:719
+msgid "Custom page range. e.g.: 'I-VII' or 1-3,4-8"
+msgstr ""
 
-#: src/templates/admin/elements/publisher_notes.html:43
-msgid "Add Publisher Note"
-msgstr "Añadir nota editorial"
+#: src/submission/models.py:742
+msgid "Add any comments you'd like the editor to consider here."
+msgstr ""
 
-#: src/templates/admin/elements/publisher_notes.html:54
-msgid "Edit A Publisher Note"
-msgstr "Editar una nota editoral"
+#: src/submission/models.py:765
+msgid ""
+"Custom 'how to cite' text. To be used only if the block generated by Janeway "
+"is not suitable."
+msgstr ""
 
-#: src/templates/admin/elements/publisher_notes.html:63
-msgid "Save Publisher Note"
-msgstr "Guardar nota editorial"
+#: src/submission/models.py:771 src/submission/models.py:778
+msgid ""
+"Name of the publisher who published this article Only relevant to migrated "
+"articles from a different publisher"
+msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:25
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:15
-#: src/themes/material/templates/core/accounts/get_reset_token.html:14
-msgid "Enter your email address to begin the reset process"
-msgstr "Ingrese su dirección de correo electrónico"
+#: src/submission/models.py:784
+msgid ""
+"Original ISSN of this article's journal when published Only relevant for "
+"back content published under a different title"
+msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:27
-msgid "somebody"
-msgstr "alguien"
+#: src/submission/models.py:1948
+msgid "Optional name prefix (e.g: Prof or Dr)"
+msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:21
-msgid "Request Token"
+#: src/submission/models.py:1954
+msgid "Optional name suffix (e.g.: Jr or III)"
+msgstr ""
+
+#: src/submission/models.py:1985
+msgid "Frozen Biography"
+msgstr ""
+
+#: src/submission/models.py:1986
+msgid ""
+"The author's biography at the time they published the linked article. For "
+"this article only, it overrides any main biography attached to the author's "
+"account. If Frozen Biography is left blank, any main biography for the "
+"account will be populated instead."
+msgstr ""
+
+#: src/submission/models.py:2009
+msgid "Author Email"
+msgstr ""
+
+#: src/submission/models.py:2015
+msgid ""
+"ORCiD to be displayed when no account is associated with this author. It "
+"should be introduced in code format (e.g: 0000-0000-0000-000X)"
+msgstr ""
+
+#: src/submission/models.py:2022
+msgid ""
+"If checked, this authors email address link will be displayed on the article "
+"page."
+msgstr ""
+
+#: src/submission/models.py:2387
+#: src/templates/admin/submission/submit_files.html:75
+msgid "Figures and Data Files"
+msgstr "Imágenes y archivos de datos"
+
+#: src/submission/models.py:2394
+msgid "The default license applied when no option is presented"
+msgstr ""
+"La licencia predeterminada aplicada cuando no se presenta ninguna opción"
+
+#: src/submission/models.py:2402
+msgid "The default language of articles when lang is hidden"
+msgstr ""
+"El idioma predeterminado de los artículos cuando el selector de idioma está "
+"oculto"
+
+#: src/submission/models.py:2408
+msgid "The default section of articles when no option is presented"
+msgstr ""
+"La sección predeterminada de artículos cuando no se presenta ninguna opción."
+
+#: src/submission/views.py:284 src/submission/views.py:319
+#: src/submission/views.py:344
+#, python-brace-format
+msgid "{author_name} added to the article."
+msgstr ""
+
+#: src/submission/views.py:312
+msgid "Errors found in the new author form"
+msgstr ""
+
+#: src/submission/views.py:333
+msgid "An empty search is not allowed."
+msgstr ""
+
+#: src/submission/views.py:351
+msgid "No author found with those details."
+msgstr ""
+
+#: src/submission/views.py:361
+msgid "You must select a main author."
+msgstr ""
+
+#: src/submission/views.py:569
+msgid "File deleted"
+msgstr ""
+
+#: src/submission/views.py:624
+msgid "You must upload a manuscript file."
+msgstr ""
+
+#: src/submission/views.py:692
+#, python-brace-format
+msgid "Article {title} submitted"
+msgstr ""
+
+#: src/submission/views.py:791
+msgid "Metadata updated."
+msgstr ""
+
+#: src/submission/views.py:803
+msgid "Primary author set."
+msgstr ""
+
+#: src/submission/views.py:820
+#, python-brace-format
+msgid "Author {author_name} updated."
+msgstr ""
+
+#: src/submission/views.py:838
+msgid "Frozen Author deleted."
+msgstr ""
+
+#: src/submission/views.py:953
+msgid "License saved."
+msgstr ""
+
+#: src/submission/views.py:998
+#, python-brace-format
+msgid "License {license_name} deleted."
+msgstr ""
+
+#: src/submission/views.py:1034
+msgid "Configuration updated."
+msgstr ""
+
+#: src/templates/admin/cms/submission_item_form.html:15
+#: src/templates/admin/cms/submission_item_form.html:22
+msgid "Editing Submission Page Item"
+msgstr ""
+
+#: src/templates/admin/cms/submission_item_form.html:15
+#: src/templates/admin/cms/submission_item_form.html:22
+msgid "Add a Submission Page Item"
+msgstr ""
+
+#: src/templates/admin/cms/submission_item_list.html:58
+msgid "No submission items found"
+msgstr ""
+
+#: src/templates/admin/copyediting/author_review.html:86
+msgid ""
+"You can add a note to the editor. They can pass any requests on to the "
+"copyeditor."
+msgstr ""
+
+#: src/templates/admin/copyediting/author_review.html:92
+msgid "Complete Copyedit Task"
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:5
+#: src/templates/admin/core/accounts/activate_account.html:10
+#: src/templates/admin/core/accounts/activate_account.html:15
+#: src/templates/admin/core/accounts/activate_account.html:29
+#: src/themes/OLH/templates/core/accounts/activate_account.html:9
+#: src/themes/OLH/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:30
+#: src/themes/clean/templates/core/accounts/activate_account.html:9
+#: src/themes/clean/templates/core/accounts/activate_account.html:17
+#: src/themes/clean/templates/core/accounts/activate_account.html:21
+#: src/themes/hourglass/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:18
+#: src/themes/material/templates/core/accounts/activate_account.html:23
+msgid "Activate Account"
+msgstr "Activar la cuenta"
+
+#: src/templates/admin/core/accounts/activate_account.html:17
+msgid "No account to activate"
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:24
+msgid ""
+"\n"
+"      You can complete the activation process by clicking the button\n"
+"      below.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:32
+msgid ""
+"\n"
+"      Sorry, we could not find an account to activate, or your account is "
+"active\n"
+"      already. You can check if it is active by attempting to log in.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:38
+#: src/templates/admin/core/accounts/login.html:5
+#: src/templates/admin/core/accounts/login.html:13
+#: src/templates/admin/core/accounts/orcid_registration.html:38
+#: src/themes/OLH/templates/core/login.html:43
+#: src/themes/clean/templates/core/login.html:40
+msgid "Log in"
+msgstr "Iniciar sesión"
+
+#: src/templates/admin/core/accounts/edit_profile.html:9
+#: src/templates/admin/core/accounts/edit_profile.html:17
+#: src/themes/OLH/templates/core/accounts/edit_profile.html:8
+#: src/themes/clean/templates/core/accounts/edit_profile.html:9
+#: src/themes/hourglass/templates/core/accounts/edit_profile.html:11
+#: src/themes/material/templates/core/accounts/edit_profile.html:8
+msgid "Edit Profile"
+msgstr "Editar perfil"
+
+#: src/templates/admin/core/accounts/edit_profile.html:26
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
+msgid "Change Your Email Address"
+msgstr "Cambia tu direccion de correo electronico"
+
+#: src/templates/admin/core/accounts/edit_profile.html:28
+#, fuzzy
+#| msgid ""
+#| "If you want to change your email address you may do so below, however, "
+#| "you will be logged out and your account will be marked as inactive until "
+#| "you follow the instructions in the verification email."
+msgid ""
+"\n"
+"          <p>If you want to change your email address you may do so below,\n"
+"          however, you will be logged out and your\n"
+"          account will be marked as inactive until you follow the\n"
+"          instructions in the verification email. <strong>Note: </strong>\n"
+"          Changing your email address will also change your username as "
+"these\n"
+"          are one and the same.</p>\n"
+"        "
+msgstr ""
+"Sin embargo, si desea cambiar su dirección de correo electrónico, puede "
+"hacerlo a continuación, se desconectará y su cuenta se marcará como inactiva "
+"hasta que siga las instrucciones del correo electrónico de verificación."
+
+#: src/templates/admin/core/accounts/edit_profile.html:36
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
+msgid "Current Email Address"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:43
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
+msgid "New Email Address"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:50
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
+msgid "Update Email Address"
+msgstr "Actualización de la dirección de correo electrónico"
+
+#: src/templates/admin/core/accounts/edit_profile.html:58
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
+msgid "Register for Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:61
+msgid ""
+"\n"
+"              Use the button below to register to receive notifications of "
+"new articles\n"
+"              published in this journal.\n"
+"            "
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:68
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
+msgid "Unsubscribe from Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:72
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
+msgid "Subscribe to Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:80
+#: src/templates/admin/core/accounts/edit_profile.html:115
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
+msgid "Update Password"
+msgstr "Actualizar contraseña"
+
+#: src/templates/admin/core/accounts/edit_profile.html:82
+#, fuzzy
+#| msgid ""
+#| "You can update your password by entering your existing password plus your "
+#| "new password."
+msgid ""
+"\n"
+"          You can update your password by entering your existing\n"
+"          password plus your new password.\n"
+"        "
+msgstr ""
+"Puede actualizar su contraseña ingresando su contraseña existente más su "
+"nueva contraseña."
+
+#: src/templates/admin/core/accounts/edit_profile.html:91
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
+msgid "Current Password"
+msgstr "Contraseña actual"
+
+#: src/templates/admin/core/accounts/edit_profile.html:98
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
+msgid "New Password"
+msgstr "Nueva contraseña"
+
+#: src/templates/admin/core/accounts/edit_profile.html:105
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
+msgid "Enter Password Again"
+msgstr "Ingrese de nuevo la contraseña"
+
+#: src/templates/admin/core/accounts/edit_profile.html:122
+#, fuzzy
+#| msgid "Profile"
+msgid "Profile Details"
+msgstr "Perfil"
+
+#: src/templates/admin/core/accounts/edit_profile.html:132
+#: src/templates/admin/core/accounts/reset_password.html:31
+#: src/templates/admin/press/edit_press_journal_description.html:24
+#: src/templates/admin/review/view_review.html:168
+#: src/templates/admin/review/view_review.html:189
+msgid "Save"
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:5
+#: src/templates/admin/core/accounts/get_reset_token.html:10
+#: src/templates/admin/core/accounts/get_reset_token.html:14
+#, fuzzy
+#| msgid "Reset Password"
+msgid "Reset password"
+msgstr "Restablecer la contraseña"
+
+#: src/templates/admin/core/accounts/get_reset_token.html:20
+msgid ""
+"\n"
+"      Enter your email address and then follow the link sent to you by "
+"email.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:27
+#, fuzzy
+#| msgid "Request Token"
+msgid "Request link"
 msgstr "Solicitar clave"
 
+#: src/templates/admin/core/accounts/login.html:24
+#: src/themes/OLH/templates/core/login.html:28
+#: src/themes/clean/templates/core/login.html:16
+#: src/themes/material/templates/core/login.html:18
+msgid "Log in with ORCiD"
+msgstr "Inicia sesión con ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:33
+#, fuzzy
+#| msgid "Log in with ORCiD"
+msgid "Log in with"
+msgstr "Inicia sesión con ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:45
+#: src/themes/OLH/templates/core/login.html:27
+#: src/themes/OLH/templates/press/core/login.html:25
+#: src/themes/clean/templates/core/login.html:14
+msgid "Log in with your account"
+msgstr "Inicia sesión con tu cuenta."
+
+#: src/templates/admin/core/accounts/login.html:50
+#: src/templates/admin/core/accounts/orcid_registration.html:43
+#: src/themes/OLH/templates/core/login.html:44
+#: src/themes/clean/templates/core/login.html:44
+msgid "Forgotten your password?"
+msgstr "¿Olvidaste tu contraseña?"
+
+#: src/templates/admin/core/accounts/login.html:55
+#: src/templates/admin/core/accounts/orcid_registration.html:48
+#: src/themes/OLH/templates/core/login.html:45
+#: src/themes/clean/templates/core/login.html:48
+msgid "Register a new account"
+msgstr "Registre una nueva cuenta"
+
+#: src/templates/admin/core/accounts/orcid_registration.html:5
+#: src/templates/admin/core/accounts/orcid_registration.html:10
+#: src/templates/admin/core/accounts/orcid_registration.html:14
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:9
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:23
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:8
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:13
+msgid "Unregistered ORCiD"
+msgstr "ORCID no registrado"
+
+#: src/templates/admin/core/accounts/orcid_registration.html:19
+msgid ""
+"\n"
+"    The ORCiD you logged in with is not currently linked with an\n"
+"    account in our system. You can either register a new account, or login "
+"with\n"
+"    an existing account to link your ORCiD for future use.\n"
+"  "
+msgstr ""
+
+#: src/templates/admin/core/accounts/password_guide.html:11
+#: src/themes/OLH/templates/core/accounts/register.html:110
+#: src/themes/OLH/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/register.html:54
+#: src/themes/clean/templates/core/accounts/reset_password.html:47
+#: src/themes/material/templates/core/accounts/register.html:53
+#: src/themes/material/templates/core/accounts/reset_password.html:43
+msgid "Password Guide"
+msgstr "Guia de contraseña"
+
+#: src/templates/admin/core/accounts/password_guide.html:15
+#, fuzzy
+#| msgid "When it comes to passwords, length is better than complexity."
+msgid ""
+"\n"
+"        When it comes to passwords, length is better than complexity.\n"
+"      "
+msgstr ""
+"Cuando se trata de contraseñas, la longitud es mejor que la complejidad."
+
+#: src/templates/admin/core/accounts/password_guide.html:18
+#, fuzzy
+#| msgid ""
+#| "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
+#| "secure than a long and uncomplicated password (our awesome moon base "
+#| "rocks)."
+msgid ""
+"\n"
+"        Its a common myth that a short and complex password\n"
+"        (Jfjfy&65^87) is more secure than a long and uncomplicated password\n"
+"        (our awesome moon base rocks).\n"
+"      "
+msgstr ""
+"Es un mito común que una contraseña corta y compleja (Jfjfy y 65 ^ 87) es "
+"más segura que una contraseña larga y sin complicaciones (nuestra "
+"impresionante base de la Luna)."
+
+#: src/templates/admin/core/accounts/password_guide.html:23
+#, fuzzy
+#| msgid ""
+#| "We recommend selecting a long, but easy to remember password such as our "
+#| "awesome moon base rocks which would take an estimated septillion years to "
+#| "crack as opposed to a complex one like Jfjfy&65^87 which would take just "
+#| "over 600 years on a standard computer."
+msgid ""
+"\n"
+"        We recommend selecting a long, but easy to remember\n"
+"        password such as our awesome moon base rocks which would take an\n"
+"        estimated septillion years to crack as opposed to a complex one "
+"like\n"
+"        Jfjfy&65^87 which would take just over 600 years on a standard\n"
+"        computer.\n"
+"      "
+msgstr ""
+"Recomendamos seleccionar una contraseña larga, pero fácil de recordar, como "
+"nuestras impresionantes rocas de la base de la luna, que demorarían un "
+"septillón aproximadamente en comparación con una compleja como Jfjfy&y65^87 "
+"que llevaría un poco más de 600 años en una computadora estándar."
+
+#: src/templates/admin/core/accounts/register.html:5
+#: src/templates/admin/core/accounts/register.html:10
+#: src/templates/admin/core/accounts/register.html:14
+#, fuzzy
+#| msgid "Register for an account with"
+msgid "Register for an account"
+msgstr "Registra una cuenta con"
+
+#: src/templates/admin/core/accounts/register.html:39
+#: src/templates/admin/core/accounts/reset_password.html:19
+#: src/themes/OLH/templates/core/accounts/register.html:31
+#: src/themes/OLH/templates/core/accounts/reset_password.html:31
+#: src/themes/clean/templates/core/accounts/register.html:22
+#: src/themes/clean/templates/core/accounts/reset_password.html:21
+#: src/themes/material/templates/core/accounts/register.html:24
+#: src/themes/material/templates/core/accounts/reset_password.html:21
+msgid "Password Rules"
+msgstr ""
+
+#: src/templates/admin/core/accounts/register.html:43
+#: src/templates/admin/core/accounts/reset_password.html:23
+msgid ""
+"\n"
+"    For more information read our <a href=\"#\"\n"
+"    data-open=\"password-modal\">password guide</a>.\n"
+"  "
+msgstr ""
+
+#: src/templates/admin/core/accounts/register.html:55
+#: src/themes/OLH/templates/core/accounts/register.html:91
+#: src/themes/clean/templates/core/accounts/register.html:31
+#: src/themes/hourglass/templates/custom/register.html:24
+#: src/themes/material/templates/core/accounts/register.html:37
+msgid "By registering an account you agree to our"
+msgstr "Al registrar una cuenta usted acepta nuestra"
+
+#: src/templates/admin/core/accounts/register.html:63
 #: src/templates/admin/journal/submissions.html:35
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:48
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:50
-#: src/themes/OLH/templates/core/accounts/register.html:5
-#: src/themes/OLH/templates/core/accounts/register.html:96
-#: src/themes/OLH/templates/core/base.html:141
-#: src/themes/OLH/templates/core/nav.html:77
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:52
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:54
+#: src/themes/OLH/templates/core/accounts/register.html:9
+#: src/themes/OLH/templates/core/accounts/register.html:100
+#: src/themes/OLH/templates/core/base.html:142
+#: src/themes/OLH/templates/core/nav.html:76
 #: src/themes/OLH/templates/journal/submissions.html:30
 #: src/themes/OLH/templates/press/nav.html:58
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:41
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:43
-#: src/themes/clean/templates/core/accounts/register.html:5
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:45
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:47
+#: src/themes/clean/templates/core/accounts/register.html:9
 #: src/themes/clean/templates/core/accounts/register.html:39
 #: src/themes/clean/templates/core/nav.html:104
 #: src/themes/clean/templates/journal/submissions.html:17
 #: src/themes/clean/templates/press/nav.html:79
-#: src/themes/material/templates/core/accounts/register.html:6
+#: src/themes/hourglass/templates/core/accounts/register.html:11
+#: src/themes/material/templates/core/accounts/register.html:10
 #: src/themes/material/templates/core/accounts/register.html:44
 #: src/themes/material/templates/core/nav.html:79
 #: src/themes/material/templates/core/nav.html:134
@@ -261,338 +1494,47 @@ msgstr "Solicitar clave"
 msgid "Register"
 msgstr "Registro"
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:26
-#: src/themes/clean/templates/core/accounts/reset_password.html:16
-#: src/themes/material/templates/core/accounts/reset_password.html:16
-msgid "Enter your new password twice to complete the reset process"
-msgstr "Ingrese su nueva contraseña dos veces para completar el proceso de restablecimiento"
-
-#: src/themes/OLH/templates/core/accounts/reset_password.html:6
-#: src/themes/OLH/templates/core/accounts/reset_password.html:38
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:4
-#: src/themes/clean/templates/core/accounts/reset_password.html:5
-#: src/themes/clean/templates/core/accounts/reset_password.html:29
-#: src/themes/material/templates/core/accounts/get_reset_token.html:4
-#: src/themes/material/templates/core/accounts/reset_password.html:5
-#: src/themes/material/templates/core/accounts/reset_password.html:29
-msgid "Reset Password"
-msgstr "Restablecer la contraseña"
-
-#: src/templates/admin/journal/submissions.html:36
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:28
-#: src/themes/OLH/templates/core/base.html:141
-#: src/themes/OLH/templates/core/login.html:6
-#: src/themes/OLH/templates/core/nav.html:76
-#: src/themes/OLH/templates/elements/journal_footer.html:30
-#: src/themes/OLH/templates/journal/become_reviewer.html:16
-#: src/themes/OLH/templates/journal/submissions.html:31
-#: src/themes/OLH/templates/press/core/login.html:5
-#: src/themes/OLH/templates/press/elements/press_footer.html:15
-#: src/themes/OLH/templates/press/nav.html:57
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:19
-#: src/themes/clean/templates/core/login.html:5
-#: src/themes/clean/templates/core/nav.html:103
-#: src/themes/clean/templates/elements/journal_footer.html:41
-#: src/themes/clean/templates/elements/press_footer.html:19
-#: src/themes/clean/templates/journal/become_reviewer.html:13
-#: src/themes/clean/templates/journal/submissions.html:18
-#: src/themes/clean/templates/press/nav.html:77
-#: src/themes/material/templates/core/login.html:5
-#: src/themes/material/templates/core/login.html:42
-#: src/themes/material/templates/core/nav.html:78
-#: src/themes/material/templates/core/nav.html:133
-#: src/themes/material/templates/journal/become_reviewer.html:16
-#: src/themes/material/templates/journal/submissions.html:34
-#: src/themes/material/templates/press/nav.html:66
-#: src/themes/material/templates/press/nav.html:114
-#: src/themes/material/templates/repository/nav.html:59
-msgid "Login"
-msgstr "Iniciar sesión"
-
-#: src/themes/OLH/templates/core/accounts/register.html:85
-#: src/themes/OLH/templates/core/accounts/register.html:87
-#: src/themes/OLH/templates/elements/journal_footer.html:25
-#: src/themes/OLH/templates/elements/journal_footer.html:27
-#: src/themes/OLH/templates/press/elements/press_footer.html:9
-#: src/themes/OLH/templates/press/elements/press_footer.html:11
-#: src/themes/clean/templates/core/accounts/register.html:29
-#: src/themes/clean/templates/core/accounts/register.html:31
-#: src/themes/clean/templates/elements/journal_footer.html:33
-#: src/themes/clean/templates/elements/journal_footer.html:37
-#: src/themes/clean/templates/elements/press_footer.html:11
-#: src/themes/clean/templates/elements/press_footer.html:14
-#: src/themes/material/templates/core/accounts/register.html:35
-#: src/themes/material/templates/core/accounts/register.html:37
-#: src/themes/material/templates/elements/journal_footer.html:28
-msgid "Privacy Policy"
-msgstr "Política de privacidad"
-
-#: src/themes/OLH/templates/press/elements/press_footer.html:13
-#: src/themes/clean/templates/elements/press_footer.html:16
-msgid "Sitemap"
-msgstr "Mapa del sitio"
-
-#: src/templates/admin/journal/contact.html:32
-#: src/themes/OLH/templates/core/nav.html:41
-#: src/themes/OLH/templates/elements/journal_footer.html:29
-#: src/themes/OLH/templates/journal/contact.html:5
-#: src/themes/OLH/templates/journal/contact.html:26
-#: src/themes/OLH/templates/press/elements/press_footer.html:14
-#: src/themes/OLH/templates/press/journal/contact.html:5
-#: src/themes/OLH/templates/press/journal/contact.html:18
-#: src/themes/OLH/templates/press/nav.html:40
-#: src/themes/clean/templates/core/nav.html:68
-#: src/themes/clean/templates/elements/journal_footer.html:39
-#: src/themes/clean/templates/elements/press_footer.html:17
-#: src/themes/clean/templates/journal/article.html:60
-#: src/themes/clean/templates/journal/contact.html:5
-#: src/themes/clean/templates/journal/contact.html:21
-#: src/themes/clean/templates/press/nav.html:53
-#: src/themes/material/templates/core/nav.html:42
-#: src/themes/material/templates/core/nav.html:103
-#: src/themes/material/templates/journal/contact.html:5
-#: src/themes/material/templates/journal/contact.html:37
-#: src/themes/material/templates/press/nav.html:52
-#: src/themes/material/templates/press/nav.html:102
-msgid "Contact"
-msgstr "Contacto"
-
-#: src/themes/OLH/templates/core/login.html:27
-#: src/themes/OLH/templates/press/core/login.html:25
-#: src/themes/clean/templates/core/login.html:14
-msgid "Log in with your account"
-msgstr "Inicia sesión con tu cuenta."
-
-#: src/themes/OLH/templates/core/login.html:28
-#: src/themes/clean/templates/core/login.html:16
-#: src/themes/material/templates/core/login.html:18
-msgid "Log in with ORCiD"
-msgstr "Inicia sesión con ORCiD"
-
-#: src/themes/OLH/templates/core/login.html:43
-#: src/themes/clean/templates/core/login.html:40
-msgid "Log in"
-msgstr "Iniciar sesión"
-
-#: src/themes/OLH/templates/core/login.html:44
-#: src/themes/clean/templates/core/login.html:44
-msgid "Forgotten your password?"
+#: src/templates/admin/core/accounts/reset_password.html:5
+#: src/templates/admin/core/accounts/reset_password.html:10
+#: src/templates/admin/core/accounts/reset_password.html:14
+#, fuzzy
+#| msgid "Forgot your password?"
+msgid "Enter your new password"
 msgstr "¿Olvidaste tu contraseña?"
 
-#: src/templates/common/elements/journal/article_issue_list.html:4
-#: src/themes/OLH/templates/403.html:4
-#: src/themes/OLH/templates/journal/issue.html:9
-#: src/themes/clean/templates/journal/issue.html:8
-#: src/themes/material/templates/elements/journal/issue_sidebar.html:8
-#: src/themes/material/templates/journal/issue.html:8
-msgid "Issue"
-msgstr "Número"
+#: src/templates/admin/core/manager/sections/manage_section.html:15
+#: src/templates/admin/core/manager/sections/manage_section.html:22
+msgid "Editing Section"
+msgstr ""
 
-#: src/templates/admin/elements/submit/author.html:8
-#: src/templates/admin/repository/submit/authors.html:65
-#: src/templates/admin/repository/submit/authors.html:116
-#: src/templates/admin/repository/submit/authors.html:123
-#: src/templates/admin/submission/submit_authors.html:49
-#: src/themes/OLH/templates/elements/submit/author.html:8
-msgid "Add New Author"
-msgstr "Añadir nuevo autor"
+#: src/templates/admin/core/manager/sections/manage_section.html:15
+#: src/templates/admin/core/manager/sections/manage_section.html:22
+msgid "Add a Section"
+msgstr ""
 
-#: src/templates/admin/elements/submit/author.html:64
-#: src/themes/OLH/templates/elements/submit/author.html:64
-msgid "Add Author"
-msgstr "Añadir autor"
+#: src/templates/admin/core/manager/sections/section_articles.html:6
+#: src/templates/admin/core/manager/sections/section_articles.html:7
+#: src/templates/admin/core/manager/sections/section_articles.html:12
+#: src/themes/OLH/templates/elements/section_block.html:1
+#: src/themes/clean/templates/elements/sections_block.html:1
+msgid "Sections"
+msgstr "Secciones"
 
-#: src/templates/admin/elements/submit/file.html:7
-#: src/themes/OLH/templates/elements/submit/file.html:6
-#: src/themes/OLH/templates/elements/submit/preprint_file.html:6
-msgid "Add New File"
-msgstr "Agregar nuevo archivo"
-
-#: src/themes/OLH/templates/elements/submit/file.html:8
-msgid "Please supply any original figure files or supporting information. The journal urges you to submit this document to a repository such as Figshare so that a DOI can be assigned to it, but this is not required."
-msgstr "Por favor, proporciona todos las imagenes o documentos de apoyo. Recomendamos  subir estos documentos a un repositorio como Figshare para que se le pueda asignar un DOI, pero no es obligatorio."
-
-#: src/templates/admin/elements/submit/file.html:35
-#: src/templates/admin/elements/submit/file.html:51
-#: src/themes/OLH/templates/elements/submit/file.html:25
-#: src/themes/OLH/templates/elements/submit/preprint_file.html:25
-msgid "Add File"
-msgstr "Agregar archivo"
-
-#: src/templates/admin/repository/submit/authors.html:70
-#: src/themes/OLH/templates/journal/article.html:27
-#: src/themes/OLH/templates/journal/article.html:63
-#: src/themes/OLH/templates/journal/article.html:158
-#: src/themes/OLH/templates/journal/article.html:332
-#: src/themes/OLH/templates/journal/authors.html:4
-#: src/themes/OLH/templates/journal/authors.html:5
-#: src/themes/OLH/templates/journal/authors.html:11
-#: src/themes/OLH/templates/journal/print.html:15
-#: src/themes/OLH/templates/repository/preprint.html:33
-#: src/themes/clean/templates/journal/article.html:37
-#: src/themes/clean/templates/journal/article.html:167
-#: src/themes/clean/templates/journal/authors.html:9
-#: src/themes/clean/templates/journal/print.html:15
-#: src/themes/material/templates/journal/article.html:269
-#: src/themes/material/templates/journal/authors.html:5
-#: src/themes/material/templates/journal/authors.html:6
-#: src/themes/material/templates/journal/authors.html:10
-#: src/themes/material/templates/preprints/article.html:28
-#: src/themes/material/templates/repository/preprint.html:149
-msgid "Authors"
-msgstr "Autores"
-
-#: src/themes/OLH/templates/journal/article.html:28
-#: src/themes/OLH/templates/journal/article.html:64
-#: src/themes/OLH/templates/journal/article.html:159
-#: src/themes/OLH/templates/journal/print.html:15
-#: src/themes/clean/templates/journal/article.html:38
-#: src/themes/clean/templates/journal/print.html:15
-msgid "Author"
-msgstr "Autor"
-
-#: src/themes/OLH/templates/journal/article.html:115
-#: src/themes/material/templates/journal/article.html:250
-msgid "Share"
-msgstr "Compartir"
-
-#: src/themes/OLH/templates/journal/article.html:130
-msgid "Dyslexia"
-msgstr "Dislexia"
-
-#: src/themes/OLH/templates/press/press_journals.html:61
-#: src/themes/OLH/templates/press/press_journals.html:68
-#: src/themes/clean/templates/journal/article.html:195
-#: src/themes/clean/templates/press/press_journals.html:32
-#: src/themes/clean/templates/press/press_journals.html:39
-#: src/themes/material/templates/journal/article.html:303
-#: src/themes/material/templates/press/press_journals.html:36
-#: src/themes/material/templates/press/press_journals.html:43
-msgid "View"
-msgstr "Ver"
-
-#: src/templates/admin/submission/submit_review.html:59
-#: src/themes/OLH/templates/journal/article.html:175
-#: src/themes/OLH/templates/journal/print.html:30
-#: src/themes/OLH/templates/repository/preprint.html:45
-#: src/themes/clean/templates/journal/article.html:78
-#: src/themes/clean/templates/journal/print.html:30
-#: src/themes/material/templates/journal/article.html:73
-#: src/themes/material/templates/preprints/article.html:43
-#: src/themes/material/templates/repository/preprint.html:157
-msgid "Abstract"
-msgstr "Resumen"
-
-#: src/templates/admin/submission/submit_info.html:67
-#: src/themes/OLH/templates/journal/article.html:178
-#: src/themes/OLH/templates/journal/keywords.html:6
-#: src/themes/OLH/templates/journal/keywords.html:12
-#: src/themes/OLH/templates/journal/print.html:33
-#: src/themes/OLH/templates/journal/search.html:40
-#: src/themes/OLH/templates/repository/list.html:76
-#: src/themes/clean/templates/journal/article.html:82
-#: src/themes/clean/templates/journal/full-text-search.html:44
-#: src/themes/clean/templates/journal/keywords.html:4
-#: src/themes/clean/templates/journal/keywords.html:5
-#: src/themes/clean/templates/journal/print.html:33
-#: src/themes/clean/templates/journal/search.html:46
-#: src/themes/material/templates/journal/article.html:81
-#: src/themes/material/templates/journal/full-text-search.html:46
-#: src/themes/material/templates/journal/keywords.html:4
-#: src/themes/material/templates/journal/keywords.html:5
-#: src/themes/material/templates/journal/keywords.html:8
-#: src/themes/material/templates/journal/search.html:50
-#: src/themes/material/templates/preprints/list.html:79
-#: src/themes/material/templates/repository/list.html:60
-#: src/themes/material/templates/repository/preprint.html:172
-msgid "Keywords"
-msgstr "Palabras clave"
-
-#: src/themes/OLH/templates/journal/article.html:183
-#: src/themes/OLH/templates/journal/print.html:35
-#: src/themes/clean/templates/journal/article.html:89
-#: src/themes/clean/templates/journal/print.html:35
-#: src/themes/material/templates/journal/article.html:91
-msgid "How to Cite"
-msgstr "Como citar"
-
-#: src/themes/OLH/templates/journal/article.html:195
-#: src/themes/clean/templates/journal/article.html:143
-#: src/themes/material/templates/journal/article.html:110
-msgid "Publisher Notes"
-msgstr "Notas del editor"
-
-#: src/themes/OLH/templates/journal/article.html:257
-#: src/themes/clean/templates/journal/article.html:280
-#: src/themes/material/templates/journal/article.html:182
-#: src/themes/material/templates/preprints/article.html:132
-msgid "Views"
-msgstr "Visitas"
-
-#: src/themes/OLH/templates/elements/journal/issue_sidebar.html:7
-#: src/themes/OLH/templates/journal/article.html:208
-#: src/themes/OLH/templates/journal/article.html:263
-#: src/themes/OLH/templates/repository/preprint.html:114
-#: src/themes/clean/templates/elements/journal/issue_sidebar.html:6
-#: src/themes/clean/templates/journal/article.html:102
-#: src/themes/clean/templates/journal/article.html:281
-#: src/themes/material/templates/elements/journal/issue_sidebar.html:5
-#: src/themes/material/templates/journal/article.html:188
-#: src/themes/material/templates/preprints/article.html:133
-#: src/themes/material/templates/repository/preprint.html:132
-msgid "Downloads"
-msgstr "Descargas"
-
-#: src/themes/OLH/templates/journal/article.html:283
-#: src/themes/clean/templates/journal/article.html:221
-#: src/themes/material/templates/preprints/article.html:123
-msgid "Published on"
-msgstr "Publicado el"
-
-#: src/themes/OLH/templates/elements/section_block.html:12
-#: src/themes/OLH/templates/journal/article.html:298
-#: src/themes/clean/templates/elements/sections_block.html:9
-#: src/themes/clean/templates/journal/article.html:242
-#: src/themes/material/templates/elements/sections_display.html:11
-msgid "Peer Reviewed"
-msgstr "Revisión por pares"
-
-#: src/themes/OLH/templates/journal/article.html:306
-#: src/themes/OLH/templates/repository/preprint.html:126
-#: src/themes/clean/templates/journal/article.html:245
-#: src/themes/material/templates/preprints/article.html:124
-#: src/themes/material/templates/repository/preprint.html:190
-msgid "License"
-msgstr "Licencia"
-
-#: src/themes/OLH/templates/journal/article.html:6
-#: src/themes/material/templates/journal/article.html:7
-msgid "Article"
-msgstr "Artículo"
-
-#: src/themes/OLH/templates/journal/article.html:137
-#: src/themes/OLH/templates/journal/article.html:210
-#: src/themes/OLH/templates/journal/article.html:353
-#: src/themes/OLH/templates/journal/article.html:357
-#: src/themes/clean/templates/journal/article.html:104
-#: src/themes/clean/templates/journal/article.html:186
-#: src/themes/clean/templates/journal/article.html:191
-#: src/themes/clean/templates/journal/article.html:298
-#: src/themes/clean/templates/journal/article.html:301
-#: src/themes/material/templates/elements/journal/issue_sidebar.html:8
-#: src/themes/material/templates/journal/article.html:124
-#: src/themes/material/templates/journal/article.html:127
-#: src/themes/material/templates/journal/article.html:293
-#: src/themes/material/templates/journal/article.html:299
-#: src/themes/material/templates/preprints/article.html:113
-#: src/themes/material/templates/preprints/article.html:117
-#: src/themes/material/templates/preprints/article.html:139
-msgid "Download"
-msgstr "Descargar"
-
-#: src/themes/OLH/templates/journal/article.html:446
-msgid "Jump to"
-msgstr "Saltar a"
+#: src/templates/admin/core/manager/sections/section_articles.html:11
+#: src/templates/admin/press/edit_press_journal_description.html:10
+#: src/themes/OLH/templates/core/nav.html:57
+#: src/themes/OLH/templates/elements/right_hand_menu.html:13
+#: src/themes/OLH/templates/press/elements/right_hand_menu.html:7
+#: src/themes/OLH/templates/press/nav.html:48
+#: src/themes/OLH/templates/repository/elements/right_hand_menu.html:7
+#: src/themes/clean/templates/core/nav.html:90
+#: src/themes/clean/templates/press/nav.html:66
+#: src/themes/material/templates/core/nav.html:154
+#: src/themes/material/templates/core/nav.html:176
+#: src/themes/material/templates/press/nav.html:130
+#: src/themes/material/templates/press/nav.html:141
+msgid "Manager"
+msgstr "Gerente"
 
 #: src/templates/admin/core/manager/sections/section_articles.html:13
 #: src/templates/admin/core/manager/sections/section_articles.html:20
@@ -619,2152 +1561,6 @@ msgstr "Saltar a"
 msgid "Articles"
 msgstr "Artículos"
 
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:6
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:19
-#: src/themes/clean/templates/journal/articles.html:50
-#: src/themes/material/templates/journal/articles.html:82
-msgid "Show"
-msgstr "Show"
-
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:16
-#: src/themes/clean/templates/journal/articles.html:60
-#: src/themes/material/templates/journal/articles.html:85
-msgid "Sort"
-msgstr "Ordenar"
-
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:19
-#: src/themes/clean/templates/journal/articles.html:63
-#: src/themes/material/templates/journal/articles.html:88
-msgid "Date"
-msgstr "Fecha"
-
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:26
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:34
-#: src/themes/OLH/templates/elements/journal/article_list_filters.html:6
-#: src/themes/OLH/templates/elements/journal/search_form.html:19
-#: src/themes/OLH/templates/press/press_journals.html:93
-#: src/themes/OLH/templates/press/press_journals.html:94
-#: src/themes/clean/templates/elements/journal/article_list_filters.html:7
-#: src/themes/clean/templates/journal/articles.html:81
-#: src/themes/clean/templates/journal/full-text-search.html:54
-#: src/themes/clean/templates/press/press_journals.html:56
-#: src/themes/material/templates/journal/articles.html:95
-#: src/themes/material/templates/journal/articles.html:106
-#: src/themes/material/templates/journal/full-text-search.html:61
-#: src/themes/material/templates/press/press_journals.html:59
-msgid "Filter"
-msgstr "Filtrar"
-
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:36
-#: src/themes/clean/templates/journal/articles.html:84
-#: src/themes/material/templates/journal/articles.html:109
-msgid "Clear Filters"
-msgstr "Borrar filtros"
-
-#: src/themes/OLH/templates/core/nav.html:44
-#: src/themes/OLH/templates/journal/become_reviewer.html:5
-#: src/themes/OLH/templates/journal/become_reviewer.html:10
-#: src/themes/OLH/templates/journal/become_reviewer.html:20
-#: src/themes/clean/templates/core/nav.html:74
-#: src/themes/clean/templates/journal/become_reviewer.html:4
-#: src/themes/clean/templates/journal/become_reviewer.html:5
-#: src/themes/clean/templates/journal/become_reviewer.html:17
-#: src/themes/material/templates/core/nav.html:64
-#: src/themes/material/templates/journal/become_reviewer.html:4
-#: src/themes/material/templates/journal/become_reviewer.html:5
-#: src/themes/material/templates/journal/become_reviewer.html:10
-#: src/themes/material/templates/journal/become_reviewer.html:21
-msgid "Become a Reviewer"
-msgstr "Conviértete en revisor"
-
-#: src/templates/admin/journal/contact.html:18
-#: src/themes/OLH/templates/journal/contact.html:12
-#: src/themes/material/templates/journal/contact.html:14
-msgid "Journal Representatives"
-msgstr "Representantes de la revista"
-
-#: src/templates/admin/journal/contact.html:20
-#: src/themes/OLH/templates/journal/contact.html:14
-#: src/themes/OLH/templates/press/journal/contact.html:11
-#: src/themes/material/templates/journal/contact.html:16
-msgid "Press Representatives"
-msgstr "Representantes editoriales"
-
-#: src/core/models.py:1492
-#: src/templates/admin/journal/contact.html:38
-#: src/themes/OLH/templates/journal/contact.html:30
-#: src/themes/OLH/templates/press/journal/contact.html:22
-#: src/themes/clean/templates/journal/contact.html:27
-msgid "Who would you like to contact?"
-msgstr "¿A quien te gustaría contactar?"
-
-#: src/templates/admin/journal/contact.html:52
-#: src/themes/OLH/templates/journal/contact.html:39
-#: src/themes/OLH/templates/press/journal/contact.html:30
-#: src/themes/clean/templates/journal/contact.html:37
-#: src/themes/material/templates/journal/contact.html:45
-msgid "Send Message"
-msgstr "Enviar mensaje"
-
-#: src/core/homepage_elements/about/hooks.py:23
-msgid "About this Journal"
-msgstr "Acerca de esta revista"
-
-#: src/themes/OLH/templates/journal/homepage_elements/featured.html:6
-#: src/themes/clean/templates/journal/homepage_elements/featured.html:6
-#: src/themes/clean/templates/journal/homepage_elements/popular.html:9
-#: src/themes/material/templates/journal/homepage_elements/featured.html:6
-msgid "Featured Articles"
-msgstr "Artículos relacionados"
-
-#: src/core/homepage_elements/carousel/models.py:11
-msgid "Latest News"
-msgstr "Últimas noticias"
-
-#: src/themes/OLH/templates/press/core/news/item.html:33
-#: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
-msgid "Posted by"
-msgstr "Publicado por"
-
-#: src/themes/OLH/templates/core/news/index.html:26
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:29
-#: src/themes/OLH/templates/press/core/news/index.html:24
-#: src/themes/clean/templates/core/news/index.html:17
-#: src/themes/clean/templates/press/core/news/index.html:17
-#: src/themes/material/templates/core/news/index.html:34
-#: src/themes/material/templates/journal/homepage_elements/news.html:36
-#: src/themes/material/templates/press/core/news/index.html:25
-msgid "Read More"
-msgstr "Leer mas"
-
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:35
-#: src/themes/clean/templates/press/core/news/index.html:21
-msgid "This journal currently has no news items to display"
-msgstr "Esta revista actualmente no tiene noticias para mostrar"
-
-#: src/themes/OLH/templates/elements/journal/issue_sidebar.html:11
-#: src/themes/clean/templates/elements/journal/issue_sidebar.html:10
-#: src/themes/material/templates/elements/journal/issue_sidebar.html:14
-msgid "Issue Archive"
-msgstr "Archivo de Números"
-
-#: src/templates/common/elements/journal/article_issue_list.html:4
-#: src/themes/OLH/templates/core/nav.html:25
-#: src/themes/OLH/templates/journal/issues.html:7
-#: src/themes/OLH/templates/journal/issues.html:9
-#: src/themes/clean/templates/core/nav.html:24
-#: src/themes/clean/templates/journal/issues.html:6
-#: src/themes/material/templates/core/nav.html:33
-#: src/themes/material/templates/core/nav.html:94
-#: src/themes/material/templates/journal/issues.html:6
-msgid "Issues"
-msgstr "Números"
-
-#: src/themes/OLH/templates/journal/issues.html:31
-#: src/themes/clean/templates/journal/issues.html:19
-#: src/themes/clean/templates/journal/issues.html:28
-#: src/themes/material/templates/journal/issues.html:29
-#: src/themes/material/templates/journal/issues.html:31
-msgid "items"
-msgstr "artículos"
-
-#: src/templates/admin/submission/submit_authors.html:35
-#: src/themes/OLH/templates/core/base.html:153
-#: src/themes/OLH/templates/journal/full-text-search.html:8
-#: src/themes/OLH/templates/journal/full-text-search.html:10
-#: src/themes/OLH/templates/journal/full-text-search.html:70
-#: src/themes/OLH/templates/journal/search.html:8
-#: src/themes/clean/templates/journal/article_list.html:26
-#: src/themes/clean/templates/journal/article_list.html:50
-#: src/themes/clean/templates/journal/full-text-search.html:8
-#: src/themes/clean/templates/journal/full-text-search.html:10
-#: src/themes/clean/templates/journal/search.html:7
-#: src/themes/clean/templates/journal/search.html:9
-#: src/themes/clean/templates/journal/search.html:63
-#: src/themes/material/templates/journal/article_list.html:58
-#: src/themes/material/templates/journal/articles.html:68
-#: src/themes/material/templates/journal/full-text-search.html:8
-#: src/themes/material/templates/journal/full-text-search.html:10
-#: src/themes/material/templates/journal/new_search.html:7
-#: src/themes/material/templates/journal/new_search.html:42
-#: src/themes/material/templates/journal/search.html:7
-#: src/themes/material/templates/journal/search.html:59
-msgid "Search"
-msgstr "Buscar"
-
-#: src/themes/OLH/templates/journal/submissions.html:5
-#: src/themes/OLH/templates/journal/submissions.html:22
-#: src/themes/clean/templates/journal/submissions.html:5
-#: src/themes/clean/templates/journal/submissions.html:10
-#: src/themes/material/templates/journal/submissions.html:6
-#: src/themes/material/templates/journal/submissions.html:23
-msgid "Submissions"
-msgstr "Artículos"
-
-#: src/templates/admin/journal/submissions.html:38
-#: src/templates/admin/submission/start.html:72
-#: src/themes/OLH/templates/core/nav.html:43
-#: src/themes/OLH/templates/journal/submissions.html:32
-#: src/themes/clean/templates/core/nav.html:71
-#: src/themes/clean/templates/journal/submissions.html:19
-#: src/themes/material/templates/journal/submissions.html:35
-msgid "Start Submission"
-msgstr "Comenzar un artículo"
-
-#: src/themes/OLH/templates/repository/about.html:15
-#: src/themes/OLH/templates/repository/nav.html:4
-#: src/themes/material/templates/preprints/about.html:4
-#: src/themes/material/templates/preprints/about.html:9
-#: src/themes/material/templates/repository/about.html:4
-#: src/themes/material/templates/repository/about.html:9
-#: src/themes/material/templates/repository/nav.html:19
-#: src/themes/material/templates/repository/nav.html:43
-msgid "About"
-msgstr "Acerca de"
-
-#: src/templates/admin/journal/submissions.html:46
-msgid "Focus and Scope for"
-msgstr "Enfoque y alcance para"
-
-#: src/templates/admin/submission/start.html:42
-msgid "Submission Checklist"
-msgstr "Lista de verificación de envío"
-
-#: src/templates/admin/submission/start.html:54
-msgid "Copyright Notice"
-msgstr "Aviso de copyright"
-
-#: src/templates/admin/submission/start.html:29
-msgid "Publication Fees"
-msgstr "Tasas de publicación"
-
-#: src/themes/OLH/templates/journal/article.html:485
-#: src/themes/material/templates/journal/article.html:446
-msgid "Peer Review"
-msgstr "Revisión por pares"
-
-#: src/templates/admin/journal/submissions.html:79
-msgid "Publication Cycle"
-msgstr "Ciclo de publicacion"
-
-#: src/templates/admin/core/manager/sections/section_articles.html:6
-#: src/templates/admin/core/manager/sections/section_articles.html:7
-#: src/templates/admin/core/manager/sections/section_articles.html:12
-#: src/themes/OLH/templates/elements/section_block.html:1
-#: src/themes/clean/templates/elements/sections_block.html:1
-msgid "Sections"
-msgstr "Secciones"
-
-#: src/templates/admin/submission/start.html:7
-msgid "Submit an Article"
-msgstr "Enviar un artículo"
-
-#: src/templates/admin/submission/start.html:9
-msgid "Author Agreement"
-msgstr "Acuerdo de Autor"
-
-#: src/templates/admin/submission/start.html:11
-msgid "Please carefully read through the statements below before checking items"
-msgstr "Lea atentamente las declaraciones a continuación antes de revisar los artículos"
-
-#: src/templates/admin/submission/start.html:36
-msgid "Author(s) agrees to the above statement"
-msgstr "Autor (es) está de acuerdo con la declaración anterior"
-
-#: src/templates/admin/submission/start.html:48
-msgid "Author(s) confirms that this article adheres to the above requirements"
-msgstr "Autor (es) confirma que este artículo cumple con los requisitos anteriores"
-
-#: src/templates/admin/submission/start.html:66
-#: src/themes/OLH/templates/journal/article.html:428
-#: src/themes/clean/templates/journal/article.html:255
-#: src/themes/material/templates/journal/article.html:424
-msgid "Competing Interests"
-msgstr "Conflicto de intereses"
-
-#: src/templates/admin/submission/submit_review.html:146
-msgid "Comments to the Editor"
-msgstr "Comentarios al Editor"
-
-#: src/templates/admin/submission/submit_authors.html:5
-#: src/templates/admin/submission/timeline.html:20
-#: src/templates/admin/submission/timeline.html:21
-msgid "Author Information"
-msgstr "Información del autor"
-
-#: src/templates/admin/submission/submit_authors.html:18
-msgid "Search for Existing Authors"
-msgstr "Búsqueda de autores existentes"
-
-#: src/templates/admin/submission/submit_authors.html:25
-msgid "Search for a user using email address or ORCiD. If a user is matched, they will be automatically added as an author. This search only returns exact matches."
-msgstr "Busque un usuario usando la dirección de correo electrónico u ORCiD. Si un usuario coincide, se agregará automáticamente como autor. Esta búsqueda solo devuelve coincidencias exactas."
-
-#: src/templates/admin/submission/submit_authors.html:31
-msgid "Search by email address or ORCiD"
-msgstr "Búsqueda por correo electrónico u ORCiD"
-
-#: src/templates/admin/repository/submit/authors.html:37
-#: src/templates/admin/submission/submit_authors.html:44
-msgid "By default, your account is the owner of this submission, but is not an Author on record. You can add yourself using the button below."
-msgstr "De manera predeterminada, su cuenta es el propietario de este envío, pero no es un Autor registrado. Puedes agregarte usando el botón de abajo."
-
-#: src/templates/admin/repository/submit/authors.html:34
-#: src/templates/admin/submission/submit_authors.html:46
-msgid "Add Self as Author"
-msgstr "Añadirme como autor"
-
-#: src/templates/admin/repository/submit/authors.html:64
-#: src/templates/admin/submission/submit_authors.html:48
-msgid "If you cannot find the author record by searching, and you are not the only author, you can add one by clicking the button below. This will open a popup modal for you to complete their details."
-msgstr "Si no puede encontrar el registro de autor mediante la búsqueda y no es el único autor, puede agregar uno haciendo clic en el botón de abajo. Esto abrirá un menú emergente para que complete sus detalles."
-
-#: src/templates/admin/submission/submit_authors.html:55
-msgid "Current Authors"
-msgstr "Autores actuales"
-
-#: src/templates/admin/repository/article.html:212
-#: src/templates/admin/repository/author_article.html:91
-#: src/templates/admin/repository/submit/authors.html:79
-#: src/templates/admin/submission/submit_authors.html:64
-#: src/templates/admin/submission/submit_funding.html:49
-msgid "Name"
-msgstr "Nombre"
-
-#: src/templates/admin/submission/submit_authors.html:81
-msgid "No authors yet, add one!"
-msgstr "No hay autores todavía, ¡añada uno!"
-
-#: src/templates/admin/submission/submit_authors.html:88
-msgid "You are required to select a main author, this author will receive the communications regarding your articles process through our systems. This does not have to be you."
-msgstr "Debe seleccionar un autor principal, este autor recibirá las comunicaciones sobre el proceso de sus artículos a través de nuestros sistemas. Puedes ser tú o cualquier otro autor."
-
-#: src/templates/admin/submission/submit_authors.html:89
-msgid "Select main author"
-msgstr "Seleccionar autor principal"
-
-#: src/templates/admin/submission/submit_authors.html:99
-#: src/templates/admin/submission/submit_files.html:112
-#: src/templates/admin/submission/submit_funding.html:75
-#: src/templates/admin/submission/submit_info.html:83
-msgid "Save and Continue"
-msgstr "Guardar y continuar"
-
-#: src/themes/OLH/templates/repository/submit_files.html:21
-msgid "Submission guidelines"
-msgstr "Directrices para el envío"
-
-#: src/themes/OLH/templates/repository/submit_files.html:21
-msgid "To upload a file, select it\n"
-"                    using one of the 'Choose file' buttons, then upload it with the 'Upload file' button next to it. You\n"
-"                    will then be asked for some additional information (label, description etc.)"
-msgstr "Para subir un archivo, selecciónelo.\n"
-"                    utilizando uno de los botones 'Elegir archivo', luego cárguelo con el botón 'Cargar archivo' que se encuentra al lado. Tú\n"
-"                    luego se le pedirá información adicional (etiqueta, descripción, etc.)"
-
-#: src/themes/OLH/templates/repository/submit_files.html:24
-msgid "Manuscript File"
-msgstr "Manuscrito"
-
-#: src/templates/admin/submission/submit_files.html:33
-#: src/templates/admin/submission/submit_files.html:74
-msgid "Upload"
-msgstr "Subir"
-
-#: src/templates/admin/submission/submit_files.html:41
-#: src/templates/admin/submission/submit_files.html:81
-#: src/templates/admin/submission/submit_review.html:121
-msgid "File Name"
-msgstr "Nombre del archivo"
-
-#: src/templates/admin/submission/submit_files.html:59
-#: src/templates/admin/submission/submit_files.html:97
-msgid "No files uploaded"
-msgstr "No hay archivos subidos"
-
-#: src/templates/admin/submission/submit_funding.html:7
-#: src/templates/admin/submission/submit_info.html:6
-#: src/templates/admin/submission/submit_review.html:43
-msgid "Article Info"
-msgstr "Información del artículo"
-
-#: src/templates/admin/journal/manage/archive_article.html:182
-msgid "Review"
-msgstr "Revisión"
-
-#: src/templates/admin/submission/submit_review.html:47
-#: src/themes/OLH/templates/repository/review.html:18
-msgid "Comments to Editor"
-msgstr "Comentarios para el editor"
-
-#: src/templates/admin/submission/submit_review.html:68
-msgid "Language"
-msgstr "Idioma"
-
-#: src/journal/views.py:2612
-#: src/templates/admin/submission/submit_review.html:70
-msgid "Section"
-msgstr "Sección"
-
-#: src/templates/admin/submission/submit_review.html:72
-#: src/themes/material/templates/journal/article.html:413
-msgid "Licence"
-msgstr "Licencia"
-
-#: src/templates/admin/submission/submit_review.html:94
-msgid "Author Info"
-msgstr "Información del autor"
-
-#: src/themes/OLH/templates/repository/review.html:59
-msgid "No authors yet! Add one."
-msgstr "¡Aún no hay autores! Agrega uno."
-
-#: src/templates/admin/submission/submit_review.html:117
-#: src/templates/admin/submission/timeline.html:28
-#: src/templates/admin/submission/timeline.html:29
-msgid "Article Files"
-msgstr "Archivos de artículos"
-
-#: src/themes/OLH/templates/repository/review.html:71
-msgid "Manuscript Files"
-msgstr "Archivos de manuscritos"
-
-#: src/templates/admin/submission/submit_review.html:136
-msgid "Figure/Data"
-msgstr "Figura / Datos"
-
-#: src/templates/admin/submission/submit_review.html:155
-msgid "Complete"
-msgstr "Completar"
-
-#: src/templates/admin/submission/submit_review.html:155
-#: src/themes/OLH/templates/core/nav.html:40
-#: src/themes/clean/templates/core/nav.html:47
-#: src/themes/material/templates/core/nav.html:39
-#: src/themes/material/templates/core/nav.html:100
-msgid "Submission"
-msgstr "Sumisión"
-
-#: src/templates/admin/submission/timeline.html:6
-msgid "Submission Started"
-msgstr "Sumisión iniciada"
-
-#: src/templates/admin/submission/timeline.html:12
-#: src/templates/admin/submission/timeline.html:13
-msgid "Article Information"
-msgstr "Información del artículo"
-
-#: src/themes/clean/templates/core/accounts/reset_password.html:17
-msgid "Your password should be at minimum 12 characters long. It does not\n"
-"                                    need to contain specific\n"
-"                                    characters but you should make it as long as possible. For more information read our\n"
-"                                    <a href=\"#\" data-toggle=\"modal\" data-target=\"#passwordmodal\">password\n"
-"                                        guide</a>."
-msgstr "Su contraseña debe tener una longitud mínima de 12 caracteres. No es asi\n"
-"                                    necesita contener específica\n"
-"                                    Caracteres pero deberías hacerlo lo más largo posible. Para más información lea nuestra\n"
-"                                    <a href=\"#\" data-toggle=\"modal\" data-target=\"#passwordmodal\"> contraseña\n"
-"                                        guía </a>."
-
-#: src/themes/clean/templates/elements/journal/table_modal.html:12
-#: src/themes/clean/templates/elements/public_reviews.html:35
-#: src/themes/material/templates/core/accounts/register.html:61
-#: src/themes/material/templates/core/accounts/reset_password.html:49
-#: src/themes/material/templates/elements/summary_modal.html:13
-msgid "Close"
-msgstr "Cerrar"
-
-#: src/templates/admin/repository/submit/authors.html:23
-#: src/themes/clean/templates/journal/article.html:217
-msgid "Information"
-msgstr "Información"
-
-#: src/themes/clean/templates/journal/article.html:278
-#: src/themes/material/templates/preprints/article.html:130
-msgid "Metrics"
-msgstr "Métrica"
-
-#: src/themes/clean/templates/journal/article.html:292
-#: src/themes/material/templates/preprints/article.html:145
-msgid "Citation"
-msgstr "Cita"
-
-#: src/core/forms/forms.py:129
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
-#: src/themes/OLH/templates/press/core/login.html:33
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:24
-#: src/themes/clean/templates/core/login.html:34
-msgid "Password"
-msgstr "Contraseña"
-
-#: src/core/forms/forms.py:130
-msgid "Repeat Password"
-msgstr "Repite la contraseña"
-
-#: src/submission/models.py:2311
-#: src/templates/admin/submission/submit_files.html:69
-msgid "Figures and Data Files"
-msgstr "Imágenes y archivos de datos"
-
-#: src/submission/models.py:2318
-msgid "The default license applied when no option is presented"
-msgstr "La licencia predeterminada aplicada cuando no se presenta ninguna opción"
-
-#: src/submission/models.py:2326
-msgid "The default language of articles when lang is hidden"
-msgstr "El idioma predeterminado de los artículos cuando el selector de idioma está oculto"
-
-#: src/submission/models.py:2332
-msgid "The default section of articles when no option is presented"
-msgstr "La sección predeterminada de artículos cuando no se presenta ninguna opción."
-
-#: src/themes/OLH/templates/elements/submit/file.html:11
-msgid "Please upload your manuscript file, it should be in PDF, RTF, ODT or DOC/X format. LaTeX may be accepted later in the process but a simple, readable file is required at this stage."
-msgstr "Suba su archivo manuscrito, debe estar en formato PDF, RTF, ODT o DOC / X. LaTeX puede aceptarse más adelante en el proceso, pero se requiere un archivo simple y legible en esta etapa."
-
-#: src/themes/OLH/templates/elements/submit/file.html:13
-msgid "Please upload your manuscript file, it should be in RTF, ODT or DOC/X format. LaTeX may be accepted later in the process but a simple, readable file is required at this stage."
-msgstr "Suba su archivo manuscrito, debe estar en formato RTF, ODT o DOC / X. LaTeX puede aceptarse más adelante en el proceso, pero se requiere un archivo simple y legible en esta etapa."
-
-#: src/templates/admin/submission/submit_authors.html:40
-msgid "Add Authors"
-msgstr "Añadir autores"
-
-#: src/templates/admin/submission/submit_files.html:5
-msgid "Upload files"
-msgstr "Subir archivos"
-
-#: src/templates/admin/submission/submit_info.html:16
-msgid "This article is a preprint"
-msgstr "Este artículo es un preprint"
-
-#: src/templates/admin/submission/submit_info.html:99
-msgid "allows the following licenses for submission"
-msgstr "Licencias disponibles para nuevos envíos"
-
-#: src/themes/OLH/templates/403.html:16 src/themes/clean/templates/403.html:14
-msgid "Permission Denied"
-msgstr "Permiso denegado"
-
-#: src/themes/OLH/templates/404.html:9 src/themes/clean/templates/404.html:12
-#: src/themes/material/templates/404.html:9
-msgid "Page Not Found"
-msgstr "Página no encontrada"
-
-#: src/themes/OLH/templates/404.html:10 src/themes/clean/templates/404.html:13
-#: src/themes/material/templates/404.html:10
-msgid "Sorry, the page you were looking for was not found."
-msgstr "Lo sentimos, no se encontró la página que buscabas."
-
-#: src/themes/OLH/templates/500.html:10 src/themes/OLH/templates/500.html:28
-#: src/themes/clean/templates/500.html:11
-#: src/themes/clean/templates/500.html:26
-#: src/themes/material/templates/500.html:9
-#: src/themes/material/templates/500.html:24
-msgid "Server Error"
-msgstr "Error del Servidor"
-
-#: src/themes/OLH/templates/500.html:14
-msgid "Sorry, there was a server error. Our team has been notified."
-msgstr "Lo sentimos, hubo un error en el servidor. Nuestro equipo ha sido notificado."
-
-#: src/themes/OLH/templates/core/accounts/activate_account.html:5
-#: src/themes/OLH/templates/core/accounts/activate_account.html:22
-#: src/themes/OLH/templates/core/accounts/activate_account.html:26
-#: src/themes/clean/templates/core/accounts/activate_account.html:5
-#: src/themes/clean/templates/core/accounts/activate_account.html:13
-#: src/themes/clean/templates/core/accounts/activate_account.html:17
-#: src/themes/material/templates/core/accounts/activate_account.html:5
-#: src/themes/material/templates/core/accounts/activate_account.html:14
-#: src/themes/material/templates/core/accounts/activate_account.html:19
-msgid "Activate Account"
-msgstr "Activar la cuenta"
-
-#: src/themes/OLH/templates/core/accounts/activate_account.html:32
-#: src/themes/clean/templates/core/accounts/activate_account.html:22
-#: src/themes/material/templates/core/accounts/activate_account.html:26
-msgid "login"
-msgstr "iniciar sesión"
-
-#: src/themes/OLH/templates/core/accounts/activate_account.html:29
-#: src/themes/clean/templates/core/accounts/activate_account.html:20
-#: src/themes/material/templates/core/accounts/activate_account.html:23
-msgid "Error"
-msgstr "Error"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
-msgid "Change Your Email Address"
-msgstr "Cambia tu direccion de correo electronico"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
-msgid "Update Email Address"
-msgstr "Actualización de la dirección de correo electrónico"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
-msgid "Update Password"
-msgstr "Actualizar contraseña"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:53
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:66
-msgid "You can update your password by entering your existing password plus your new password."
-msgstr "Puede actualizar su contraseña ingresando su contraseña existente más su nueva contraseña."
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
-msgid "Current Password"
-msgstr "Contraseña actual"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
-msgid "New Password"
-msgstr "Nueva contraseña"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
-msgid "Enter Password Again"
-msgstr "Ingrese de nuevo la contraseña"
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:5
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:86
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:105
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:100
-msgid "Update"
-msgstr "Actualizar"
-
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:5
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:19
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:4
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:9
-msgid "Unregistered ORCiD"
-msgstr "ORCID no registrado"
-
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:37
-#: src/themes/OLH/templates/press/core/login.html:37
-msgid "Forgot your password?"
-msgstr "¿Olvidaste tu contraseña?"
-
-#: src/themes/OLH/templates/core/accounts/public_profile.html:5
-#: src/themes/OLH/templates/core/nav.html:73
-#: src/themes/OLH/templates/elements/right_hand_menu.html:38
-#: src/themes/OLH/templates/press/elements/right_hand_menu.html:12
-#: src/themes/OLH/templates/press/nav.html:54
-#: src/themes/OLH/templates/repository/elements/right_hand_menu.html:10
-#: src/themes/clean/templates/core/accounts/public_profile.html:4
-#: src/themes/clean/templates/core/nav.html:98
-#: src/themes/clean/templates/press/nav.html:71
-#: src/themes/material/templates/core/accounts/public_profile.html:5
-#: src/themes/material/templates/core/nav.html:165
-#: src/themes/material/templates/core/nav.html:200
-#: src/themes/material/templates/press/nav.html:135
-#: src/themes/material/templates/press/nav.html:146
-msgid "Profile"
-msgstr "Perfil"
-
-#: src/themes/OLH/templates/core/accounts/public_profile.html:13
-#: src/themes/clean/templates/core/accounts/public_profile.html:13
-#: src/themes/material/templates/core/accounts/public_profile.html:13
-msgid "Roles"
-msgstr "Roles"
-
-#: src/templates/admin/repository/article.html:214
-#: src/templates/admin/repository/author_article.html:93
-#: src/templates/admin/repository/submit/authors.html:81
-#: src/templates/admin/submission/submit_review.html:102
-#: src/themes/OLH/templates/core/accounts/public_profile.html:14
-#: src/themes/clean/templates/core/accounts/public_profile.html:14
-#: src/themes/material/templates/core/accounts/public_profile.html:14
-msgid "Affiliation"
-msgstr "Afiliación"
-
-#: src/themes/OLH/templates/core/accounts/public_profile.html:25
-#: src/themes/clean/templates/core/accounts/public_profile.html:25
-#: src/themes/material/templates/core/accounts/public_profile.html:25
-msgid "Publications"
-msgstr "Publicaciones"
-
-#: src/themes/OLH/templates/core/accounts/register.html:83
-#: src/themes/clean/templates/core/accounts/register.html:27
-#: src/themes/material/templates/core/accounts/register.html:33
-msgid "By registering an account you agree to our"
-msgstr "Al registrar una cuenta usted acepta nuestra"
-
-#: src/themes/OLH/templates/core/accounts/register.html:106
-#: src/themes/OLH/templates/core/accounts/reset_password.html:48
-#: src/themes/clean/templates/core/accounts/register.html:54
-#: src/themes/clean/templates/core/accounts/reset_password.html:43
-#: src/themes/material/templates/core/accounts/register.html:53
-#: src/themes/material/templates/core/accounts/reset_password.html:41
-msgid "Password Guide"
-msgstr "Guia de contraseña"
-
-#: src/themes/OLH/templates/core/accounts/register.html:107
-#: src/themes/OLH/templates/core/accounts/reset_password.html:49
-#: src/themes/clean/templates/core/accounts/reset_password.html:49
-#: src/themes/material/templates/core/accounts/register.html:54
-#: src/themes/material/templates/core/accounts/reset_password.html:42
-msgid "When it comes to passwords, length is better than complexity."
-msgstr "Cuando se trata de contraseñas, la longitud es mejor que la complejidad."
-
-#: src/themes/OLH/templates/core/accounts/register.html:108
-#: src/themes/OLH/templates/core/accounts/reset_password.html:50
-#: src/themes/material/templates/core/accounts/register.html:55
-#: src/themes/material/templates/core/accounts/reset_password.html:43
-msgid "Its a common myth that a short and complex password (Jfjfy&65^87) is more secure than a long and uncomplicated password (our awesome moon base rocks)."
-msgstr "Es un mito común que una contraseña corta y compleja (Jfjfy y 65 ^ 87) es más segura que una contraseña larga y sin complicaciones (nuestra impresionante base de la Luna)."
-
-#: src/themes/OLH/templates/core/accounts/register.html:109
-#: src/themes/OLH/templates/core/accounts/reset_password.html:51
-msgid "We recommend selecting a long, but easy to remember password such as our awesome moon base rocks which would take an estimated septillion years to crack as opposed to a complex one like Jfjfy&65^87 which would take just over 600 years on a standard computer."
-msgstr "Recomendamos seleccionar una contraseña larga, pero fácil de recordar, como nuestras impresionantes rocas de la base de la luna, que demorarían un septillón aproximadamente en comparación con una compleja como Jfjfy&y65^87 que llevaría un poco más de 600 años en una computadora estándar."
-
-#: src/themes/OLH/templates/core/accounts/reset_password.html:27
-msgid "Your password should be at minimum 12 characters long. It does not need to\n"
-"                            contain specific\n"
-"                            characters but you should make it as long as possible. For more information read our\n"
-"                            <a href=\"#\" data-open=\"password-modal\">password guide</a>"
-msgstr "Su contraseña debe tener una longitud mínima de 12 caracteres. No necesita\n"
-"                            contener especifico\n"
-"                            Caracteres pero deberías hacerlo lo más largo posible. Para más información lea nuestra\n"
-"                            <a href=\"#\" data-open=\"password-modal\"> guía de contraseñas </a>"
-
-#: src/themes/OLH/templates/core/login.html:45
-#: src/themes/clean/templates/core/login.html:48
-msgid "Register a new account"
-msgstr "Registre una nueva cuenta"
-
-#: src/themes/OLH/templates/core/news/index.html:11
-#: src/themes/material/templates/core/news/index.html:11
-#: src/themes/material/templates/press/core/news/index.html:11
-msgid "Filtering tag"
-msgstr "Etiqueta de filtrado"
-
-#: src/themes/OLH/templates/core/news/index.html:33
-#: src/themes/material/templates/press/core/news/index.html:30
-msgid "This journal currently has no news items to display."
-msgstr "Esta revista no tiene nuevas noticias disponibles."
-
-#: src/themes/OLH/templates/elements/submit/preprint_file.html:8
-msgid "Please supply any supporting information or data files."
-msgstr "Por favor, proporcione cualquier información de apoyo o archivos de datos."
-
-#: src/themes/OLH/templates/elements/submit/preprint_file.html:11
-msgid "Please upload your manuscript file, it should be in PDF format."
-msgstr "Por favor, cargue su archivo manuscrito, debe estar en formato PDF."
-
-#: src/themes/OLH/templates/elements/submit/preprint_file.html:13
-msgid "Please upload your manuscript file, it should be in PDF, RTF, ODT or DOC/X format."
-msgstr "Suba su archivo manuscrito, debe estar en formato PDF, RTF, ODT o DOC / X."
-
-#: src/themes/OLH/templates/journal/article.html:287
-#: src/themes/clean/templates/journal/article.html:224
-msgid "Accepted on"
-msgstr "Aceptado en"
-
-#: src/themes/OLH/templates/journal/article.html:416
-#: src/themes/clean/templates/journal/article.html:209
-#: src/themes/material/templates/journal/article.html:366
-#: src/themes/material/templates/repository/preprint.html:140
-msgid "Supplementary Files"
-msgstr "Archivos suplementarios"
-
-#: src/themes/OLH/templates/elements/journal/summary_modal.html:3
-#: src/themes/OLH/templates/journal/article.html:437
-#: src/themes/clean/templates/elements/journal/summary_modal.html:6
-#: src/themes/clean/templates/journal/article.html:250
-#: src/themes/material/templates/elements/summary_modal.html:5
-#: src/themes/material/templates/journal/article.html:380
-msgid "Non Specialist Summary"
-msgstr "Resumen no especializado"
-
-#: src/themes/OLH/templates/journal/article.html:439
-#: src/themes/material/templates/journal/article.html:381
-msgid "View Summary"
-msgstr "Ver resumen"
-
-#: src/themes/OLH/templates/journal/article.html:428
-msgid "File Checksums (MD5)"
-msgstr "Sumas de comprobación de archivos (MD5)"
-
-#: src/templates/admin/journal/contact.html:27
-#: src/themes/OLH/templates/journal/contact.html:21
-#: src/themes/clean/templates/journal/contact.html:16
-#: src/themes/material/templates/journal/contact.html:25
-msgid "Contact Information"
-msgstr "Información de contacto"
-
-#: src/themes/OLH/templates/core/nav.html:29
-#: src/themes/OLH/templates/core/nav.html:37
-#: src/themes/OLH/templates/journal/editorial_team.html:10
-#: src/themes/OLH/templates/journal/editorial_team.html:20
-#: src/themes/OLH/templates/press/nav.html:39
-#: src/themes/clean/templates/core/nav.html:32
-#: src/themes/clean/templates/core/nav.html:41
-#: src/themes/clean/templates/journal/editorial_team.html:4
-#: src/themes/clean/templates/journal/editorial_team.html:9
-#: src/themes/material/templates/core/nav.html:36
-#: src/themes/material/templates/core/nav.html:97
-#: src/themes/material/templates/journal/editorial_team.html:11
-#: src/themes/material/templates/preprints/editors.html:5
-#: src/themes/material/templates/preprints/editors.html:6
-msgid "Editorial Team"
-msgstr "Equipo editorial"
-
-#: src/themes/OLH/templates/journal/homepage_elements/journals.html:5
-#: src/themes/OLH/templates/press/homepage_elements/journals_and_html.html:7
-#: src/themes/clean/templates/journal/homepage_elements/journals.html:4
-#: src/themes/clean/templates/press/homepage_elements/journals_and_html.html:4
-#: src/themes/material/templates/journal/homepage_elements/journals.html:6
-#: src/themes/material/templates/press/homepage_elements/journals_and_html.html:5
-msgid "Featured Journals"
-msgstr "Revistas destacadas"
-
-#: src/themes/OLH/templates/journal/homepage_elements/journals.html:23
-#: src/themes/OLH/templates/journal/homepage_elements/journals.html:28
-#: src/themes/OLH/templates/press/homepage_elements/journals_and_html.html:30
-msgid "Unnamed Journal"
-msgstr "Revista sin nombre"
-
-#: src/themes/OLH/templates/journal/homepage_elements/preprints.html:6
-#: src/themes/clean/templates/journal/homepage_elements/preprints.html:6
-msgid "Featured Preprints"
-msgstr "Preprints destacados"
-
-#: src/themes/OLH/templates/elements/journal/issue_sidebar.html:8
-#: src/themes/clean/templates/elements/journal/issue_sidebar.html:7
-msgid "Download Issue"
-msgstr "Descargar Numero"
-
-#: src/themes/OLH/templates/journal/issues.html:39
-msgid "There are no issues published in this journal yet."
-msgstr "Aún no hay temas publicados en esta revista."
-
-#: src/templates/admin/journal/submissions.html:47
-#: src/themes/OLH/templates/journal/submissions.html:39
-msgid "Licences"
-msgstr "Licencias"
-
-#: src/templates/admin/journal/submissions.html:48
-#: src/themes/OLH/templates/journal/submissions.html:40
-#: src/themes/clean/templates/journal/submissions.html:27
-#: src/themes/material/templates/journal/submissions.html:46
-msgid "allows the following licences for submission"
-msgstr "Permite las siguientes licencias para su presentación."
-
-#: src/themes/OLH/templates/elements/section_block.html:9
-#: src/themes/clean/templates/elements/sections_block.html:8
-#: src/themes/material/templates/elements/sections_display.html:8
-msgid "Public Submissions"
-msgstr "Sumisiones públicas"
-
-#: src/themes/OLH/templates/elements/section_block.html:15
-#: src/themes/clean/templates/elements/sections_block.html:10
-#: src/themes/material/templates/elements/sections_display.html:14
-msgid "Indexed"
-msgstr "Indexado"
-
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:9
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:30
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:54
-#: src/themes/material/templates/preprints/about.html:4
-#: src/themes/material/templates/preprints/about.html:9
-msgid "Preprints"
-msgstr "Preprints"
-
-#: src/themes/OLH/templates/repository/preprint.html:60
-#: src/themes/material/templates/preprints/article.html:63
-#: src/themes/material/templates/repository/preprint.html:87
-msgid "Comments"
-msgstr "Comentarios"
-
-#: src/themes/OLH/templates/repository/preprint.html:104
-msgid "There are no comments or no comments have been made public for this article."
-msgstr "No hay comentarios o no se han hecho comentarios para este artículo."
-
-#: src/templates/admin/repository/submit/start.html:38
-#: src/themes/OLH/templates/repository/preprint.html:122
-#: src/themes/material/templates/preprints/article.html:121
-msgid "Metadata"
-msgstr "Metadatos"
-
-#: src/themes/OLH/templates/repository/preprint.html:143
-#: src/themes/material/templates/preprints/article.html:152
-#: src/themes/material/templates/preprints/list.html:6
-#: src/themes/material/templates/preprints/list.html:14
-msgid "All Preprints"
-msgstr "Todos los Preprints"
-
-#: src/themes/OLH/templates/repository/preprint.html:134
-#: src/themes/material/templates/preprints/article.html:135
-msgid "Versions"
-msgstr "Versiones"
-
-#: src/themes/OLH/templates/repository/preprint.html:139
-msgid "This is the only version of the preprint."
-msgstr "Esta es la única versión de la preimpresión."
-
-#: src/themes/OLH/templates/repository/authors.html:7
-#: src/themes/OLH/templates/repository/authors.html:15
-msgid "Preprint Authors"
-msgstr "Autores de preimpresión"
-
-#: src/themes/OLH/templates/repository/authors.html:16
-msgid "Add authors to"
-msgstr "Añadir autores a"
-
-#: src/themes/OLH/templates/repository/authors.html:80
-msgid "When you've added all the authors, select Save and Continue to move to the next step of your submission."
-msgstr "Cuando haya agregado todos los autores, seleccione Guardar y continuar para pasar al siguiente paso de su envío."
-
-#: src/themes/OLH/templates/repository/editors.html:5
-#: src/themes/OLH/templates/repository/editors.html:16
-msgid "Preprint Editors"
-msgstr "Editores de preimpresión"
-
-#: src/themes/OLH/templates/repository/editors.html:46
-msgid "This repository has no subjects or editors to display."
-msgstr "Este repositorio no tiene temas o editores para mostrar."
-
-#: src/themes/OLH/templates/repository/home.html:29
-#: src/themes/material/templates/repository/home.html:37
-msgid "Read about"
-msgstr "Leer acerca de"
-
-#: src/themes/OLH/templates/preprints/home.html:29
-#: src/themes/material/templates/preprints/home.html:25
-msgid "preprints"
-msgstr "preprints"
-
-#: src/themes/OLH/templates/repository/home.html:30
-#: src/themes/material/templates/repository/home.html:38
-msgid "or view list of"
-msgstr "o ver la lista de"
-
-#: src/themes/OLH/templates/preprints/home.html:30
-#: src/themes/material/templates/preprints/home.html:26
-msgid "all preprints"
-msgstr "todos los preprints"
-
-#: src/themes/OLH/templates/repository/home.html:36
-msgid "Latest Preprints"
-msgstr "Últimos Preprints"
-
-#: src/themes/OLH/templates/repository/list.html:69
-msgid "Search preprints"
-msgstr "Buscar preprints"
-
-#: src/themes/OLH/templates/repository/list.html:73
-msgid "Searching by"
-msgstr "Buscando por"
-
-#: src/journal/views.py:2631 src/themes/OLH/templates/repository/list.html:77
-#: src/themes/material/templates/preprints/list.html:80
-#: src/themes/material/templates/repository/list.html:61
-msgid "Author Name"
-msgstr "Nombre del autor"
-
-#: src/themes/OLH/templates/repository/list.html:78
-#: src/themes/material/templates/repository/list.html:62
-msgid "Author Affiliation"
-msgstr "Afiliación del autor"
-
-#: src/templates/admin/core/manager/sections/section_articles.html:34
-#: src/themes/OLH/templates/repository/list.html:84
-msgid "Editors"
-msgstr "Editores"
-
-#: src/themes/OLH/templates/repository/home.html:43
-#: src/themes/OLH/templates/repository/list.html:95
-msgid "Filter by Subject"
-msgstr "Filtrar por tema"
-
-#: src/themes/OLH/templates/repository/review.html:5
-msgid "Review Preprint Submission"
-msgstr "Revisar la presentación de preimpresión"
-
-#: src/themes/material/templates/preprints/list.html:71
-#: src/themes/material/templates/repository/list.html:52
-msgid "Search Preprints"
-msgstr "Buscar Preprints"
-
-#: src/themes/OLH/templates/repository/submit_files.html:5
-#: src/themes/OLH/templates/repository/submit_files.html:13
-msgid "Preprint Files"
-msgstr "Archivos de preimpresión"
-
-#: src/themes/OLH/templates/repository/submit_start.html:7
-#: src/themes/OLH/templates/repository/submit_start.html:14
-msgid "Submit a Preprint"
-msgstr "Presentar una preimpresión"
-
-#: src/themes/OLH/templates/repository/submit_start.html:15
-msgid "Please read the following carefully before you submit your preprints."
-msgstr "Lea atentamente lo siguiente antes de enviar sus preimpresiones."
-
-#: src/themes/OLH/templates/repository/submit_start.html:30
-#: src/themes/OLH/templates/repository/submit_start.html:71
-msgid "If you have any additional information you'd like to supply to the preprints editor, do so here"
-msgstr "Si tiene alguna información adicional que le gustaría proporcionar al editor de preprints, hágalo aquí"
-
-#: src/templates/admin/elements/repository/metadata_form.html:39
-#: src/templates/admin/repository/submit/start.html:73 src/utils/forms.py:55
-msgid "Hit Enter to add a new keyword."
-msgstr "Presione Entrar para agregar una nueva palabra clave."
-
-#: src/templates/admin/elements/repository/metadata_form.html:50
-#: src/templates/admin/elements/submission/additional_fields.html:4
-msgid "Additional Fields"
-msgstr "Campos Adicionales"
-
-#: src/themes/OLH/templates/press/core/login.html:26
-msgid "Login with ORCiD"
-msgstr "Iniciar sesión con ORCiD"
-
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
-#: src/themes/OLH/templates/press/core/login.html:36
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:29
-msgid "Log In"
-msgstr "Iniciar sesión"
-
-#: src/themes/OLH/templates/press/core/news/index.html:31
-msgid "This press currently has no news items to display."
-msgstr "Esta prensa actualmente no tiene noticias para mostrar."
-
-#: src/themes/OLH/templates/core/news/index.html:24
-#: src/themes/OLH/templates/core/news/item.html:24
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:27
-#: src/themes/OLH/templates/press/core/news/index.html:22
-#: src/themes/OLH/templates/press/core/news/item.html:24
-#: src/themes/OLH/templates/press/core/news/item.html:33
-#: src/themes/material/templates/core/news/index.html:30
-#: src/themes/material/templates/core/news/item.html:30
-#: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
-msgid "on"
-msgstr "en"
-
-#: src/themes/OLH/templates/press/core/news/item.html:40
-#: src/themes/material/templates/core/news/item.html:35
-#: src/themes/material/templates/press/core/news/item.html:22
-msgid "Tags"
-msgstr "Etiquetas"
-
-#: src/themes/OLH/templates/press/core/news/item.html:45
-#: src/themes/clean/templates/press/core/news/item.html:18
-#: src/themes/material/templates/press/core/news/item.html:30
-msgid "Back to News List"
-msgstr "Volver a la lista de noticias"
-
-#: src/themes/OLH/templates/press/nav.html:23
-#: src/themes/OLH/templates/press/press_journals.html:5
-#: src/themes/clean/templates/press/nav.html:37
-#: src/themes/clean/templates/press/press_journals.html:10
-#: src/themes/material/templates/press/press_journals.html:9
-msgid "Journals"
-msgstr "Revistas"
-
-#: src/themes/OLH/templates/elements/journal/editorial_social_content.html:4
-#: src/themes/clean/templates/elements/journal/editorial_social_content.html:4
-#: src/themes/clean/templates/journal/article.html:283
-msgid "Twitter"
-msgstr "Gorjeo"
-
-#: src/themes/clean/templates/journal/article.html:285
-#: src/themes/material/templates/journal/article.html:203
-msgid "Wikipedia"
-msgstr "Wikipedia"
-
-#: src/themes/clean/templates/journal/article.html:287
-#: src/themes/material/templates/journal/article.html:211
-msgid "Reddit"
-msgstr "Reddit"
-
-#: src/themes/OLH/templates/core/accounts/edit_profile.html:4
-#: src/themes/clean/templates/core/accounts/edit_profile.html:5
-#: src/themes/material/templates/core/accounts/edit_profile.html:4
-msgid "Edit Profile"
-msgstr "Editar perfil"
-
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:9
-msgid "If you want to change your email address you may do so below, however, you will be logged out and your account will be marked as inactive until you follow the instructions in the verification email."
-msgstr "Sin embargo, si desea cambiar su dirección de correo electrónico, puede hacerlo a continuación, se desconectará y su cuenta se marcará como inactiva hasta que siga las instrucciones del correo electrónico de verificación."
-
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:10
-msgid "Note:"
-msgstr "Nota:"
-
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:11
-msgid "Changing your email address will also change your username as these are one and the same."
-msgstr "Cambiar su dirección de correo electrónico también cambiará su nombre de usuario ya que estos son uno y el mismo."
-
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:50
-msgid "Data Export"
-msgstr "Exportación de datos"
-
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:51
-msgid "You may export your data into a JSON file for reuse."
-msgstr "Puede exportar sus datos a un archivo JSON para reutilizarlos."
-
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:54
-msgid "Export"
-msgstr "Exportar"
-
-#: src/themes/material/templates/core/accounts/register.html:56
-#: src/themes/material/templates/core/accounts/reset_password.html:44
-msgid "We recommend selecting a long, but easy to remember password such as <i>our awesome moon base\n"
-"                rocks</i> which would take an estimated septillion years to crack as opposed to a complex one\n"
-"                like <i>Jfjfy&65^87</i> which would take just over 600 years on a standard computer."
-msgstr "Recomendamos seleccionar una contraseña larga, pero fácil de recordar, como <i> nuestra impresionante base lunar\n"
-"                rocas </i> que tardarían un septilón estimado en romperse en comparación con una compleja\n"
-"                como <i> Jfjfy & 65 ^ 87 </i> que llevaría un poco más de 600 años en una computadora estándar."
-
-#: src/themes/material/templates/core/login.html:45
-msgid "Register an Account"
-msgstr "Registrar una cuenta"
-
-#: src/themes/material/templates/core/login.html:48
-msgid "Reset Your Password"
-msgstr "Restablecer su contraseña"
-
-#: src/themes/OLH/templates/core/base.html:60
-#: src/themes/OLH/templates/core/nav.html:7
-#: src/themes/OLH/templates/press/nav.html:6
-#: src/themes/OLH/templates/press/press_index.html:5
-#: src/themes/OLH/templates/repository/nav.html:3
-#: src/themes/clean/templates/core/nav.html:16
-#: src/themes/clean/templates/press/nav.html:14
-#: src/themes/material/templates/core/nav.html:24
-#: src/themes/material/templates/core/nav.html:85
-#: src/themes/material/templates/press/nav.html:19
-#: src/themes/material/templates/press/nav.html:72
-#: src/themes/material/templates/repository/nav.html:18
-#: src/themes/material/templates/repository/nav.html:42
-msgid "Home"
-msgstr "Inicio"
-
-#: src/themes/OLH/templates/core/nav.html:47
-#: src/themes/OLH/templates/press/nav.html:43
-#: src/themes/clean/templates/press/nav.html:61
-#: src/themes/material/templates/core/nav.html:73
-#: src/themes/material/templates/core/nav.html:128
-#: src/themes/material/templates/press/nav.html:61
-#: src/themes/material/templates/press/nav.html:109
-#: src/themes/material/templates/repository/nav.html:54
-msgid "Account"
-msgstr "Cuenta"
-
-#: src/themes/OLH/templates/core/nav.html:50
-#: src/themes/OLH/templates/elements/right_hand_menu.html:4
-#: src/themes/OLH/templates/repository/elements/right_hand_menu.html:5
-#: src/themes/clean/templates/core/nav.html:85
-#: src/themes/material/templates/core/nav.html:149
-#: src/themes/material/templates/core/nav.html:170
-#: src/themes/material/templates/repository/nav.html:74
-#: src/themes/material/templates/repository/nav.html:87
-msgid "Dashboard"
-msgstr "Tablero"
-
-#: src/themes/OLH/templates/core/nav.html:56
-#: src/themes/OLH/templates/elements/right_hand_menu.html:5
-#: src/themes/clean/templates/core/nav.html:89
-#: src/themes/material/templates/core/nav.html:153
-#: src/themes/material/templates/core/nav.html:171
-msgid "Kanban"
-msgstr "Kanban"
-
-#: src/themes/OLH/templates/core/nav.html:52
-#: src/themes/OLH/templates/elements/right_hand_menu.html:8
-#: src/themes/OLH/templates/press/press_journals.html:58
-#: src/themes/OLH/templates/press/press_journals.html:65
-#: src/themes/clean/templates/core/nav.html:86
-#: src/themes/clean/templates/press/press_journals.html:29
-#: src/themes/clean/templates/press/press_journals.html:36
-#: src/themes/material/templates/core/nav.html:151
-#: src/themes/material/templates/core/nav.html:173
-#: src/themes/material/templates/press/press_journals.html:33
-#: src/themes/material/templates/press/press_journals.html:40
-#: src/themes/material/templates/repository/nav.html:22
-#: src/themes/material/templates/repository/nav.html:46
-msgid "Submit"
-msgstr "Enviar"
-
-#: src/templates/admin/core/manager/sections/section_articles.html:11
-#: src/templates/admin/press/edit_press_journal_description.html:10
-#: src/themes/OLH/templates/core/nav.html:57
-#: src/themes/OLH/templates/elements/right_hand_menu.html:13
-#: src/themes/OLH/templates/press/elements/right_hand_menu.html:7
-#: src/themes/OLH/templates/press/nav.html:48
-#: src/themes/OLH/templates/repository/elements/right_hand_menu.html:7
-#: src/themes/clean/templates/core/nav.html:90
-#: src/themes/clean/templates/press/nav.html:66
-#: src/themes/material/templates/core/nav.html:154
-#: src/themes/material/templates/core/nav.html:176
-#: src/themes/material/templates/press/nav.html:130
-#: src/themes/material/templates/press/nav.html:141
-msgid "Manager"
-msgstr "Gerente"
-
-#: src/themes/OLH/templates/core/nav.html:70
-#: src/themes/OLH/templates/elements/right_hand_menu.html:35
-#: src/themes/OLH/templates/press/elements/right_hand_menu.html:8
-#: src/themes/OLH/templates/press/nav.html:51
-#: src/themes/OLH/templates/repository/elements/right_hand_menu.html:9
-#: src/themes/clean/templates/core/nav.html:96
-#: src/themes/clean/templates/press/nav.html:69
-#: src/themes/material/templates/core/nav.html:163
-#: src/themes/material/templates/core/nav.html:198
-#: src/themes/material/templates/press/nav.html:133
-#: src/themes/material/templates/press/nav.html:144
-#: src/themes/material/templates/repository/nav.html:81
-#: src/themes/material/templates/repository/nav.html:94
-msgid "Admin"
-msgstr "Administración"
-
-#: src/themes/OLH/templates/core/nav.html:74
-#: src/themes/OLH/templates/elements/right_hand_menu.html:39
-#: src/themes/OLH/templates/press/elements/right_hand_menu.html:13
-#: src/themes/OLH/templates/press/nav.html:55
-#: src/themes/OLH/templates/repository/elements/right_hand_menu.html:11
-#: src/themes/clean/templates/core/nav.html:99
-#: src/themes/clean/templates/press/nav.html:72
-#: src/themes/material/templates/core/nav.html:166
-#: src/themes/material/templates/core/nav.html:201
-#: src/themes/material/templates/press/nav.html:136
-#: src/themes/material/templates/press/nav.html:147
-#: src/themes/material/templates/repository/nav.html:83
-#: src/themes/material/templates/repository/nav.html:96
-msgid "Logout"
-msgstr "Cerrar sesión"
-
-#: src/themes/OLH/templates/elements/right_hand_menu.html:15
-#: src/themes/material/templates/core/nav.html:178
-msgid "Edit Submissions Page"
-msgstr "Editar página de envíos"
-
-#: src/themes/OLH/templates/elements/right_hand_menu.html:16
-#: src/themes/material/templates/core/nav.html:179
-msgid "Edit Journal Info"
-msgstr "Editar información del diario"
-
-#: src/themes/OLH/templates/elements/right_hand_menu.html:19
-#: src/themes/OLH/templates/press/elements/right_hand_menu.html:10
-#: src/themes/material/templates/core/nav.html:182
-msgid "Edit Page"
-msgstr "Editar página"
-
-#: src/themes/OLH/templates/elements/right_hand_menu.html:22
-#: src/themes/material/templates/core/nav.html:185
-msgid "Manage Editorial Team"
-msgstr "Administrar equipo editorial"
-
-#: src/templates/admin/elements/accounts/user_form.html:4
-#: src/themes/OLH/templates/elements/accounts/user_form.html:5
-#: src/themes/clean/templates/elements/accounts/user_form.html:5
-#: src/themes/material/templates/elements/accounts/user_form.html:6
-msgid "Core Data"
-msgstr "Datos básicos"
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:41
-#: src/themes/clean/templates/elements/accounts/user_form.html:38
-#: src/themes/material/templates/elements/accounts/user_form.html:39
-msgid "Social Media and Accounts"
-msgstr "Redes sociales y cuentas"
-
-#: src/templates/admin/elements/accounts/user_form.html:61
-#: src/themes/OLH/templates/elements/accounts/user_form.html:65
-#: src/themes/clean/templates/elements/accounts/user_form.html:62
-#: src/themes/material/templates/elements/accounts/user_form.html:63
-msgid "Biography and Signature"
-msgstr "Biografia y firma"
-
-#: src/templates/admin/elements/accounts/user_form.html:70
-#: src/themes/OLH/templates/elements/accounts/user_form.html:74
-#: src/themes/clean/templates/elements/accounts/user_form.html:71
-#: src/themes/material/templates/elements/accounts/user_form.html:72
-msgid "Review Interests"
-msgstr "Revisar los intereses"
-
-#: src/templates/admin/elements/accounts/user_form.html:71
-#: src/themes/OLH/templates/elements/accounts/user_form.html:75
-#: src/themes/clean/templates/elements/accounts/user_form.html:72
-#: src/themes/material/templates/elements/accounts/user_form.html:73
-msgid "Hit Enter to add a new interest"
-msgstr "Pulsa Enter para añadir un nuevo interés."
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:95
-#: src/themes/OLH/templates/journal/article.html:108
-#: src/themes/clean/templates/elements/accounts/user_form.html:92
-#: src/themes/material/templates/elements/accounts/user_form.html:93
-msgid "Options"
-msgstr "Opciones"
-
-#: src/themes/OLH/templates/elements/journal/summary_modal.html:7
-#: src/themes/clean/templates/elements/journal/summary_modal.html:15
-#: src/themes/material/templates/elements/summary_modal.html:9
-msgid "This article has no summary"
-msgstr "Este artículo no tiene resumen."
-
-#: src/themes/material/templates/journal/article.html:389
-msgid "Dates"
-msgstr "fechas"
-
-#: src/templates/admin/review/view_review.html:63
-#: src/themes/material/templates/journal/article.html:394
-msgid "Accepted"
-msgstr "Aceptado"
-
-#: src/themes/OLH/templates/journal/collections.html:29
-#: src/themes/OLH/templates/repository/preprint.html:124
-#: src/themes/material/templates/journal/article.html:400
-msgid "Published"
-msgstr "Publicado"
-
-#: src/themes/material/templates/journal/article.html:390
-msgid "This article has not been peer reviewed."
-msgstr "Este artículo no ha sido revisado por pares."
-
-#: src/themes/OLH/templates/journal/article.html:472
-#: src/themes/clean/templates/journal/article.html:305
-#: src/themes/material/templates/journal/article.html:478
-msgid "File Checksums"
-msgstr "File Checksums"
-
-#: src/themes/clean/templates/journal/article.html:317
-#: src/themes/material/templates/journal/article.html:494
-#: src/themes/material/templates/journal/submissions.html:72
-msgid "Table of Contents"
-msgstr "Tabla de contenido"
-
-#: src/themes/material/templates/journal/collections.html:33
-msgid "View Collection"
-msgstr "Ver colección"
-
-#: src/themes/clean/templates/journal/collections.html:36
-#: src/themes/material/templates/journal/collections.html:38
-msgid "There are no collections to display"
-msgstr "No hay colecciones para mostrar"
-
-#: src/themes/OLH/templates/journal/collections.html:28
-#: src/themes/OLH/templates/journal/issue.html:7
-#: src/themes/clean/templates/journal/issue.html:6
-#: src/themes/material/templates/elements/journal/issue_sidebar.html:8
-#: src/themes/material/templates/journal/issue.html:6
-msgid "Collection"
-msgstr "Colección"
-
-#: src/themes/material/templates/journal/issues.html:39
-msgid "View Issue"
-msgstr "Ver problema"
-
-#: src/themes/OLH/templates/journal/article_list.html:27
-#: src/themes/clean/templates/journal/article_list.html:19
-#: src/themes/material/templates/journal/article_list.html:26
-#: src/themes/material/templates/journal/full-text-search.html:26
-#: src/themes/material/templates/journal/new_search.html:21
-#: src/themes/material/templates/journal/search.html:23
-msgid "No articles to display."
-msgstr "No hay artículos para mostrar."
-
-#: src/themes/material/templates/journal/new_search.html:26
-#: src/themes/material/templates/journal/search.html:28
-msgid "Searching"
-msgstr "buscando"
-
-#: src/templates/admin/journal/submissions.html:56
-msgid "Acceptance Criteria"
-msgstr "Criterios de aceptación"
-
-#: src/themes/material/templates/preprints/editors.html:10
-msgid "Subject Area Editors"
-msgstr "Editores del área temática"
-
-#: src/themes/material/templates/preprints/list.html:69
-msgid "search"
-msgstr "buscar"
-
-#: src/themes/material/templates/preprints/home.html:24
-msgid "Read about "
-msgstr "Leer acerca de"
-
-#: src/themes/material/templates/preprints/list.html:37
-msgid "There are no preprints to display"
-msgstr "No hay preimpresos para mostrar"
-
-#: src/themes/material/templates/preprints/list.html:74
-#: src/themes/material/templates/repository/list.html:55
-msgid "You can search by:"
-msgstr "Puedes buscar por:"
-
-#: src/themes/material/templates/preprints/list.html:81
-msgid "Author Institution"
-msgstr "Institución del autor"
-
-#: src/themes/material/templates/core/nav.html:109
-#: src/themes/material/templates/press/nav.html:77
-msgid "menu"
-msgstr "menú"
-
-#: src/themes/OLH/templates/repository/list.html:7
-msgid "All"
-msgstr "Todos"
-
-#: src/themes/OLH/templates/journal/article.html:6
-#: src/themes/material/templates/journal/article.html:7
-msgid "Preprint"
-msgstr "Preimpresión"
-
-#: src/core/forms.py:452
-msgid "Anti-spam captcha"
-msgstr ""
-
-#: src/core/forms/forms.py:495
-msgid "E-mail"
-msgstr ""
-
-#: src/core/janeway_global_settings.py:257
-msgid "Welsh"
-msgstr ""
-
-#: src/core/validators.py:15
-msgid "Extension {extension} is not allowed. Allowed extensions are: {validator.extensions}"
-msgstr ""
-
-#: src/core/validators.py:17
-msgid "MIME type {mimetype} is not valid. Valid types are: {validator.mimetypes}"
-msgstr ""
-
-#: src/journal/views.py:751
-msgid "No file uploaded"
-msgstr ""
-
-#: src/journal/views.py:937
-msgid "Your article must have a section assigned."
-msgstr ""
-
-#: src/journal/views.py:1129
-msgid "Article set for publication."
-msgstr ""
-
-#: src/journal/views.py:1401
-msgid "You cannot move the first section up the order list"
-msgstr ""
-
-#: src/journal/views.py:1433
-msgid "You cannot move the last section down the order list"
-msgstr ""
-
-#: src/journal/views.py:1440
-msgid "This page accepts post requests only."
-msgstr ""
-
-#: src/journal/logic.py:212
-msgid "Articles without a section cannot be added to an issue."
-msgstr ""
-
-#: src/journal/views.py:1511
-msgid "User is already a guest editor."
-msgstr ""
-
-#: src/journal/views.py:1517
-msgid "This user is not a member of this journal."
-msgstr ""
-
-#: src/journal/views.py:1570
-msgid "Editor removed from Issue."
-msgstr ""
-
-#: src/journal/views.py:1576
-msgid "Issue Editor not found."
-msgstr ""
-
-#: src/journal/views.py:1582
-msgid "No Issue Editor ID supplied."
-msgstr ""
-
-#: src/journal/views.py:1729
-msgid "Uploaded file is not UTF-8 encoded"
-msgstr ""
-
-#: src/journal/views.py:1879
-msgid "Your message has been sent."
-msgstr ""
-
-#: src/journal/views.py:2313 src/journal/views.py:2330
-#: src/journal/views.py:2340
-msgid "Production file uploaded."
-msgstr ""
-
-#: src/journal/views.py:2350
-msgid "Proofing file uploaded."
-msgstr ""
-
-#: src/submission/decorators.py:22
-msgid "This page can only be accessed on Journals."
-msgstr ""
-
-#: src/submission/decorators.py:30
-msgid "Submission is disabled for this journal."
-msgstr ""
-
-#: src/repository/models.py:990 src/repository/models.py:1146
-msgid "Please avoid pasting content from word processors as they can add unwanted styling to the abstract. You can retype the abstract here or copy and paste it into notepad/a plain text editor before pasting here."
-msgstr ""
-
-#: src/submission/views.py:260 src/submission/views.py:295
-#: src/submission/views.py:320
-msgid "{author_name} added to the article."
-msgstr ""
-
-#: src/submission/views.py:288
-msgid "Errors found in the new author form"
-msgstr ""
-
-#: src/submission/views.py:309
-msgid "An empty search is not allowed."
-msgstr ""
-
-#: src/submission/views.py:327
-msgid "No author found with those details."
-msgstr ""
-
-#: src/submission/views.py:337
-msgid "You must select a main author."
-msgstr ""
-
-#: src/submission/views.py:447
-msgid "File deleted"
-msgstr ""
-
-#: src/submission/views.py:564
-msgid "Article {title} submitted"
-msgstr ""
-
-#: src/submission/views.py:661
-msgid "Metadata updated."
-msgstr ""
-
-#: src/submission/views.py:690
-msgid "Author {author_name} updated."
-msgstr ""
-
-#: src/submission/views.py:708
-msgid "Frozen Author deleted."
-msgstr ""
-
-#: src/submission/views.py:823
-msgid "License saved."
-msgstr ""
-
-#: src/submission/views.py:868
-msgid "License {license_name} deleted."
-msgstr ""
-
-#: src/submission/views.py:904
-msgid "Configuration updated."
-msgstr ""
-
-#: src/templates/admin/elements/fundref/fundref.html:24
-msgid "Funder"
-msgstr ""
-
-#: src/templates/admin/elements/fundref/fundref.html:61
-#: src/templates/admin/elements/fundref/fundref.html:82
-#: src/templates/admin/elements/fundref/fundref.html:166
-#: src/templates/admin/submission/submit_funding.html:85
-#: src/templates/admin/submission/submit_funding.html:108
-msgid "Add funder"
-msgstr ""
-
-#: src/templates/admin/elements/fundref/fundref.html:137
-msgid "Funder DOI (optional)"
-msgstr ""
-
-#: src/templates/admin/elements/fundref/fundref.html:158
-msgid "Funder grant number (optional)"
-msgstr ""
-
-#: src/templates/admin/journal/submissions.html:28
-#: src/themes/OLH/templates/journal/submissions.html:24
-#: src/themes/material/templates/journal/submissions.html:27
-msgid "Submission is currently disabled for this journal."
-msgstr ""
-
-#: src/templates/admin/proofing/proofing_article.html:272
-msgid "Each proofing round is limited to"
-msgstr ""
-
-#: src/templates/admin/proofing/proofing_article.html:272
-msgid "proofreaders"
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:20
-msgid "Save Projected Issue"
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:30
-msgid "What is this for?"
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:31
-msgid "The projected issue setting helps you track which issue an article is intended to be published with."
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:33
-msgid "How does it work?"
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:33
-msgid "Select an issue from the drop down on the left and press save, this articles projected issue will now be set."
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:35
-msgid "Can I unset a projected issue?"
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:35
-msgid "Yes, simply select the blank option (-------) from the drop down."
-msgstr ""
-
-#: src/templates/admin/press/edit_press_journal_description.html:11
-#: src/templates/admin/press/edit_press_journal_description.html:17
-#: src/templates/admin/repository/article.html:215
-#: src/templates/admin/review/unassigned_article.html:117
-#: src/templates/admin/review/view_review.html:112
-#: src/themes/OLH/templates/elements/edit_author.html:4
-msgid "Edit"
-msgstr ""
-
-#: src/templates/admin/review/unassigned_article.html:117
-msgid "Assign"
-msgstr ""
-
-#: src/templates/admin/review/unassigned_article.html:117
-msgid "Projected Issue"
-msgstr ""
-
-#: src/templates/admin/review/unassigned_article.html:122
-msgid "This article is projected to be published as part of"
-msgstr ""
-
-#: src/templates/admin/review/unassigned_article.html:124
-msgid "This article is not projected to be published as part of any issue."
-msgstr ""
-
-#: src/templates/admin/submission/manager/delete_license.html:26
-msgid "This license is currently used by the following articles. If you delete it these articles will no longer have a license listed."
-msgstr ""
-
-#: src/templates/admin/submission/manager/delete_license.html:27
-msgid "You should only delete this license if you are absolutley sure you want to remove it."
-msgstr ""
-
-#: src/templates/admin/submission/start.html:24
-msgid "In order to submit an article to %(request.journal.name)s all authors have to agree to the below statements.\n"
-"                        Unfortunately, if you do not agree with them you will be unable to proceed with your submission."
-msgstr ""
-
-#: src/templates/admin/submission/submit_authors.html:57
-msgid "Drag and drop an author to re-order them."
-msgstr ""
-
-#: src/templates/admin/submission/submit_funding.html:16
-#: src/templates/admin/submission/timeline.html:36
-#: src/templates/admin/submission/timeline.html:37
-#: src/themes/OLH/templates/journal/article.html:229
-#: src/themes/clean/templates/journal/article.html:123
-#: src/themes/material/templates/journal/article.html:151
-msgid "Funding"
-msgstr ""
-
-#: src/templates/admin/submission/submit_funding.html:20
-msgid "Add Funding Source"
-msgstr ""
-
-#: src/templates/admin/submission/submit_funding.html:27
-msgid "Search for funder"
-msgstr ""
-
-#: src/templates/admin/submission/submit_funding.html:31
-msgid "Add funder manually"
-msgstr ""
-
-#: src/templates/admin/submission/submit_funding.html:41
-msgid "Current Funders"
-msgstr ""
-
-#: src/templates/admin/submission/submit_funding.html:50
-msgid "Grant Number"
-msgstr ""
-
-#: src/templates/admin/submission/submit_funding.html:65
-msgid "No funders added."
-msgstr ""
-
-#: src/templates/admin/submission/submit_funding.html:99
-msgid "Funder DOI"
-msgstr ""
-
-#: src/templates/admin/submission/submit_funding.html:99
-#: src/templates/admin/submission/submit_funding.html:105
-msgid "(optional)"
-msgstr ""
-
-#: src/templates/admin/submission/submit_funding.html:105
-msgid "Funder grant number"
-msgstr ""
-
-#: src/templates/admin/submission/submit_info.html:58
-msgid "View license information"
-msgstr ""
-
-#: src/templates/admin/submission/submit_info.html:96
-msgid "License Information"
-msgstr ""
-
-#: src/templates/admin/hijack/notification.html:5
-msgid "You are currently working on behalf of %(user)s."
-msgstr ""
-
-#: src/templates/admin/hijack/notification.html:9
-msgid "release %(user)s"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/activate_account.html:25
-#: src/themes/clean/templates/core/accounts/activate_account.html:16
-#: src/themes/material/templates/core/accounts/activate_account.html:17
-msgid "You can complete the activation process by clicking the button below."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/activate_account.html:31
-msgid "There was no inactive account with this activation code found. It is possible that your account is already active, you can check by attempting to"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:20
-msgid "The ORCiD you logged in with is not currently linked with an account in our system. You can either register a new account, or login with an existing account to link your ORCiD for future use."
-msgstr ""
-
-#: src/themes/OLH/templates/core/nav.html:59
-#: src/themes/OLH/templates/elements/right_hand_menu.html:25
-#: src/themes/clean/templates/core/nav.html:92
-#: src/themes/material/templates/core/nav.html:156
-#: src/themes/material/templates/core/nav.html:188
-msgid "Edit Article"
-msgstr ""
-
-#: src/themes/OLH/templates/core/nav.html:62
-#: src/themes/OLH/templates/elements/right_hand_menu.html:28
-#: src/themes/material/templates/core/nav.html:159
-#: src/themes/material/templates/core/nav.html:191
-msgid "Edit Issue"
-msgstr ""
-
-#: src/themes/OLH/templates/core/nav.html:66
-#: src/themes/OLH/templates/elements/right_hand_menu.html:31
-#: src/themes/material/templates/core/nav.html:194
-msgid "Edit News Item"
-msgstr ""
-
-#: src/templates/admin/elements/accounts/user_form.html:75
-#: src/themes/OLH/templates/elements/accounts/user_form.html:79
-#: src/themes/clean/templates/elements/accounts/user_form.html:76
-#: src/themes/material/templates/elements/accounts/user_form.html:77
-msgid "Profile Image"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/edit_author.html:10
-msgid "Save Metadata"
-msgstr ""
-
-#: src/templates/common/elements/journal/article_issue_list.html:21
-msgid "This article is not a part of any issues"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/box_article.html:30
-#: src/themes/clean/templates/elements/article_listing.html:40
-#: src/themes/material/templates/elements/article_listing.html:41
-msgid "Also a part of:"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:5
-#: src/themes/clean/templates/elements/journal/citation_modals.html:6
-#: src/themes/clean/templates/journal/article.html:294
-msgid "Harvard-style Citation"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:19
-#: src/themes/OLH/templates/journal/article.html:135
-msgid "Vancouver Citation Style"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:19
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:40
-#: src/themes/OLH/templates/journal/article.html:136
-msgid "APA Citation Style"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:27
-#: src/themes/clean/templates/elements/journal/citation_modals.html:28
-#: src/themes/clean/templates/journal/article.html:295
-msgid "Vancouver-style Citation"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:40
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:63
-#: src/themes/OLH/templates/journal/article.html:134
-msgid "Harvard Citation Style"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/citation_modals.html:49
-#: src/themes/clean/templates/elements/journal/citation_modals.html:49
-#: src/themes/clean/templates/journal/article.html:296
-msgid "APA-style Citation"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/article.html:269
-#: src/themes/clean/templates/journal/article.html:289
-#: src/themes/material/templates/journal/article.html:220
-msgid "Citations"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/articles.html:30
-msgid "Pinned Articles"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/articles.html:39
-msgid "There are no articles published in this journal yet"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/homepage_elements/popular.html:6
-#: src/themes/clean/templates/journal/homepage_elements/popular.html:7
-#: src/themes/material/templates/journal/homepage_elements/popular.html:6
-msgid "Most Popular Articles"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/keyword.html:6
-#: src/themes/OLH/templates/journal/keyword.html:12
-#: src/themes/OLH/templates/journal/search.html:23
-#: src/themes/clean/templates/journal/keyword.html:4
-#: src/themes/clean/templates/journal/keyword.html:5
-#: src/themes/material/templates/journal/full-text-search.html:17
-#: src/themes/material/templates/journal/keyword.html:4
-#: src/themes/material/templates/journal/keyword.html:5
-#: src/themes/material/templates/journal/search.html:14
-msgid "Keyword"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/keyword.html:14
-#: src/themes/clean/templates/journal/keyword.html:10
-#: src/themes/material/templates/journal/keyword.html:9
-msgid "Back to Keywords List"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/keyword.html:16
-#: src/themes/clean/templates/journal/keyword.html:12
-#: src/themes/material/templates/journal/keyword.html:10
-msgid "Articles that use this keyword are listed below."
-msgstr ""
-
-#: src/themes/OLH/templates/journal/search.html:21
-#: src/themes/material/templates/journal/full-text-search.html:15
-#: src/themes/material/templates/journal/new_search.html:12
-#: src/themes/material/templates/journal/search.html:12
-msgid "Searching for"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/search_form.html:9
-#: src/themes/clean/templates/journal/full-text-search.html:39
-msgid "You are currently browsing by keyword"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/search_form.html:10
-#: src/themes/OLH/templates/journal/full-text-search.html:64
-#: src/themes/clean/templates/journal/article_list.html:36
-#: src/themes/clean/templates/journal/full-text-search.html:39
-#: src/themes/clean/templates/journal/search.html:42
-msgid "Search for an article"
-msgstr ""
-
-#: src/themes/material/templates/preprints/article.html:19
-msgid "This article is a preprint, it has not been peer reviewed or had any extensive editorial over-sight."
-msgstr ""
-
-#: src/themes/OLH/templates/press/elements/right_hand_menu.html:13
-msgid "Preprints Dashboard"
-msgstr ""
-
-#: src/themes/OLH/templates/press/nav.html:26
-msgid "Conferences"
-msgstr ""
-
-#: src/themes/OLH/templates/press/nav.html:32
-msgid "Preprints Home"
-msgstr ""
-
-#: src/themes/OLH/templates/press/nav.html:34
-msgid "About Preprints"
-msgstr ""
-
-#: src/themes/OLH/templates/press/press_journals.html:48
-msgid "Disciplines"
-msgstr ""
-
-#: src/journal/models.py:676
-#: src/themes/OLH/templates/press/press_journals.html:71
-#: src/themes/clean/templates/press/press_journals.html:42
-#: src/themes/material/templates/press/press_journals.html:46
-msgid "Current Issue"
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:10
-msgid "The ORCiD you logged in with is not currently linked with an account in our system. You can either\n"
-"            register a new account, or login with an existing account to link your ORCiD for future use."
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:30
-msgid "Forgot your password"
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/public_profile.html:10
-msgid "profile photo"
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/reset_password.html:50
-msgid "Its a common myth that a short and complex password (Jfjfy&65^87) is more secure than a long and\n"
-"                        uncomplicated password (our awesome moon base rocks)."
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/reset_password.html:52
-msgid "We recommend selecting a long, but easy to remember password such as <em>our awesome moon base\n"
-"                        rocks</em> which would take an estimated septillion years to crack as opposed to a complex one\n"
-"                        like <em>Jfjfy&65^87</em> which would take just over 600 years on a standard computer."
-msgstr ""
-
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:9
-msgid "If you want to change your email address you may do so\n"
-"                    below, however, you will be logged out and\n"
-"                    your account will be marked as inactive until you follow the\n"
-"                    instructions in the verfication email."
-msgstr ""
-
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:13
-msgid "Note"
-msgstr ""
-
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:14
-msgid "Changing your email address will also change your username\n"
-"                    as these are one and the same."
-msgstr ""
-
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:68
-msgid "You can update your password by entering your existing password plus your new password"
-msgstr ""
-
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:77
-msgid "Enter New Password"
-msgstr ""
-
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:81
-msgid "Enter New Password Again"
-msgstr ""
-
-#: src/core/models.py:231
-#: src/themes/OLH/templates/elements/journal/editorial_social_content.html:3
-#: src/themes/clean/templates/elements/journal/editorial_social_content.html:3
-msgid "Website"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/editorial_social_content.html:5
-#: src/themes/clean/templates/elements/journal/editorial_social_content.html:5
-msgid "Facebook"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/editorial_social_content.html:6
-#: src/themes/clean/templates/elements/journal/editorial_social_content.html:6
-msgid "Github"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/editorial_social_content.html:7
-#: src/themes/clean/templates/elements/journal/editorial_social_content.html:7
-msgid "Linkedin"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/keywords_block.html:4
-#: src/themes/clean/templates/elements/journal/keywords_block.html:4
-msgid "Keywords used by articles in this journal are listed below. Select a keyword to view which articles use it."
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/keywords_block.html:10
-#: src/themes/clean/templates/elements/journal/keywords_block.html:10
-msgid "This journal has no keywords to display."
-msgstr ""
-
-#: src/themes/clean/templates/journal/articles.html:48
-msgid "Sort and Filter"
-msgstr ""
-
-#: src/themes/clean/templates/journal/contact.html:10
-msgid "Journal Contacts"
-msgstr ""
-
-#: src/themes/clean/templates/journal/homepage_elements/carousel.html:5
-msgid "Latest Articles & News"
-msgstr ""
-
-#: src/themes/clean/templates/journal/homepage_elements/carousel.html:32
-msgid "Previous"
-msgstr ""
-
-#: src/themes/clean/templates/journal/homepage_elements/carousel.html:36
-msgid "Next"
-msgstr ""
-
-#: src/themes/clean/templates/journal/homepage_elements/carousel.html:41
-#: src/themes/clean/templates/journal/homepage_elements/carousel.html:46
-msgid "Play"
-msgstr ""
-
-#: src/themes/clean/templates/journal/issues.html:16
-msgid "The current issue is"
-msgstr ""
-
-#: src/themes/clean/templates/journal/issues.html:30
-msgid "This journal has no issues"
-msgstr ""
-
-#: src/themes/clean/templates/elements/sections_block.html:4
-msgid "Sections submission information"
-msgstr ""
-
-#: src/themes/material/templates/core/accounts/activate_account.html:25
-msgid "There was no inactive account with this activation code found. It is possible that your account is already active, you can check by attempting to "
-msgstr ""
-
-#: src/themes/material/templates/journal/article.html:195
-msgid "Tweets"
-msgstr ""
-
-#: src/themes/material/templates/journal/article.html:450
-msgid "This article has been peer reviewed."
-msgstr ""
-
-#: src/comms/models.py:94
-msgid "Posted by {byline}"
-msgstr ""
-
-#: src/comms/models.py:95
-msgid "Posted by  {byline}"
-msgstr ""
-
-#: src/core/janeway_global_settings.py:256
-msgid "Dutch"
-msgstr ""
-
-#: src/core/views.py:1943
-msgid "You cannot remove a section that contains articles. Remove articles from the section if you want to delete it."
-msgstr ""
-
-#: src/journal/models.py:80
-msgid "Short acronym for the journal. Used as part of the journal URLin path mode and to uniquely identify the journal"
-msgstr ""
-
-#: src/journal/models.py:158
-msgid "When enabled, the journal is marked as not hosted in Janeway."
-msgstr ""
-
-#: src/journal/models.py:169
-msgid "If the journal is remote you can link to its submission page."
-msgstr ""
-
-#: src/journal/models.py:174
-msgid "If the journal is remote you can link to its home page."
-msgstr ""
-
-#: src/journal/models.py:178
-msgid "Enables a \"View PDF\" link on article pages."
-msgstr ""
-
-#: src/journal/views.py:2632
-msgid "Volume"
-msgstr ""
-
-#: src/journal/models.py:532
-msgid "Please add as much detail as you can."
-msgstr ""
-
-#: src/submission/forms.py:338
-msgid "Currently linked to %s, leave blank to use this address"
-msgstr ""
-
-#: src/submission/forms.py:343
-msgid "If left blank, the account ORCiD will be used (%s)"
-msgstr ""
-
-#: src/submission/models.py:715
-msgid "Custom page range. e.g.: 'I-VII' or 1-3,4-8"
-msgstr ""
-
-#: src/submission/models.py:767 src/submission/models.py:774
-msgid "Name of the publisher who published this article Only relevant to migrated articles from a different publisher"
-msgstr ""
-
-#: src/submission/models.py:1898
-msgid "Optional name prefix (e.g: Prof or Dr)"
-msgstr ""
-
-#: src/submission/models.py:1903
-msgid "Optional name suffix (e.g.: Jr or III)"
-msgstr ""
-
-#: src/submission/models.py:1939
-msgid "Author Email"
-msgstr ""
-
-#: src/submission/models.py:1944
-msgid "ORCiD to be displayed when no account is associated with this author. It should be introduced in code format (e.g: 0000-0000-0000-000X)"
-msgstr ""
-
-#: src/submission/models.py:1951
-msgid "If checked, this authors email address link will be displayed on the article page."
-msgstr ""
-
-#: src/submission/views.py:673
-msgid "Primary author set."
-msgstr ""
-
-#: src/templates/admin/cms/submission_item_form.html:15
-#: src/templates/admin/cms/submission_item_form.html:22
-msgid "Editing Submission Page Item"
-msgstr ""
-
-#: src/templates/admin/cms/submission_item_form.html:15
-#: src/templates/admin/cms/submission_item_form.html:22
-msgid "Add a Submission Page Item"
-msgstr ""
-
-#: src/templates/admin/cms/submission_item_list.html:58
-msgid "No submission items found"
-msgstr ""
-
-#: src/templates/admin/core/manager/sections/manage_section.html:15
-#: src/templates/admin/core/manager/sections/manage_section.html:22
-msgid "Editing Section"
-msgstr ""
-
-#: src/templates/admin/core/manager/sections/manage_section.html:15
-#: src/templates/admin/core/manager/sections/manage_section.html:22
-msgid "Add a Section"
-msgstr ""
-
 #: src/templates/admin/core/manager/sections/section_articles.html:21
 msgid "Back"
 msgstr ""
@@ -2789,6 +1585,11 @@ msgstr ""
 msgid "Main Author"
 msgstr ""
 
+#: src/templates/admin/core/manager/sections/section_articles.html:34
+#: src/themes/OLH/templates/repository/list.html:84
+msgid "Editors"
+msgstr "Editores"
+
 #: src/templates/admin/core/manager/sections/section_articles.html:35
 msgid "Article Archive"
 msgstr ""
@@ -2798,817 +1599,57 @@ msgid "This section has no articles."
 msgstr ""
 
 #: src/templates/admin/core/manager/sections/section_list.html:26
-msgid "\n"
-"                    You can create and edit article section types below. To quickly re-order sections, drag and drop the "
+msgid ""
+"\n"
+"\t\t\t\t\t\t\t\t\tHere you can create and edit the sections that make up a "
+"typical issue. You can also think of these as article types, since authors "
+"will choose one on submission. To quickly re-order sections, drag and drop "
+"the \n"
+"\t\t\t\t\t\t\t\t\t"
 msgstr ""
 
 #: src/templates/admin/core/manager/sections/section_list.html:30
 msgid "handles on the left of each row"
 msgstr ""
 
-#: src/templates/admin/core/manager/sections/section_list.html:28
-msgid "This will change the order that the author sees these on the submission page - so you may want to move the most popular or current sections to the top."
+#: src/templates/admin/core/manager/sections/section_list.html:31
+msgid ""
+"\n"
+"\t\t\t\t\t\t\t\t\t\tThis will change the order that the author sees these on "
+"the submission page - so you may want to move the most popular or current "
+"sections to the top.\n"
+"\t\t\t\t\t\t\t\t\t"
 msgstr ""
 
 #: src/templates/admin/core/manager/sections/section_list.html:36
-msgid "You cannot delete a Section that contains articles. Remove the articles from the section if you want to delete it."
-msgstr ""
-
-#: src/templates/admin/elements/forms/field.html:7
-msgid "translatable"
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_article.html:5
-msgid "A set of controls for how things display on the article page"
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_article.html:28
-msgid "If you don't want to display metrics you can disable them all, or you can disable the display of citation metrics below"
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_journal.html:32
-msgid "You can set the from address your journal will use to send emails and the base signature that will be included."
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_journal.html:42
-msgid "Where you have a journal in your press that is not hosted on Janeway you can link directly to the journal and submit pages."
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_journal.html:49
-msgid "Slack/Discord Integration"
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_journal.html:52
-msgid "You can integrate Janeway into Slack (and Discord as they support the same endpoints) by setting it up below."
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_journal_images.html:9
-msgid "If you wish to disable the display of article images across Janeway you can use the \"Disable article images\" setting. To override an existing image simply upload a new one."
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_journal_news.html:5
-msgid "You can use this setting to overwrite the title of the news section."
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_review.html:5
-msgid "You can set review file guidance and default review settings below. Review forms can be managed in the"
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_review.html:5
-msgid "Review Form manager"
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_review.html:29
-msgid "Settings here determine the review form experience."
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_review.html:49
-msgid "Settings here determine the review experience for authors."
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_styling.html:3
-msgid "Full Width Navbar only applies to the Material theme"
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_submission.html:41
-msgid "The text below make up the Submission page as well as the Submission Agreement that authors accept."
-msgstr ""
-
-#: src/templates/admin/review/add_review_assignment.html:27
-msgid "\n"
-"                        You can select a reviewer using the radio buttons in the first column and complete the section under \"Set Options\".\n"
-"                        If you cannot find the reviewer you want in this list you can use \"Enroll Existing User\" to search the database and give users the Reviewer role, or \"Add New Reviewer\" to create a new account for a reviewer (this process is silent, they will not receive an account creation email).\n"
-"                        "
-msgstr ""
-
-#: src/templates/admin/review/decision.html:44
-msgid "Note: This article has completed reviews that have not been made available to the author:"
-msgstr ""
-
-#: src/templates/admin/review/in_review.html:25
-msgid "This article is not yet in the review stage"
-msgstr ""
-
-#: src/templates/admin/review/in_review.html:27
-msgid "Before you can move this paper into review you need to"
-msgstr ""
-
-#: src/templates/admin/review/in_review.html:28
-msgid "assign an editor"
-msgstr ""
-
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
-msgid "This paper has not had an automatic plagiarism check. If you wish to do so you can run a"
-msgstr ""
-
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
-msgid "Similarity Check via iThenticate"
-msgstr ""
-
-#: src/templates/admin/review/unassigned_article.html:137
-msgid "To check an article for possible plagiarism, you can send an article for an automated Similarity Check via iThenticate by clicking Send below. The report then takes a few minutes to be generated, so refresh this page; results will be displayed under Similarity Check when ready."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
-msgid "Register for an account with"
-msgstr "Registra una cuenta con"
-
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
-msgid "account"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:33
-#: src/themes/clean/templates/core/accounts/register.html:25
-#: src/themes/material/templates/core/accounts/register.html:24
-msgid "Your password should be"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:33
-#: src/themes/clean/templates/core/accounts/register.html:25
-#: src/themes/material/templates/core/accounts/register.html:24
-msgid "characters long"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:34
-#: src/themes/clean/templates/core/accounts/register.html:26
-#: src/themes/material/templates/core/accounts/register.html:25
-msgid "Your password should contain at least one upper case letter."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:35
-#: src/themes/clean/templates/core/accounts/register.html:27
-#: src/themes/material/templates/core/accounts/register.html:26
-msgid "Your password should contain at least one number."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:32
-msgid "For more information read our <a href=\"#\" data-open=\"password-modal\">password guide</a>."
-msgstr ""
-
-#: src/themes/OLH/templates/core/news/item.html:47
-#: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
-msgid "Back to"
-msgstr ""
-
-#: src/themes/OLH/templates/core/news/item.html:47
-#: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
-msgid "List"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:8
-msgid "\n"
-"                <p>If you want to change your email address you may do so below, however, you will be logged out and your\n"
-"                account will be marked as inactive until you follow the instructions in the verification email. <strong>Note: </strong>\n"
-"                Changing your email address will also change your username as these are one and the same.</p>\n"
-"                "
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
-msgid "Current Email Address"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
-msgid "New Email Address"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/edit_author.html:5
-msgid "NB."
-msgstr ""
-
-#: src/themes/OLH/templates/elements/edit_author.html:5
-msgid "You are editing the frozen metadata record for this author, not their live user profile."
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/authors_block.html:4
-#: src/themes/clean/templates/elements/journal/authors_block.html:4
-#: src/themes/material/templates/elements/article_listing.html:25
-msgid "and"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/article.html:190
-#: src/themes/clean/templates/journal/article.html:95
-#: src/themes/material/templates/journal/article.html:101
-msgid "Rights"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/article.html:383
-#: src/themes/material/templates/journal/article.html:434
-msgid "Identifiers"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/article.html:393
-#: src/themes/material/templates/journal/article.html:326
-msgid "Publication details"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/article.html:396
-#: src/themes/clean/templates/journal/article.html:227
-#: src/themes/material/templates/journal/article.html:330
-msgid "Pages"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/article.html:399
-#: src/themes/clean/templates/journal/article.html:230
-msgid "Article Number"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/article.html:402
-#: src/themes/clean/templates/journal/article.html:233
-#: src/themes/material/templates/journal/article.html:342
-msgid "Publisher"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/article.html:405
-#: src/themes/clean/templates/journal/article.html:236
-msgid "Original Publication"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
-#: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
-msgid "Latest"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
-#: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
-msgid "Posts"
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/register.html:24
-msgid "For more information read our <a href=\"#\" data-toggle=\"modal\" data-target=\"#passwordmodal\">password guide</a>."
-msgstr ""
-
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:19
-msgid "Current email address"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/reset_password.html:33
-#: src/themes/material/templates/core/accounts/register.html:26
-msgid "For more information read our\n"
-"                        <a href=\"#passwordmodal\" class=\"modal-trigger\">password guide</a>\n"
-"                        ."
-msgstr ""
-
-#: src/themes/material/templates/core/accounts/reset_password.html:17
-msgid "Your password should be at minimum 12 characters long. It does not\n"
-"                                    need to contain specific\n"
-"                                    characters but you should make it as long as possible. For more information read our"
-msgstr ""
-
-#: src/themes/material/templates/core/accounts/reset_password.html:20
-msgid "password guide"
-msgstr ""
-
-#: src/themes/material/templates/core/news/index.html:39
-msgid "This journal currently has no items to display."
-msgstr ""
-
-#: src/themes/material/templates/elements/license_block.html:4
-msgid "More Information "
-msgstr ""
-
-#: src/themes/material/templates/journal/article.html:336
-msgid "Article No."
-msgstr ""
-
-#: src/themes/material/templates/journal/article.html:348
-msgid "Publication"
-msgstr ""
-
-#: src/themes/clean/templates/journal/authors.html:26
-#: src/themes/material/templates/journal/authors.html:31
-#: src/themes/material/templates/journal/editorial_team.html:36
-msgid "View Profile"
-msgstr ""
-
-#: src/themes/material/templates/journal/issues.html:35
-msgid "close"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/journal/search_form.html:14
-#: src/themes/clean/templates/journal/search.html:55
-#: src/themes/material/templates/journal/new_search.html:36
-#: src/themes/material/templates/journal/search.html:44
-msgid "Sort articles by"
-msgstr ""
-
-#: src/themes/OLH/templates/repository/preprint.html:53
-#: src/themes/material/templates/preprints/article.html:51
-msgid "Preprint Body"
-msgstr ""
-
-#: src/themes/OLH/templates/repository/preprint.html:66
-#: src/themes/material/templates/preprints/article.html:69
-msgid "Add Comment"
-msgstr ""
-
-#: src/themes/material/templates/preprints/article.html:147
-msgid "Harvard Citation"
-msgstr ""
-
-#: src/themes/material/templates/preprints/article.html:148
-msgid "Vancouver Citation"
-msgstr ""
-
-#: src/themes/material/templates/preprints/article.html:149
-msgid "APA Citation"
-msgstr ""
-
-#: src/utils/transactional_emails.py:370
-msgid "accepted"
-msgstr ""
-
-#: src/utils/transactional_emails.py:380
-msgid "declined"
-msgstr ""
-
-#: src/core/homepage_elements/carousel/models.py:30
-msgid "If enabled, the selectors below will behave as an exclusion list"
-msgstr ""
-
-#: src/core/homepage_elements/carousel/models.py:70
-msgid "Issues and Collections"
-msgstr ""
-
-#: src/core/logic.py:810
-msgid "Your password must be {} characters long"
-msgstr ""
-
-#: src/core/logic.py:814
-msgid "An uppercase character is required"
-msgstr ""
-
-#: src/core/logic.py:817
-msgid "A number is required"
-msgstr ""
-
-#: src/discussion/models.py:27
-msgid "Max. 300 characters."
-msgstr ""
-
-#: src/journal/models.py:440
-msgid "Image representing the the cover of a printed issue or volume"
-msgstr ""
-
-#: src/journal/models.py:594
-msgid "landscape hero image used in the carousel and issue page"
-msgstr ""
-
-#: src/journal/models.py:613
-msgid "An optional alphanumeric code (Slug) used to generate a verbose  url for this issue. e.g: 'winter-special-issue'."
-msgstr ""
-
-#: src/repository/models.py:140
-msgid "Used for outputs including DC and Citation metadata"
-msgstr ""
-
-#: src/repository/models.py:145
-msgid "The contents of this field are output into the JS areaat the foot of every Repository page."
-msgstr ""
-
-#: src/repository/models.py:154
-msgid "If set to True, this will require all file uploads fromauthors to be PDF files."
-msgstr ""
-
-#: src/repository/models.py:350
-msgid "If this field is to be output as a dc metadata field you can addthe type here."
-msgstr ""
-
-#: src/repository/models.py:949
-#: src/templates/admin/submission/submit_review.html:101
-msgid "ORCID"
-msgstr ""
-
-#: src/repository/models.py:1209
-msgid "Approved"
-msgstr ""
-
-#: src/repository/models.py:1211
-msgid "Under Review"
-msgstr ""
-
-#: src/repository/models.py:1213 src/templates/admin/review/view_review.html:64
-msgid "Declined"
-msgstr ""
-
-#: src/repository/views.py:1076
-msgid "Author information saved"
-msgstr ""
-
-#: src/submission/models.py:1914
-msgid "Frozen Biography"
-msgstr ""
-
-#: src/submission/models.py:1915
-msgid "The author's biography at the time they published the linked article. For this article only, it overrides any main biography attached to the author's account. If Frozen Biography is left blank, any main biography for the account will be populated instead."
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_journal.html:58
-msgid "Support"
-msgstr ""
-
-#: src/templates/admin/elements/forms/group_journal.html:61
-msgid "How should editors and staff members get help with Janeway?"
-msgstr ""
-
-#: src/templates/admin/journal/manage/languages.html:21
-msgid "\n"
-"                 This interface allows you to override the press level languages and set the languages that are available for this journal.\n"
-"                 "
-msgstr ""
-
-#: src/templates/admin/repository/article.html:216
-#: src/templates/admin/repository/submit/authors.html:82
-msgid "Delete"
-msgstr ""
-
-#: src/templates/admin/repository/article.html:239
-#: src/templates/admin/repository/submit/authors.html:97
-msgid "No authors added."
-msgstr ""
-
-#: src/templates/admin/repository/edit_authors.html:28
-msgid "\n"
-"                            You can search for an existing author or add them using the form below. If you\n"
-"                            complete the form with an email address of an existing user, that user will be added\n"
-"                            to the"
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:8
-msgid "Add Authors to"
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:27
-msgid "You can add yourself as an author using the button below. This will copy metadata from your profile to create a"
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:27
-msgid "author record."
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:28
-msgid "You can search the database of existing authors and add them as authors."
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:29
-msgid "You can create a new record for an author using the form below."
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:45
-msgid "Search for an Author"
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:48
-msgid "You can search by email or ORCiD. eg. person@example.com or 0000-0003-2126-266X."
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:61
-msgid "Add an Author"
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:73
-msgid "You can reorder the authors by dragging and dropping rows in the table below."
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:103
-msgid "Once you have added all of your authors you can complete this stage."
-msgstr ""
-
-#: src/templates/admin/repository/submit/authors.html:106
-msgid "Complete Step 2 of 3"
-msgstr ""
-
-#: src/templates/admin/repository/submit/files.html:8
-msgid "Upload Files for"
-msgstr ""
-
-#: src/templates/admin/repository/submit/files.html:29
-msgid "You can use the form below to select and upload your manuscript file."
-msgstr ""
-
-#: src/templates/admin/repository/submit/files.html:32
-msgid "requires that all author uploads be PDF files."
-msgstr ""
-
-#: src/templates/admin/repository/submit/files.html:34
-msgid "You can upload a file in any format though PDF is recommended."
-msgstr ""
-
-#: src/templates/admin/repository/submit/files.html:47
-msgid "Supplementary files"
-msgstr ""
-
-#: src/templates/admin/repository/submit/files.html:50
-msgid "Optional links to externaly hosted supplementary files."
-msgstr ""
-
-#: src/templates/admin/repository/submit/files.html:51
-#: src/templates/admin/repository/submit/files.html:101
-#: src/templates/admin/repository/submit/files.html:108
-#: src/templates/admin/repository/supp_files_body.html:53
-msgid "Add New Supplementary File"
-msgstr ""
-
-#: src/templates/admin/repository/submit/files.html:60
-msgid "If you want to change this file you can upload a new one and it will be overwritten."
-msgstr ""
-
-#: src/templates/admin/repository/submit/files.html:93
-msgid "Complete Step 3 of 3"
-msgstr ""
-
-#: src/templates/admin/repository/submit/review.html:8
-msgid "Submission Complete"
-msgstr ""
-
-#: src/templates/admin/repository/submit/start.html:26
-msgid "Submission Agreement"
-msgstr ""
-
-#: src/templates/admin/repository/submit/start.html:94
-msgid "Complete Step 1 of 3"
-msgstr ""
-
-#: src/templates/admin/repository/version_queue.html:19
-msgid "The following updates are ready for moderation. By default the lists are show the oldest request first."
-msgstr ""
-
-#: src/templates/admin/submission/start.html:24
-msgid "All authors must agree to the below statements in order to submit an article to"
-msgstr ""
-
-#: src/templates/admin/submission/start.html:24
-msgid "If you do not agree with these terms you will be unable to proceed with your submission."
-msgstr ""
-
-#: src/themes/OLH/templates/500.html:29
-#: src/themes/material/templates/500.html:25
-msgid "A server error has occurred"
-msgstr ""
-
-#: src/themes/OLH/templates/repository/article.html:18
-msgid "This is a preprint, it has not been peer reviewed or had any extensive editorial over-sight."
-msgstr ""
-
-#: src/themes/clean/templates/500.html:27
-msgid "A server error has occurred."
-msgstr ""
-
-#: src/themes/material/templates/repository/home.html:34
-msgid "Start New Submission"
-msgstr ""
-
-#: src/themes/OLH/templates/repository/nav.html:6
-#: src/themes/material/templates/repository/nav.html:21
-#: src/themes/material/templates/repository/nav.html:45
-#: src/themes/material/templates/repository/preprint.html:168
-msgid "Subjects"
-msgstr ""
-
-#: src/themes/material/templates/repository/preprint.html:70
-msgid "Add a Comment"
-msgstr ""
-
-#: src/templates/admin/elements/submit/file.html:15
-#: src/themes/OLH/templates/elements/submit/file.html:11
-msgid "File types limited to Doc, Docx, RTF, and ODT."
-msgstr ""
-
-#: src/copyediting/forms.py:16
-msgid "Are you sure you want to create a copyediting assignment?"
-msgstr ""
-
-#: src/copyediting/forms.py:99
-msgid "Are you sure you want to ask the author to review copyedits?"
-msgstr ""
-
-#: src/copyediting/forms.py:146
-msgid "Are you sure you want to complete the copyedit task?"
-msgstr ""
-
-#: src/core/forms/forms.py:694
-msgid "Are you sure?"
-msgstr ""
-
-#: src/core/forms/forms.py:725
-msgid "The account belonging to %(email)s has not yet been activated, so the recipient of this assignment may not be able to log in and view it."
-msgstr ""
-
-#: src/core/janeway_global_settings.py:246
-msgid "English (GB)"
-msgstr ""
-
-#: src/core/janeway_global_settings.py:253
-msgid "English (US)"
-msgstr ""
-
-#: src/core/models.py:222
-msgid "Name suffix eg. jr"
-msgstr ""
-
-#: src/core/models.py:1150
-msgid "Other"
-msgstr ""
-
-#: src/core/models.py:1151
-msgid "Image"
-msgstr ""
-
-#. Translators: Search order options
-#: src/journal/forms.py:20
-msgid "Relevance"
-msgstr ""
-
-#: src/journal/forms.py:21 src/journal/views.py:2629
-msgid "Titles A-Z"
-msgstr ""
-
-#: src/journal/forms.py:22 src/journal/views.py:2630
-msgid "Titles Z-A"
-msgstr ""
-
-#: src/journal/forms.py:23 src/journal/views.py:2627
-msgid "Newest"
-msgstr ""
-
-#: src/journal/forms.py:24 src/journal/views.py:2628
-msgid "Oldest"
-msgstr ""
-
-#: src/journal/forms.py:97
-#: src/themes/clean/templates/core/homepage_elements/search_bar.html:20
-msgid "Search term"
-msgstr ""
-
-#: src/journal/forms.py:98
-msgid "Search Titles"
-msgstr ""
-
-#: src/journal/forms.py:99
-msgid "Search Abstract"
-msgstr ""
-
-#: src/journal/forms.py:100
-msgid "Search Authors"
-msgstr ""
-
-#: src/journal/forms.py:101
-msgid "Search Keywords"
-msgstr ""
-
-#: src/journal/forms.py:102
-msgid "Search Full Text"
-msgstr ""
-
-#: src/journal/forms.py:103
-msgid "Search ORCIDs"
-msgstr ""
-
-#: src/journal/forms.py:104 src/templates/common/elements/sorting.html:16
-#: src/themes/clean/templates/elements/sorting.html:17
-#: src/themes/material/templates/elements/sorting.html:31
-msgid "Sort results by"
-msgstr ""
-
-#: src/journal/models.py:98
-msgid "The default thumbnail for articles, not to be confused with 'Default cover image'."
-msgstr ""
-
-#: src/journal/models.py:106
-msgid "Replaces the press logo in the footer."
-msgstr ""
-
-#: src/journal/models.py:113
-msgid "The default cover image for journal issues and for the journal's listing on the press-level website."
-msgstr ""
-
-#: src/journal/models.py:121
-msgid "The default background image for article openers and carousel items."
-msgstr ""
-
-#: src/journal/models.py:129
-msgid "The logo-sized image at the top of all pages, typically used for journal logos."
-msgstr ""
-
-#: src/journal/models.py:137
-msgid "The tiny round or square image appearing in browser tabs before the webpage title"
-msgstr ""
-
-#: src/journal/models.py:148
-msgid "This field has been deprecated in v1.4.3"
-msgstr ""
-
-#: src/journal/models.py:220
-msgid "Whether to display article numbers. Article numbers are distinct from article ID and can be set in Edit Metadata."
-msgstr ""
-
-#: src/journal/models.py:573
-msgid "Autogenerated cache of the display format of an issue title"
-msgstr ""
-
-#: src/journal/models.py:588
-msgid "Image representing the cover of a printed issue or volume"
-msgstr ""
-
-#: src/journal/models.py:635
-msgid "An ISBN is relevant for non-serial collections such as conference proceedings"
-msgstr ""
-
-#: src/journal/models.py:734
-msgid "pages"
-msgstr ""
-
-#: src/journal/models.py:736
-msgid "page"
-msgstr ""
-
-#: src/journal/views.py:1009
-msgid "Issue not in this journal’s issue list."
-msgstr ""
-
-#: src/press/views.py:406
-msgid "Description deleted."
-msgstr ""
-
-#: src/press/views.py:419
-msgid "Description saved."
-msgstr ""
-
-#: src/review/forms.py:237
-msgid "Are you sure you want to request revisions?"
-msgstr ""
-
-#: src/review/forms.py:281
-msgid "Are you sure you want to complete the revision request?"
-msgstr ""
-
-#: src/review/forms.py:406
-msgid "Author can access this review"
-msgstr ""
-
-#: src/review/forms.py:407
-msgid "Author can access review file"
-msgstr ""
-
-#: src/review/forms.py:427
-msgid "Author can see ‘%(name)s’"
-msgstr ""
-
-#: src/review/models.py:137
-msgid "Anonimity"
-msgstr ""
-
-#: src/review/models.py:331
-msgid "available for the author to access"
-msgstr ""
-
-#: src/review/models.py:332
-msgid "not available for the author to access"
-msgstr ""
-
-#: src/review/views.py:1605
-msgid "This article has already been accepted or declined."
-msgstr ""
-
-#: src/submission/models.py:639
-msgid "Do not use--deprecated in version 1.4.1 and later."
-msgstr ""
-
-#: src/submission/models.py:780
-msgid "Original ISSN of this article's journal when published Only relevant for back content published under a different title"
-msgstr ""
-
-#: src/templates/admin/copyediting/author_review.html:86
-msgid "You can add a note to the editor. They can pass any requests on to the copyeditor."
-msgstr ""
-
-#: src/templates/admin/copyediting/author_review.html:92
-msgid "Complete Copyedit Task"
-msgstr ""
-
-#: src/templates/admin/core/manager/sections/section_list.html:26
-msgid "\n"
-"\t\t\t\t\t\t\t\t\tHere you can create and edit the sections that make up a typical issue. You can also think of these as article types, since authors will choose one on submission. To quickly re-order sections, drag and drop the \n"
-"\t\t\t\t\t\t\t\t\t"
-msgstr ""
-
-#: src/templates/admin/core/manager/sections/section_list.html:31
-msgid "\n"
-"\t\t\t\t\t\t\t\t\t\tThis will change the order that the author sees these on the submission page - so you may want to move the most popular or current sections to the top.\n"
-"\t\t\t\t\t\t\t\t\t"
-msgstr ""
+msgid ""
+"You cannot delete a Section that contains articles. Remove the articles from "
+"the section if you want to delete it."
+msgstr ""
+
+#: src/templates/admin/core/manager/users/list.html:16
+#, fuzzy
+#| msgid "Journals"
+msgid "Journal Users"
+msgstr "Revistas"
+
+#: src/templates/admin/core/manager/users/list.html:18
+#, fuzzy
+#| msgid "All Preprints"
+msgid "All Users"
+msgstr "Todos los Preprints"
+
+#: src/templates/admin/core/manager/users/list.html:40
+#, fuzzy
+#| msgid "Username"
+msgid "Users"
+msgstr "Nombre de usuario"
+
+#: src/templates/admin/core/manager/users/list.html:70
+#, fuzzy
+#| msgid "No articles to display."
+msgid "No accounts to display."
+msgstr "No hay artículos para mostrar."
 
 #: src/templates/admin/core/request_submission_access.html:14
 msgid "requires that you request permission to make a submission."
@@ -3621,6 +1662,67 @@ msgstr ""
 #: src/templates/admin/core/request_submission_access.html:33
 msgid "You have an active access request that was submitted on: "
 msgstr ""
+
+#: src/templates/admin/elements/accounts/user_form.html:4
+#: src/templates/admin/repository/article.html:212
+#: src/templates/admin/repository/author_article.html:91
+#: src/templates/admin/repository/submit/authors.html:76
+#: src/templates/admin/submission/submit_authors.html:69
+#: src/templates/admin/submission/submit_funding.html:72
+#: src/templates/common/elements/funder_info_for_readers.html:4
+msgid "Name"
+msgstr "Nombre"
+
+#: src/templates/admin/elements/accounts/user_form.html:13
+#, fuzzy
+#| msgid "Affiliation"
+msgid "Affiliations"
+msgstr "Afiliación"
+
+#: src/templates/admin/elements/accounts/user_form.html:20
+#: src/themes/OLH/templates/elements/accounts/user_form.html:41
+#: src/themes/clean/templates/elements/accounts/user_form.html:38
+#: src/themes/material/templates/elements/accounts/user_form.html:39
+msgid "Social Media and Accounts"
+msgstr "Redes sociales y cuentas"
+
+#: src/templates/admin/elements/accounts/user_form.html:30
+#: src/themes/OLH/templates/elements/accounts/user_form.html:65
+#: src/themes/clean/templates/elements/accounts/user_form.html:62
+#: src/themes/material/templates/elements/accounts/user_form.html:63
+msgid "Biography and Signature"
+msgstr "Biografia y firma"
+
+#: src/templates/admin/elements/accounts/user_form.html:40
+#: src/templates/admin/elements/accounts/user_form.html:43
+#: src/themes/OLH/templates/elements/accounts/user_form.html:74
+#: src/themes/clean/templates/elements/accounts/user_form.html:71
+#: src/themes/material/templates/elements/accounts/user_form.html:72
+msgid "Review Interests"
+msgstr "Revisar los intereses"
+
+#: src/templates/admin/elements/accounts/user_form.html:50
+#: src/themes/OLH/templates/elements/accounts/user_form.html:75
+#: src/themes/clean/templates/elements/accounts/user_form.html:72
+#: src/themes/material/templates/elements/accounts/user_form.html:73
+msgid "Hit Enter to add a new interest"
+msgstr "Pulsa Enter para añadir un nuevo interés."
+
+#: src/templates/admin/elements/accounts/user_form.html:53
+#: src/themes/OLH/templates/elements/accounts/user_form.html:79
+#: src/themes/clean/templates/elements/accounts/user_form.html:76
+#: src/themes/material/templates/elements/accounts/user_form.html:77
+msgid "Profile Image"
+msgstr ""
+
+#: src/templates/admin/elements/accounts/user_form.html:69
+#: src/themes/OLH/templates/elements/accounts/user_form.html:95
+#: src/themes/OLH/templates/journal/article.html:107
+#: src/themes/OLH/templates/journal/article.html:108
+#: src/themes/clean/templates/elements/accounts/user_form.html:92
+#: src/themes/material/templates/elements/accounts/user_form.html:93
+msgid "Options"
+msgstr "Opciones"
 
 #: src/templates/admin/elements/confirm_modal.html:7
 #: src/templates/admin/elements/review/draft_decisions_js.html:13
@@ -3641,24 +1743,167 @@ msgstr ""
 msgid "No, go back"
 msgstr ""
 
+#: src/templates/admin/elements/forms/field.html:13
+msgid "translatable"
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_article.html:5
+msgid "A set of controls for how things display on the article page"
+msgstr ""
+
 #: src/templates/admin/elements/forms/group_article.html:19
-msgid "Settings to control the display of view and download links on article pages"
+msgid ""
+"Settings to control the display of view and download links on article pages"
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_journal_images.html:10
-msgid "For details about where each image appears, see the Janeway documentation: "
+#: src/templates/admin/elements/forms/group_article.html:28
+msgid ""
+"If you don't want to display metrics you can disable them all, or you can "
+"disable the display of citation metrics below"
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_review.html:41
+#: src/templates/admin/elements/forms/group_article.html:37
+msgid "Enable the display of the dates an article was submitted and accepted."
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_journal.html:32
+msgid ""
+"You can set the from address your journal will use to send emails and the "
+"base signature that will be included."
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_journal.html:42
+msgid ""
+"Where you have a journal in your press that is not hosted on Janeway you can "
+"link directly to the journal and submit pages."
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_journal.html:49
+msgid "Slack/Discord Integration"
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_journal.html:52
+msgid ""
+"You can integrate Janeway into Slack (and Discord as they support the same "
+"endpoints) by setting it up below."
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_journal.html:58
+msgid "Support"
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_journal.html:61
+msgid "How should editors and staff members get help with Janeway?"
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_journal_images.html:11
+msgid ""
+"For details about where each image appears, see the Janeway documentation: "
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_journal_news.html:5
+msgid "You can use this setting to overwrite the title of the news section."
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_review.html:5
+msgid ""
+"You can set review file guidance and default review settings below. Review "
+"forms can be managed in the"
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_review.html:5
+msgid "Review Form manager"
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_review.html:28
+msgid "Settings here determine the review form experience."
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_review.html:40
 msgid "Settings here determine the review experience for editors."
 msgstr ""
 
+#: src/templates/admin/elements/forms/group_review.html:48
+msgid "Settings here determine the review experience for authors."
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_styling.html:3
+msgid "Full Width Navbar only applies to the Material theme"
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_submission.html:41
+msgid ""
+"The text below make up the Submission page as well as the Submission "
+"Agreement that authors accept."
+msgstr ""
+
+#: src/templates/admin/elements/forms/messages_in_callout.html:11
+msgid "Problems processing the form"
+msgstr ""
+
+#: src/templates/admin/elements/fundref/fundref.html:22
+msgid "Funder"
+msgstr ""
+
+#: src/templates/admin/elements/fundref/fundref.html:23
+#: src/templates/admin/submission/submit_funding.html:73
+#: src/templates/common/elements/funder_info_for_readers.html:5
+msgid "FundRef ID"
+msgstr ""
+
+#: src/templates/admin/elements/fundref/fundref.html:24
+#, fuzzy
+#| msgid "Add File"
+msgid "Add Funder"
+msgstr "Agregar archivo"
+
+#: src/templates/admin/elements/fundref/fundref.html:39
+#: src/templates/admin/submission/submit_funding.html:121
+#: src/templates/admin/submission/submit_funding.html:128
+msgid "Add funder"
+msgstr ""
+
+#: src/templates/admin/elements/history_modal.html:8
+msgid "History"
+msgstr ""
+
 #: src/templates/admin/elements/issue/sort_toc.html:6
-msgid "You can automatically sort the articles in your issue by Title (Alphabetically) or by date published using the form below. Note, this will not affect the order of the Sections (Article Types)"
+msgid ""
+"You can automatically sort the articles in your issue by Title "
+"(Alphabetically) or by date published using the form below. Note, this will "
+"not affect the order of the Sections (Article Types)"
 msgstr ""
 
 #: src/templates/admin/elements/issue/sort_toc.html:17
 msgid "Sort Articles"
+msgstr ""
+
+#: src/templates/admin/elements/list_filters.html:7
+#, fuzzy
+#| msgid "Clear Filters"
+msgid "Search and filter"
+msgstr "Borrar filtros"
+
+#: src/templates/admin/elements/list_filters.html:28
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
+msgid "Apply"
+msgstr ""
+
+#: src/templates/admin/elements/list_filters.html:32
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:10
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:11
+#: src/themes/material/templates/elements/journal/article_list_filters.html:15
+#, fuzzy
+#| msgid "Clear Filters"
+msgid "Clear all"
+msgstr "Borrar filtros"
+
+#: src/templates/admin/elements/metadata.html:143
+#: src/templates/admin/submission/edit/metadata.html:244
+#: src/templates/admin/submission/submit_funding.html:75
+#: src/templates/common/elements/funder_info_for_readers.html:7
+msgid "Funding Statement"
 msgstr ""
 
 #: src/templates/admin/elements/move_to_next_modal.html:7
@@ -3677,28 +1922,151 @@ msgstr ""
 msgid "Not right now"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:24
+#: src/templates/admin/elements/publisher_notes.html:34
+msgid "Add A Publisher Note"
+msgstr "Añadir una nota editorial"
+
+#: src/templates/admin/elements/publisher_notes.html:43
+msgid "Add Publisher Note"
+msgstr "Añadir nota editorial"
+
+#: src/templates/admin/elements/publisher_notes.html:54
+msgid "Edit A Publisher Note"
+msgstr "Editar una nota editoral"
+
+#: src/templates/admin/elements/publisher_notes.html:63
+msgid "Save Publisher Note"
+msgstr "Guardar nota editorial"
+
+#: src/templates/admin/elements/repository/metadata_form.html:39
+#: src/templates/admin/repository/submit/start.html:71 src/utils/forms.py:60
+msgid "Hit Enter to add a new keyword."
+msgstr "Presione Entrar para agregar una nueva palabra clave."
+
+#: src/templates/admin/elements/repository/metadata_form.html:50
+#: src/templates/admin/elements/submission/additional_fields.html:4
+msgid "Additional Fields"
+msgstr "Campos Adicionales"
+
+#: src/templates/admin/elements/submit/author.html:8
+#: src/templates/admin/repository/submit/authors.html:62
+#: src/templates/admin/repository/submit/authors.html:113
+#: src/templates/admin/repository/submit/authors.html:120
+#: src/templates/admin/submission/submit_authors.html:54
+#: src/themes/OLH/templates/elements/submit/author.html:8
+msgid "Add New Author"
+msgstr "Añadir nuevo autor"
+
+#: src/templates/admin/elements/submit/author.html:64
+#: src/themes/OLH/templates/elements/submit/author.html:64
+msgid "Add Author"
+msgstr "Añadir autor"
+
+#: src/templates/admin/elements/submit/file.html:9
+#: src/themes/OLH/templates/elements/submit/file.html:6
+#: src/themes/OLH/templates/elements/submit/preprint_file.html:6
+msgid "Add New File"
+msgstr "Agregar nuevo archivo"
+
+#: src/templates/admin/elements/submit/file.html:33
+#: src/themes/OLH/templates/elements/submit/file.html:25
+#: src/themes/OLH/templates/elements/submit/preprint_file.html:25
+msgid "Add File"
+msgstr "Agregar archivo"
+
+#: src/templates/admin/hijack/notification.html:5
+#, python-format
+msgid "You are currently working on behalf of %(user)s."
+msgstr ""
+
+#: src/templates/admin/hijack/notification.html:9
+#, python-format
+msgid "release %(user)s"
+msgstr ""
+
+#: src/templates/admin/journal/contact.html:18
+#: src/themes/OLH/templates/journal/contact.html:12
+#: src/themes/material/templates/journal/contact.html:14
+msgid "Journal Representatives"
+msgstr "Representantes de la revista"
+
+#: src/templates/admin/journal/contact.html:20
+#: src/themes/OLH/templates/journal/contact.html:14
+#: src/themes/OLH/templates/press/journal/contact.html:11
+#: src/themes/material/templates/journal/contact.html:16
+msgid "Press Representatives"
+msgstr "Representantes editoriales"
+
+#: src/templates/admin/journal/contact.html:27
+#: src/themes/OLH/templates/journal/contact.html:21
+#: src/themes/clean/templates/journal/contact.html:16
+#: src/themes/material/templates/journal/contact.html:25
+msgid "Contact Information"
+msgstr "Información de contacto"
+
+#: src/templates/admin/journal/contact.html:32
+#: src/themes/OLH/templates/core/nav.html:41
+#: src/themes/OLH/templates/elements/journal_footer.html:29
+#: src/themes/OLH/templates/journal/contact.html:5
+#: src/themes/OLH/templates/journal/contact.html:26
+#: src/themes/OLH/templates/press/elements/press_footer.html:14
+#: src/themes/OLH/templates/press/journal/contact.html:5
+#: src/themes/OLH/templates/press/journal/contact.html:18
+#: src/themes/OLH/templates/press/nav.html:40
+#: src/themes/clean/templates/core/nav.html:68
+#: src/themes/clean/templates/elements/journal_footer.html:39
+#: src/themes/clean/templates/elements/press_footer.html:17
+#: src/themes/clean/templates/journal/article.html:60
+#: src/themes/clean/templates/journal/contact.html:5
+#: src/themes/clean/templates/journal/contact.html:21
+#: src/themes/clean/templates/press/nav.html:53
+#: src/themes/hourglass/templates/press/contact.html:4
+#: src/themes/material/templates/core/nav.html:42
+#: src/themes/material/templates/core/nav.html:103
+#: src/themes/material/templates/journal/contact.html:5
+#: src/themes/material/templates/journal/contact.html:37
+#: src/themes/material/templates/press/nav.html:52
+#: src/themes/material/templates/press/nav.html:102
+msgid "Contact"
+msgstr "Contacto"
+
+#: src/templates/admin/journal/contact.html:52
+#: src/themes/OLH/templates/journal/contact.html:39
+#: src/themes/OLH/templates/press/journal/contact.html:30
+#: src/themes/clean/templates/journal/contact.html:37
+#: src/themes/material/templates/journal/contact.html:45
+msgid "Send Message"
+msgstr "Enviar mensaje"
+
+#: src/templates/admin/journal/manage/archive_article.html:25
 msgid "Edit Article Images"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:26
+#: src/templates/admin/journal/manage/archive_article.html:27
 msgid "Edit Publication Info"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:28
+#: src/templates/admin/journal/manage/archive_article.html:29
 msgid "Remote Article View"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:178
+#: src/templates/admin/journal/manage/archive_article.html:179
 msgid "Undo Article Rejection"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:184
+#: src/templates/admin/journal/manage/archive_article.html:183
+msgid "Review"
+msgstr "Revisión"
+
+#: src/templates/admin/journal/manage/archive_article.html:185
 msgid "Unassigned"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:186
-msgid "You will have the opportunity to send an email to the author, and then the article will move back to the %(stage)s stage."
+#: src/templates/admin/journal/manage/archive_article.html:187
+#, python-format
+msgid ""
+"You will have the opportunity to send an email to the author, and then the "
+"article will move back to the %(stage)s stage."
 msgstr ""
 
 #: src/templates/admin/journal/manage/issues.html:86
@@ -3709,9 +2077,74 @@ msgstr ""
 msgid "Issue is already set as the current issue."
 msgstr ""
 
+#: src/templates/admin/journal/manage/languages.html:21
+msgid ""
+"\n"
+"                 This interface allows you to override the press level "
+"languages and set the languages that are available for this journal.\n"
+"                 "
+msgstr ""
+
+#: src/templates/admin/journal/submissions.html:36
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/themes/OLH/templates/core/base.html:142
+#: src/themes/OLH/templates/core/login.html:6
+#: src/themes/OLH/templates/core/nav.html:75
+#: src/themes/OLH/templates/elements/journal_footer.html:30
+#: src/themes/OLH/templates/journal/become_reviewer.html:16
+#: src/themes/OLH/templates/journal/submissions.html:31
+#: src/themes/OLH/templates/press/core/login.html:5
+#: src/themes/OLH/templates/press/elements/press_footer.html:15
+#: src/themes/OLH/templates/press/nav.html:57
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:23
+#: src/themes/clean/templates/core/login.html:5
+#: src/themes/clean/templates/core/nav.html:103
+#: src/themes/clean/templates/elements/journal_footer.html:43
+#: src/themes/clean/templates/elements/press_footer.html:19
+#: src/themes/clean/templates/journal/become_reviewer.html:13
+#: src/themes/clean/templates/journal/submissions.html:18
+#: src/themes/clean/templates/press/nav.html:77
+#: src/themes/hourglass/templates/core/accounts/login.html:11
+#: src/themes/material/templates/core/login.html:5
+#: src/themes/material/templates/core/login.html:42
+#: src/themes/material/templates/core/nav.html:78
+#: src/themes/material/templates/core/nav.html:133
+#: src/themes/material/templates/journal/become_reviewer.html:16
+#: src/themes/material/templates/journal/submissions.html:34
+#: src/themes/material/templates/press/nav.html:66
+#: src/themes/material/templates/press/nav.html:114
+#: src/themes/material/templates/repository/nav.html:59
+msgid "Login"
+msgstr "Iniciar sesión"
+
+#: src/templates/admin/journal/submissions.html:38
+#: src/templates/admin/submission/start.html:77
+#: src/themes/OLH/templates/core/nav.html:43
+#: src/themes/OLH/templates/journal/submissions.html:32
+#: src/themes/clean/templates/core/nav.html:71
+#: src/themes/clean/templates/journal/submissions.html:19
+#: src/themes/material/templates/journal/submissions.html:35
+msgid "Start Submission"
+msgstr "Comenzar un artículo"
+
 #: src/templates/admin/journal/submissions.html:40
 msgid "Contact Us"
 msgstr ""
+
+#: src/templates/admin/journal/submissions.html:47
+#: src/themes/OLH/templates/journal/submissions.html:39
+msgid "Licences"
+msgstr "Licencias"
+
+#: src/templates/admin/journal/submissions.html:48
+#: src/templates/admin/submission/submit_info.html:109
+#: src/themes/OLH/templates/journal/submissions.html:40
+#: src/themes/clean/templates/journal/submissions.html:27
+#: src/themes/material/templates/journal/submissions.html:46
+#, fuzzy
+#| msgid "allows the following licences for submission"
+msgid "The following licences are allowed:"
+msgstr "Permite las siguientes licencias para su presentación."
 
 #: src/templates/admin/press/edit_press_journal_description.html:5
 #: src/templates/admin/press/edit_press_journal_description.html:6
@@ -3720,21 +2153,254 @@ msgstr ""
 
 #: src/templates/admin/press/edit_press_journal_description.html:11
 #: src/templates/admin/press/edit_press_journal_description.html:17
+#: src/templates/admin/repository/article.html:215
+#: src/templates/admin/review/unassigned_article.html:120
+#: src/templates/admin/review/view_review.html:112
+#: src/templates/admin/submission/submit_funding.html:76
+#: src/themes/OLH/templates/elements/edit_author.html:4
+msgid "Edit"
+msgstr ""
+
+#: src/templates/admin/press/edit_press_journal_description.html:11
+#: src/templates/admin/press/edit_press_journal_description.html:17
 msgid "'s Description for Press Site"
 msgstr ""
 
 #: src/templates/admin/press/edit_press_journal_description.html:20
-msgid "Here you can add a press-specific description of the journal that will be used on the journal list page. If this is left empty, the journal's main description is used."
-msgstr ""
-
-#: src/templates/admin/press/edit_press_journal_description.html:24
-#: src/templates/admin/review/view_review.html:168
-#: src/templates/admin/review/view_review.html:189
-msgid "Save"
+msgid ""
+"Here you can add a press-specific description of the journal that will be "
+"used on the journal list page. If this is left empty, the journal's main "
+"description is used."
 msgstr ""
 
 #: src/templates/admin/press/edit_press_journal_description.html:25
 msgid "Clear Description"
+msgstr ""
+
+#: src/templates/admin/proofing/proofing_article.html:272
+msgid "Each proofing round is limited to"
+msgstr ""
+
+#: src/templates/admin/proofing/proofing_article.html:272
+msgid "proofreaders"
+msgstr ""
+
+#: src/templates/admin/repository/article.html:214
+#: src/templates/admin/repository/author_article.html:93
+#: src/templates/admin/repository/submit/authors.html:78
+#: src/templates/admin/submission/submit_review.html:118
+#: src/themes/OLH/templates/core/accounts/public_profile.html:42
+#: src/themes/clean/templates/core/accounts/public_profile.html:18
+#: src/themes/material/templates/core/accounts/public_profile.html:18
+msgid "Affiliation"
+msgstr "Afiliación"
+
+#: src/templates/admin/repository/article.html:216
+#: src/templates/admin/repository/submit/authors.html:79
+#: src/templates/admin/submission/submit_funding.html:77
+msgid "Delete"
+msgstr ""
+
+#: src/templates/admin/repository/article.html:239
+#: src/templates/admin/repository/submit/authors.html:94
+msgid "No authors added."
+msgstr ""
+
+#: src/templates/admin/repository/edit_authors.html:28
+msgid ""
+"\n"
+"                            You can search for an existing author or add "
+"them using the form below. If you\n"
+"                            complete the form with an email address of an "
+"existing user, that user will be added\n"
+"                            to the"
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:8
+msgid "Add Authors to"
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:20
+#: src/themes/clean/templates/journal/article.html:219
+msgid "Information"
+msgstr "Información"
+
+#: src/templates/admin/repository/submit/authors.html:24
+msgid ""
+"You can add yourself as an author using the button below. This will copy "
+"metadata from your profile to create a"
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:24
+msgid "author record."
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:25
+msgid ""
+"You can search the database of existing authors and add them as authors."
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:26
+msgid "You can create a new record for an author using the form below."
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:31
+#: src/templates/admin/submission/submit_authors.html:51
+msgid "Add Self as Author"
+msgstr "Añadirme como autor"
+
+#: src/templates/admin/repository/submit/authors.html:34
+#: src/templates/admin/submission/submit_authors.html:49
+msgid ""
+"By default, your account is the owner of this submission, but is not an "
+"Author on record. You can add yourself using the button below."
+msgstr ""
+"De manera predeterminada, su cuenta es el propietario de este envío, pero no "
+"es un Autor registrado. Puedes agregarte usando el botón de abajo."
+
+#: src/templates/admin/repository/submit/authors.html:42
+msgid "Search for an Author"
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:45
+msgid ""
+"You can search by email or ORCiD. eg. person@example.com or "
+"0000-0003-2126-266X."
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:58
+msgid "Add an Author"
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/submission/submit_authors.html:53
+msgid ""
+"If you cannot find the author record by searching, and you are not the only "
+"author, you can add one by clicking the button below. This will open a popup "
+"modal for you to complete their details."
+msgstr ""
+"Si no puede encontrar el registro de autor mediante la búsqueda y no es el "
+"único autor, puede agregar uno haciendo clic en el botón de abajo. Esto "
+"abrirá un menú emergente para que complete sus detalles."
+
+#: src/templates/admin/repository/submit/authors.html:67
+#: src/themes/OLH/templates/journal/article.html:27
+#: src/themes/OLH/templates/journal/article.html:63
+#: src/themes/OLH/templates/journal/article.html:161
+#: src/themes/OLH/templates/journal/article.html:313
+#: src/themes/OLH/templates/journal/authors.html:4
+#: src/themes/OLH/templates/journal/authors.html:5
+#: src/themes/OLH/templates/journal/authors.html:11
+#: src/themes/OLH/templates/journal/print.html:15
+#: src/themes/OLH/templates/repository/preprint.html:33
+#: src/themes/clean/templates/journal/article.html:37
+#: src/themes/clean/templates/journal/article.html:153
+#: src/themes/clean/templates/journal/authors.html:9
+#: src/themes/clean/templates/journal/print.html:15
+#: src/themes/material/templates/journal/article.html:250
+#: src/themes/material/templates/journal/authors.html:5
+#: src/themes/material/templates/journal/authors.html:6
+#: src/themes/material/templates/journal/authors.html:10
+#: src/themes/material/templates/preprints/article.html:28
+#: src/themes/material/templates/repository/preprint.html:147
+msgid "Authors"
+msgstr "Autores"
+
+#: src/templates/admin/repository/submit/authors.html:70
+msgid ""
+"You can reorder the authors by dragging and dropping rows in the table below."
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:100
+msgid "Once you have added all of your authors you can complete this stage."
+msgstr ""
+
+#: src/templates/admin/repository/submit/authors.html:103
+msgid "Complete Step 2 of 4"
+msgstr ""
+
+#: src/templates/admin/repository/submit/files.html:8
+msgid "Upload Files for"
+msgstr ""
+
+#: src/templates/admin/repository/submit/files.html:25
+msgid "You can use the form below to select and upload your manuscript file."
+msgstr ""
+
+#: src/templates/admin/repository/submit/files.html:43
+msgid "Supplementary files"
+msgstr ""
+
+#: src/templates/admin/repository/submit/files.html:46
+msgid "Optional links to externaly hosted supplementary files."
+msgstr ""
+
+#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:97
+#: src/templates/admin/repository/submit/files.html:104
+#: src/templates/admin/repository/supp_files_body.html:53
+msgid "Add New Supplementary File"
+msgstr ""
+
+#: src/templates/admin/repository/submit/files.html:56
+msgid ""
+"If you want to change this file you can upload a new one and it will be "
+"overwritten."
+msgstr ""
+
+#: src/templates/admin/repository/submit/files.html:89
+msgid "Complete Step 3 of 4"
+msgstr ""
+
+#: src/templates/admin/repository/submit/files.html:116
+msgid "Submission Information"
+msgstr ""
+
+#: src/templates/admin/repository/submit/start.html:24
+msgid "Submission Agreement"
+msgstr ""
+
+#: src/templates/admin/repository/submit/start.html:36
+#: src/themes/OLH/templates/repository/preprint.html:122
+#: src/themes/material/templates/preprints/article.html:121
+msgid "Metadata"
+msgstr "Metadatos"
+
+#: src/templates/admin/repository/submit/start.html:92
+msgid "Complete Step 1 of 4"
+msgstr ""
+
+#: src/templates/admin/repository/version_queue.html:19
+msgid ""
+"The following updates are ready for moderation. By default the lists are "
+"show the oldest request first."
+msgstr ""
+
+#: src/templates/admin/review/add_review_assignment.html:27
+msgid ""
+"\n"
+"                                You can select a reviewer using the radio\n"
+"                                buttons in the first column and complete "
+"the\n"
+"                                section under 'Set Options'.\n"
+"                                If you cannot find the reviewer you want in\n"
+"                                this list you can use 'Enroll Existing User' "
+"to\n"
+"                                search the database and give users the "
+"Reviewer\n"
+"                                role, or 'Add New Reviewer' to create a new\n"
+"                                account for a reviewer (this process is "
+"silent,\n"
+"                                so they will not receive an account "
+"creation\n"
+"                                email).\n"
+"                            "
+msgstr ""
+
+#: src/templates/admin/review/decision.html:57
+msgid ""
+"Note: This article has completed reviews that have not been made available "
+"to the author:"
 msgstr ""
 
 #: src/templates/admin/review/decision_helper.html:101
@@ -3748,28 +2414,132 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:68
-msgid "\n"
-"                                            These files are the versions sent out to reviewers in Round %(round.round_number)s of review.\n"
+#: src/templates/admin/review/in_review.html:23
+msgid "This article is not yet in the review stage"
+msgstr ""
+
+#: src/templates/admin/review/in_review.html:25
+msgid "Before you can move this paper into review you need to"
+msgstr ""
+
+#: src/templates/admin/review/in_review.html:26
+msgid "assign an editor"
+msgstr ""
+
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
+msgid ""
+"This paper has not had an automatic plagiarism check. If you wish to do so "
+"you can run a"
+msgstr ""
+
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
+msgid "Similarity Check via iThenticate"
+msgstr ""
+
+#: src/templates/admin/review/in_review.html:66
+#, python-format
+msgid ""
+"\n"
+"                                            These files are the versions "
+"sent out to reviewers in Round %(round.round_number)s of review.\n"
 "                                            "
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:217
-msgid "\n"
-"                                The latest manuscript and figure files for this article. When a revision task is completed these will be updated with the latest versions from the authors.\n"
+#: src/templates/admin/review/in_review.html:215
+msgid ""
+"\n"
+"                                The latest manuscript and figure files for "
+"this article. When a revision task is completed these will be updated with "
+"the latest versions from the authors.\n"
 "                                "
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:287
+#: src/templates/admin/review/in_review.html:285
 msgid "Move to Next Stage"
 msgstr ""
 
+#: src/templates/admin/review/projected_issue.html:27
+msgid "Save Projected Issue"
+msgstr ""
+
+#: src/templates/admin/review/projected_issue.html:37
+msgid "What is this for?"
+msgstr ""
+
+#: src/templates/admin/review/projected_issue.html:38
+msgid ""
+"The projected issue field can be used internally to keep track of plans and "
+"communicate with typesetters, without affecting issue assignment or "
+"displaying anything publicly. It is helpful for journals that add articles "
+"to issues on a rolling basis and publish them individually."
+msgstr ""
+
+#: src/templates/admin/review/projected_issue.html:39
+msgid ""
+"You can assign articles directly to issues in the prepublication stage or "
+"through "
+msgstr ""
+
+#: src/templates/admin/review/projected_issue.html:39
+msgid "issue management"
+msgstr ""
+
+#: src/templates/admin/review/projected_issue.html:40
+msgid "How does it work?"
+msgstr ""
+
+#: src/templates/admin/review/projected_issue.html:41
+msgid ""
+"Select an issue from the drop down on the left and press save. This "
+"article's projected issue will now be set."
+msgstr ""
+
+#: src/templates/admin/review/projected_issue.html:42
+msgid "Can I unset a projected issue?"
+msgstr ""
+
+#: src/templates/admin/review/projected_issue.html:43
+msgid "Yes, you can select the blank option (-------) from the dropdown."
+msgstr ""
+
 #: src/templates/admin/review/revision/do_revision.html:125
-msgid "When you have completed your revisions and finished writing your covering letter, click the 'Submit Revisions' button below to finish. Please note that you will not be able to make any further changes to your letter or revisions once you click 'Submit Revisions'"
+msgid ""
+"When you have completed your revisions and finished writing your covering "
+"letter, click the 'Submit Revisions' button below to finish. Please note "
+"that you will not be able to make any further changes to your letter or "
+"revisions once you click 'Submit Revisions'"
+msgstr ""
+
+#: src/templates/admin/review/unassigned_article.html:120
+msgid "Assign"
+msgstr ""
+
+#: src/templates/admin/review/unassigned_article.html:120
+msgid "Projected Issue"
+msgstr ""
+
+#: src/templates/admin/review/unassigned_article.html:125
+msgid "This article is projected to be published as part of"
+msgstr ""
+
+#: src/templates/admin/review/unassigned_article.html:127
+msgid "This article is not projected to be published as part of any issue."
+msgstr ""
+
+#: src/templates/admin/review/unassigned_article.html:140
+msgid ""
+"To check an article for possible plagiarism, you can send an article for an "
+"automated Similarity Check via iThenticate by clicking Send below. The "
+"report then takes a few minutes to be generated, so refresh this page; "
+"results will be displayed under Similarity Check when ready."
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:22
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                        Review #%(review_id)s by %(reviewer_full_name)s\n"
 "                    "
 msgstr ""
@@ -3779,17 +2549,24 @@ msgid "Edit in Admin"
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:36
-msgid "\n"
-"                        You can make this review available for the author to see using\n"
-"                        the <em>Review Availability Controls</em> below. You can also\n"
-"                        make individual review elements hidden or available.\n"
+msgid ""
+"\n"
+"                        You can make this review available for the author to "
+"see using\n"
+"                        the <em>Review Availability Controls</em> below. You "
+"can also\n"
+"                        make individual review elements hidden or "
+"available.\n"
 "                    "
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:43
-msgid "\n"
-"                        If you need to make changes to the review you can do so by\n"
-"                        using the <em>Edit</em> button below each form element\n"
+msgid ""
+"\n"
+"                        If you need to make changes to the review you can do "
+"so by\n"
+"                        using the <em>Edit</em> button below each form "
+"element\n"
 "                    "
 msgstr ""
 
@@ -3814,11 +2591,7 @@ msgid "Access Code"
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:55
-msgid "Decision"
-msgstr ""
-
-#: src/templates/admin/review/view_review.html:56
-msgid "Completed"
+msgid "Recommendation"
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:58
@@ -3828,6 +2601,10 @@ msgstr ""
 #: src/templates/admin/review/view_review.html:62
 msgid "Withdrawn"
 msgstr ""
+
+#: src/templates/admin/review/view_review.html:63
+msgid "Accepted"
+msgstr "Aceptado"
 
 #: src/templates/admin/review/view_review.html:65
 msgid "Awaiting acknowledgement"
@@ -3866,9 +2643,13 @@ msgid "Review Visibility"
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:160
-msgid "\n"
-"                                            Currently this review is %(visibility_statement)s. Note that the author\n"
-"                                            must have access to the review before they can access the review file.\n"
+#, python-format
+msgid ""
+"\n"
+"                                            Currently this review is "
+"%(visibility_statement)s. Note that the author\n"
+"                                            must have access to the review "
+"before they can access the review file.\n"
 "                                        "
 msgstr ""
 
@@ -3877,10 +2658,14 @@ msgid "Answer Visibility"
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:177
-msgid "\n"
-"                                                The toggles below control the visibility of the individual review form\n"
-"                                                answers. Note that changing these will have no effect unless the Review is\n"
-"                                                marked as visible to the author using the <em>Author can access this review</em>\n"
+msgid ""
+"\n"
+"                                                The toggles below control "
+"the visibility of the individual review form\n"
+"                                                answers. Note that changing "
+"these will have no effect unless the Review is\n"
+"                                                marked as visible to the "
+"author using the <em>Author can access this review</em>\n"
 "                                                toggle above.\n"
 "                                            "
 msgstr ""
@@ -3889,396 +2674,492 @@ msgstr ""
 msgid "Suggested Reviewers"
 msgstr ""
 
-#: src/templates/admin/submission/edit/metadata.html:178
-msgid "\n"
-"                            You can search the <a href=\"https://www.crossref.org/services/funder-registry/\">\n"
-"                            Crossref Funder Registry</a> to add known funders.\n"
+#: src/templates/admin/submission/edit/metadata.html:195
+msgid ""
+"\n"
+"                            You can search the <a href=\"https://www."
+"crossref.org/services/funder-registry/\">\n"
+"                            Crossref Funder Registry</a> to add known "
+"funders.\n"
 "                        "
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:24
-msgid "Please review your submission use the details below. If you need to make changes use the links above to move back along the submission steps. You must click the Complete Submission button at the foot of this page to complete the submission process, you will then receive a receipt email. "
+#: src/templates/admin/submission/manager/delete_license.html:25
+msgid ""
+"This license is currently used by the following articles. If you delete it "
+"these articles will no longer have a license listed."
 msgstr ""
+
+#: src/templates/admin/submission/manager/delete_license.html:26
+msgid ""
+"You should only delete this license if you are absolutely sure you want to "
+"remove it."
+msgstr ""
+
+#: src/templates/admin/submission/start.html:7
+msgid "Submit an Article"
+msgstr "Enviar un artículo"
+
+#: src/templates/admin/submission/start.html:9
+msgid "Author Agreement"
+msgstr "Acuerdo de Autor"
+
+#: src/templates/admin/submission/start.html:11
+msgid ""
+"Please carefully read through the statements below before checking items"
+msgstr ""
+"Lea atentamente las declaraciones a continuación antes de revisar los "
+"artículos"
+
+#: src/templates/admin/submission/start.html:29
+msgid ""
+"All authors must agree to the below statements in order to submit an article "
+"to"
+msgstr ""
+
+#: src/templates/admin/submission/start.html:29
+msgid ""
+"If you do not agree with these terms you will be unable to proceed with your "
+"submission."
+msgstr ""
+
+#: src/templates/admin/submission/start.html:34
+msgid "Publication Fees"
+msgstr "Tasas de publicación"
+
+#: src/templates/admin/submission/start.html:41
+msgid "Author(s) agrees to the above statement"
+msgstr "Autor (es) está de acuerdo con la declaración anterior"
+
+#: src/templates/admin/submission/start.html:47
+msgid "Submission Checklist"
+msgstr "Lista de verificación de envío"
+
+#: src/templates/admin/submission/start.html:53
+msgid "Author(s) confirms that this article adheres to the above requirements"
+msgstr ""
+"Autor (es) confirma que este artículo cumple con los requisitos anteriores"
+
+#: src/templates/admin/submission/start.html:59
+msgid "Copyright Notice"
+msgstr "Aviso de copyright"
+
+#: src/templates/admin/submission/start.html:71
+#: src/themes/OLH/templates/journal/article.html:419
+#: src/themes/clean/templates/journal/article.html:265
+#: src/themes/material/templates/journal/article.html:400
+msgid "Competing Interests"
+msgstr "Conflicto de intereses"
+
+#: src/templates/admin/submission/submit_authors.html:5
+#: src/templates/admin/submission/timeline.html:20
+#: src/templates/admin/submission/timeline.html:21
+msgid "Author Information"
+msgstr "Información del autor"
+
+#: src/templates/admin/submission/submit_authors.html:23
+msgid "Search for Existing Authors"
+msgstr "Búsqueda de autores existentes"
+
+#: src/templates/admin/submission/submit_authors.html:30
+msgid ""
+"Search for a user using email address or ORCiD. If a user is matched, they "
+"will be automatically added as an author. This search only returns exact "
+"matches."
+msgstr ""
+"Busque un usuario usando la dirección de correo electrónico u ORCiD. Si un "
+"usuario coincide, se agregará automáticamente como autor. Esta búsqueda solo "
+"devuelve coincidencias exactas."
+
+#: src/templates/admin/submission/submit_authors.html:36
+msgid "Search by email address or ORCiD"
+msgstr "Búsqueda por correo electrónico u ORCiD"
+
+#: src/templates/admin/submission/submit_authors.html:40
+#: src/themes/OLH/templates/core/base.html:154
+#: src/themes/OLH/templates/journal/full-text-search.html:8
+#: src/themes/OLH/templates/journal/full-text-search.html:10
+#: src/themes/OLH/templates/journal/full-text-search.html:70
+#: src/themes/OLH/templates/journal/search.html:8
+#: src/themes/clean/templates/journal/article_list.html:26
+#: src/themes/clean/templates/journal/article_list.html:50
+#: src/themes/clean/templates/journal/full-text-search.html:8
+#: src/themes/clean/templates/journal/full-text-search.html:10
+#: src/themes/clean/templates/journal/search.html:7
+#: src/themes/clean/templates/journal/search.html:9
+#: src/themes/clean/templates/journal/search.html:63
+#: src/themes/material/templates/journal/article_list.html:58
+#: src/themes/material/templates/journal/articles.html:68
+#: src/themes/material/templates/journal/full-text-search.html:8
+#: src/themes/material/templates/journal/full-text-search.html:10
+#: src/themes/material/templates/journal/new_search.html:7
+#: src/themes/material/templates/journal/new_search.html:42
+#: src/themes/material/templates/journal/search.html:7
+#: src/themes/material/templates/journal/search.html:59
+msgid "Search"
+msgstr "Buscar"
+
+#: src/templates/admin/submission/submit_authors.html:45
+msgid "Add Authors"
+msgstr "Añadir autores"
+
+#: src/templates/admin/submission/submit_authors.html:60
+msgid "Current Authors"
+msgstr "Autores actuales"
+
+#: src/templates/admin/submission/submit_authors.html:62
+msgid "Drag and drop an author to re-order them."
+msgstr ""
+
+#: src/templates/admin/submission/submit_authors.html:86
+msgid "No authors yet, add one!"
+msgstr "No hay autores todavía, ¡añada uno!"
+
+#: src/templates/admin/submission/submit_authors.html:93
+msgid ""
+"You are required to select a main author, this author will receive the "
+"communications regarding your articles process through our systems. This "
+"does not have to be you."
+msgstr ""
+"Debe seleccionar un autor principal, este autor recibirá las comunicaciones "
+"sobre el proceso de sus artículos a través de nuestros sistemas. Puedes ser "
+"tú o cualquier otro autor."
+
+#: src/templates/admin/submission/submit_authors.html:94
+msgid "Select main author"
+msgstr "Seleccionar autor principal"
+
+#: src/templates/admin/submission/submit_authors.html:104
+#: src/templates/admin/submission/submit_files.html:118
+#: src/templates/admin/submission/submit_funding.html:111
+#: src/templates/admin/submission/submit_info.html:93
+msgid "Save and Continue"
+msgstr "Guardar y continuar"
+
+#: src/templates/admin/submission/submit_files.html:5
+msgid "Upload files"
+msgstr "Subir archivos"
+
+#: src/templates/admin/submission/submit_files.html:39
+#: src/templates/admin/submission/submit_files.html:80
+msgid "Upload"
+msgstr "Subir"
+
+#: src/templates/admin/submission/submit_files.html:47
+#: src/templates/admin/submission/submit_files.html:87
+#: src/templates/admin/submission/submit_review.html:137
+msgid "File Name"
+msgstr "Nombre del archivo"
+
+#: src/templates/admin/submission/submit_files.html:65
+#: src/templates/admin/submission/submit_files.html:103
+msgid "No files uploaded"
+msgstr "No hay archivos subidos"
+
+#: src/templates/admin/submission/submit_funding.html:7
+#, fuzzy
+#| msgid "Information"
+msgid "Funding Information"
+msgstr "Información"
+
+#: src/templates/admin/submission/submit_funding.html:25
+#: src/templates/admin/submission/timeline.html:36
+#: src/templates/admin/submission/timeline.html:37
+#: src/templates/common/elements/funder_info_for_readers.html:3
+msgid "Funding"
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:30
+msgid ""
+"\n"
+"                         Here you can search the FundRef database to add "
+"grant IDs to your article's metadata. If you can't find a specific funder, "
+"you can manually enter the details. You can also edit or delete entries as "
+"necessary.\n"
+"                    "
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:36
+msgid "Add Funding Source"
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:47
+msgid "Search for funder"
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:53
+msgid "Add funder manually"
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:64
+msgid "Current Funders"
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:74
+msgid "Grant Number"
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:100
+msgid "No funders added."
+msgstr ""
+
+#: src/templates/admin/submission/submit_info.html:6
+#: src/templates/admin/submission/submit_review.html:48
+msgid "Article Info"
+msgstr "Información del artículo"
+
+#: src/templates/admin/submission/submit_info.html:26
+msgid "This article is a preprint"
+msgstr "Este artículo es un preprint"
+
+#: src/templates/admin/submission/submit_info.html:31
+msgid "Basic Information"
+msgstr ""
+
+#: src/templates/admin/submission/submit_info.html:68
+msgid "View license information"
+msgstr ""
+
+#: src/templates/admin/submission/submit_info.html:77
+#: src/themes/OLH/templates/journal/article.html:181
+#: src/themes/OLH/templates/journal/keywords.html:6
+#: src/themes/OLH/templates/journal/keywords.html:12
+#: src/themes/OLH/templates/journal/print.html:33
+#: src/themes/OLH/templates/journal/search.html:40
+#: src/themes/OLH/templates/repository/list.html:76
+#: src/themes/clean/templates/journal/article.html:82
+#: src/themes/clean/templates/journal/full-text-search.html:44
+#: src/themes/clean/templates/journal/keywords.html:4
+#: src/themes/clean/templates/journal/keywords.html:5
+#: src/themes/clean/templates/journal/print.html:33
+#: src/themes/clean/templates/journal/search.html:46
+#: src/themes/material/templates/journal/article.html:81
+#: src/themes/material/templates/journal/full-text-search.html:46
+#: src/themes/material/templates/journal/keywords.html:4
+#: src/themes/material/templates/journal/keywords.html:5
+#: src/themes/material/templates/journal/keywords.html:8
+#: src/themes/material/templates/journal/search.html:50
+#: src/themes/material/templates/preprints/list.html:79
+#: src/themes/material/templates/repository/list.html:60
+#: src/themes/material/templates/repository/preprint.html:170
+msgid "Keywords"
+msgstr "Palabras clave"
+
+#: src/templates/admin/submission/submit_info.html:106
+msgid "License Information"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:7
+#: src/templates/admin/submission/timeline.html:43
+#: src/templates/admin/submission/timeline.html:44
+#: src/templates/admin/submission/timeline.html:51
+#: src/templates/admin/submission/timeline.html:52
+msgid "Review your submission"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:26
+msgid ""
+"Please review your submission use the details below. If you need to make "
+"changes use the links above to move back along the submission steps. You "
+"must click the <strong>Complete Submission</strong> button at the foot of "
+"this page to complete the submission process, you will then receive a "
+"receipt email. "
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:30
+msgid "Agreements"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:34
+msgid "Agreed to Publication Fees statement"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:38
+msgid "Agreed to Submission Checklist"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:42
+msgid "Agreed to Copyright statement"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:64
+#: src/themes/OLH/templates/journal/article.html:178
+#: src/themes/OLH/templates/journal/print.html:30
+#: src/themes/OLH/templates/repository/preprint.html:45
+#: src/themes/clean/templates/journal/article.html:78
+#: src/themes/clean/templates/journal/print.html:30
+#: src/themes/material/templates/journal/article.html:73
+#: src/themes/material/templates/preprints/article.html:43
+#: src/themes/material/templates/repository/preprint.html:155
+msgid "Abstract"
+msgstr "Resumen"
+
+#: src/templates/admin/submission/submit_review.html:73
+msgid "Language"
+msgstr "Idioma"
+
+#: src/templates/admin/submission/submit_review.html:77
+#: src/themes/material/templates/journal/article.html:389
+msgid "Licence"
+msgstr "Licencia"
+
+#: src/templates/admin/submission/submit_review.html:110
+msgid "Author Info"
+msgstr "Información del autor"
+
+#: src/templates/admin/submission/submit_review.html:113
+msgid "First Name"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:114
+msgid "Middle Name"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:115
+msgid "Last Name"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:116
+msgid "Email Address"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:126
+msgid "No ORCID supplied"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:133
+#: src/templates/admin/submission/timeline.html:28
+#: src/templates/admin/submission/timeline.html:29
+msgid "Article Files"
+msgstr "Archivos de artículos"
+
+#: src/templates/admin/submission/submit_review.html:138
+msgid "File Type"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:144
+msgid "Manuscript"
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:152
+msgid "Figure/Data"
+msgstr "Figura / Datos"
+
+#: src/templates/admin/submission/submit_review.html:162
+msgid "Comments to the Editor"
+msgstr "Comentarios al Editor"
+
+#: src/templates/admin/submission/submit_review.html:165
+msgid ""
+"Before submitting you have the option to add additional comments for the "
+"editor using the field below. Only the editor will see anything you add here."
+msgstr ""
+
+#: src/templates/admin/submission/submit_review.html:171
+msgid "Complete"
+msgstr "Completar"
+
+#: src/templates/admin/submission/submit_review.html:171
+#: src/themes/OLH/templates/core/nav.html:40
+#: src/themes/clean/templates/core/nav.html:47
+#: src/themes/material/templates/core/nav.html:39
+#: src/themes/material/templates/core/nav.html:100
+msgid "Submission"
+msgstr "Sumisión"
+
+#: src/templates/admin/submission/timeline.html:6
+msgid "Submission Started"
+msgstr "Sumisión iniciada"
+
+#: src/templates/admin/submission/timeline.html:12
+#: src/templates/admin/submission/timeline.html:13
+msgid "Article Information"
+msgstr "Información del artículo"
+
+#: src/templates/common/accounts/register_privacy_policy.html:3
+#: src/templates/common/accounts/register_privacy_policy.html:7
+#: src/templates/common/accounts/register_privacy_policy.html:11
+#: src/themes/OLH/templates/elements/journal_footer.html:25
+#: src/themes/OLH/templates/elements/journal_footer.html:27
+#: src/themes/OLH/templates/press/elements/press_footer.html:9
+#: src/themes/OLH/templates/press/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/journal_footer.html:33
+#: src/themes/clean/templates/elements/journal_footer.html:37
+#: src/themes/clean/templates/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/press_footer.html:14
+#: src/themes/hourglass/templates/custom/register.html:29
+#: src/themes/hourglass/templates/custom/register.html:35
+#: src/themes/material/templates/elements/journal_footer.html:28
+msgid "Privacy Policy"
+msgstr "Política de privacidad"
+
+#: src/templates/common/elements/funder_info_for_readers.html:6
+msgid "Funding ID"
+msgstr ""
+
+#: src/templates/common/elements/journal/article_issue_list.html:4
+#: src/themes/OLH/templates/core/nav.html:25
+#: src/themes/OLH/templates/journal/issues.html:5
+#: src/themes/OLH/templates/journal/issues.html:7
+#: src/themes/clean/templates/core/nav.html:24
+#: src/themes/clean/templates/journal/issues.html:6
+#: src/themes/material/templates/core/nav.html:33
+#: src/themes/material/templates/core/nav.html:94
+#: src/themes/material/templates/journal/issues.html:5
+msgid "Issues"
+msgstr "Números"
+
+#: src/templates/common/elements/journal/article_issue_list.html:4
+#: src/themes/OLH/templates/403.html:4
+#: src/themes/OLH/templates/journal/issue.html:9
+#: src/themes/clean/templates/journal/issue.html:8
+#: src/themes/material/templates/elements/journal/issue_sidebar.html:8
+#: src/themes/material/templates/journal/issue.html:8
+msgid "Issue"
+msgstr "Número"
 
 #: src/templates/common/elements/journal/article_issue_list.html:10
 msgid "Primary: "
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/register.html:26
-#: src/themes/OLH/templates/core/accounts/reset_password.html:27
-#: src/themes/clean/templates/core/accounts/register.html:18
-#: src/themes/clean/templates/core/accounts/reset_password.html:17
-#: src/themes/material/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/reset_password.html:17
-msgid "Password Rules"
+#: src/templates/common/elements/journal/article_issue_list.html:21
+msgid "This article is not a part of any issues"
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:29
-#: src/themes/clean/templates/core/accounts/reset_password.html:19
-msgid "Your password should be %(request.press.password_length)s characters long."
-msgstr ""
+#: src/templates/common/elements/orcid_registration.html:16
+#, fuzzy
+#| msgid "Login with ORCiD"
+msgid "Register with ORCiD"
+msgstr "Iniciar sesión con ORCiD"
 
-#: src/themes/OLH/templates/core/accounts/register.html:29
-#: src/themes/OLH/templates/core/accounts/reset_password.html:30
-#: src/themes/clean/templates/core/accounts/register.html:21
-#: src/themes/clean/templates/core/accounts/reset_password.html:20
-#: src/themes/material/templates/core/accounts/register.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:20
-msgid "Your password should contain at least one upper case letter.\""
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:30
-#: src/themes/OLH/templates/core/accounts/reset_password.html:31
-#: src/themes/clean/templates/core/accounts/register.html:22
-#: src/themes/clean/templates/core/accounts/reset_password.html:21
-#: src/themes/material/templates/core/accounts/register.html:24
-#: src/themes/material/templates/core/accounts/reset_password.html:21
-msgid "Your password should contain at least one number.\" %%}"
-msgstr ""
-
-#: src/themes/OLH/templates/core/login.html:31
-#: src/themes/OLH/templates/press/core/login.html:28
-#: src/themes/clean/templates/core/login.html:20
-#: src/themes/material/templates/core/login.html:22
-msgid "Login with"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
-msgid "Register for Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:31
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:43
-msgid "Use the button below to register to receive notifications of new articles\n"
-"                            published in this journal "
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
-msgid "Unsubscribe from Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
-msgid "Subscribe to Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/article.html:408
-#: src/themes/clean/templates/journal/article.html:239
-#: src/themes/material/templates/journal/article.html:354
-msgid "Original ISSN"
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/reset_password.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:23
-msgid "For more information read our\n"
-"                                    <a href=\"#passwordmodal\" class=\"modal-trigger\">password guide</a>\n"
-"                                    ."
-msgstr ""
-
-#: src/themes/clean/templates/journal/article.html:268
-msgid "Open Peer Reviews"
-msgstr ""
-
-#: src/themes/clean/templates/journal/article.html:263
-msgid "Download RIS"
-msgstr ""
-
-#: src/themes/clean/templates/journal/article.html:266
-msgid "Download BibTeX"
-msgstr ""
-
-#: src/themes/OLH/templates/press/nav.html:30
-#: src/themes/clean/templates/press/nav.html:43
-#: src/themes/material/templates/press/nav.html:46
-#: src/themes/material/templates/press/nav.html:97
-msgid "Repositories"
-msgstr ""
-
-#: src/themes/clean/templates/press/press_journals.html:57
-#: src/themes/material/templates/press/press_journals.html:60
-msgid "Start typing to filter."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:28
-#: src/themes/clean/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/register.html:22
-#: src/themes/material/templates/core/accounts/reset_password.html:19
+#: src/templates/common/elements/password_rules.html:2
+#, python-format
 msgid "Your password should be %(password_length)s characters long."
 msgstr ""
 
-#: src/themes/material/templates/core/login.html:15
-msgid "Login with your account"
+#: src/templates/common/elements/password_rules.html:6
+msgid "Your password should contain at least one upper case letter."
 msgstr ""
 
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:32
-msgid "Use the button below to register to receive notifications of new articles\n"
-"                                published in this journal "
+#: src/templates/common/elements/password_rules.html:11
+msgid "Your password should contain at least one number."
 msgstr ""
 
-#: src/core/forms/forms.py:133
-msgid "Check this box if you would like to receive notifications of new articles published in this journal"
-msgstr ""
-
-#: src/core/models.py:69
-msgid "Miss"
-msgstr ""
-
-#: src/core/models.py:70
-msgid "Ms"
-msgstr ""
-
-#: src/core/models.py:71
-msgid "Mrs"
-msgstr ""
-
-#: src/core/models.py:72
-msgid "Mr"
-msgstr ""
-
-#: src/core/models.py:73
-msgid "Mx"
-msgstr ""
-
-#: src/core/models.py:74
-msgid "Dr"
-msgstr ""
-
-#: src/core/models.py:75
-msgid "Prof."
-msgstr ""
-
-#: src/core/models.py:228
-msgid "Twitter Handle"
-msgstr ""
-
-#: src/core/models.py:229
-msgid "Facebook Handle"
-msgstr ""
-
-#: src/core/models.py:230
-msgid "Linkedin Profile"
-msgstr ""
-
-#: src/core/models.py:232
-msgid "Github Username"
-msgstr ""
-
-#: src/core/models.py:236
-msgid "Confirmation Code"
-msgstr ""
-
-#: src/core/models.py:237
-msgid "Signature"
-msgstr ""
-
-#: src/core/models.py:246
-msgid "Preferred Timezone"
-msgstr ""
-
-#: src/core/models.py:254
-msgid "Enable Digest"
-msgstr ""
-
-#: src/core/models.py:259
-msgid "If enabled, your basic profile will be available to the public."
-msgstr ""
-
-#: src/core/models.py:261
-msgid "Enable public profile"
-msgstr ""
-
-#: src/core/models.py:566 src/core/models.py:578
-msgid "Expires on"
-msgstr ""
-
-#: src/core/models.py:840 src/core/models.py:1118
-msgid "Article PK"
-msgstr ""
-
-#: src/core/models.py:857
-msgid "Remote URL of file"
-msgstr ""
-
-#: src/core/views.py:78
-msgid "You have been banned from logging in due to failed attempts."
-msgstr ""
-
-#: src/core/views.py:122
-msgid "Password reset process has been initiated, please check your inbox for a reset request link."
-msgstr ""
-
-#: src/core/views.py:132
-msgid "Wrong email/password combination or your email address has not been confirmed yet."
-msgstr ""
-
-#: src/core/views.py:219
-msgid "You have been logged out."
-msgstr ""
-
-#: src/core/views.py:236
-msgid "If your account was found, an email has been sent to you."
-msgstr ""
-
-#: src/journal/views.py:2603
-msgid "Published after"
-msgstr ""
-
-#: src/journal/views.py:2607
-msgid "Published before"
-msgstr ""
-
-#: src/repository/models.py:403 src/submission/models.py:645
-msgid "Copying and pasting from word processors is supported."
-msgstr ""
-
-#: src/review/models.py:195
-msgid "Anonymity"
-msgstr ""
-
-#: src/submission/forms.py:274
-msgid "Enter biography here"
-msgstr ""
-
-#: src/submission/forms.py:277
-msgid "Twitter handle"
-msgstr ""
-
-#: src/submission/forms.py:278
-msgid "LinkedIn profile"
-msgstr ""
-
-#: src/submission/forms.py:279
-msgid "ImpactStory profile"
-msgstr ""
-
-#: src/submission/forms.py:280
-msgid "ORCID ID"
-msgstr ""
-
-#: src/submission/forms.py:281
-msgid "Email address"
-msgstr ""
-
-#: src/submission/logic.py:98
-msgid "You must upload a file that is either a Doc, Docx, RTF or ODT."
-msgstr ""
-
-#: src/submission/models.py:738
-msgid "Add any comments you'd like the editor to consider here."
-msgstr ""
-
-#: src/submission/models.py:761
-msgid "Custom 'how to cite' text. To be used only if the block generated by Janeway is not suitable."
-msgstr ""
-
-#: src/submission/views.py:501
-msgid "You must upload a manuscript file."
-msgstr ""
-
-#: src/templates/admin/elements/accounts/user_form.html:91
-msgid "Email Options"
-msgstr ""
-
-#: src/templates/admin/elements/history_modal.html:8
-msgid "History"
-msgstr ""
-
-#: src/templates/admin/repository/submit/files.html:120
-msgid "Submission Information"
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:31
-msgid "The projected issue field can be used internally to keep track of plans and communicate with typesetters, without affecting issue assignment or displaying anything publicly. It is helpful for journals that add articles to issues on a rolling basis and publish them individually."
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:32
-msgid "You can assign articles directly to issues in the prepublication stage or through "
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:32
-msgid "issue management"
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:34
-msgid "Select an issue from the drop down on the left and press save. This article's projected issue will now be set."
-msgstr ""
-
-#: src/templates/admin/review/projected_issue.html:36
-msgid "Yes, you can select the blank option (-------) from the dropdown."
-msgstr ""
-
-#: src/templates/admin/review/view_review.html:55
-msgid "Recommendation"
-msgstr ""
-
-#: src/templates/admin/submission/submit_info.html:21
-msgid "Basic Information"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:21
-msgid "Please review your submission use the details below. If you need to make changes use the links above to move back along the submission steps. You must click the <strong>Complete Submission</strong> button at the foot of this page to complete the submission process, you will then receive a receipt email. "
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:25
-msgid "Agreements"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:29
-msgid "Agreed to Publication Fees statement"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:33
-msgid "Agreed to Submission Checklist"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:37
-msgid "Agreed to Copyright statement"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:97
-msgid "First Name"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:98
-msgid "Middle Name"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:99
-msgid "Last Name"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:100
-msgid "Email Address"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:110
-msgid "No ORCID supplied"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:122
-msgid "File Type"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:128
-msgid "Manuscript"
-msgstr ""
-
-#: src/templates/admin/submission/submit_review.html:149
-msgid "Before submitting you have the option to add additional comments for the editor using the field below. Only the editor will see anything you add here."
+#: src/templates/common/elements/skip_to_main_content.html:3
+#: src/themes/clean/templates/500.html:21
+msgid "Skip to main content"
 msgstr ""
 
 #: src/templates/common/elements/sorting.html:7
 #: src/themes/clean/templates/elements/sorting.html:7
 #: src/themes/material/templates/elements/sorting.html:7
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                    1 result\n"
 "                "
-msgid_plural "\n"
+msgid_plural ""
+"\n"
 "                    %(result_count)s results\n"
 "                "
 msgstr[0] ""
@@ -4288,10 +3169,448 @@ msgstr[1] ""
 msgid "Maintenance Mode"
 msgstr ""
 
-#: src/themes/OLH/templates/core/news/item.html:40
+#: src/themes/OLH/templates/403.html:16 src/themes/clean/templates/403.html:14
+msgid "Permission Denied"
+msgstr "Permiso denegado"
+
+#: src/themes/OLH/templates/404.html:9 src/themes/clean/templates/404.html:12
+#: src/themes/material/templates/404.html:9
+msgid "Page Not Found"
+msgstr "Página no encontrada"
+
+#: src/themes/OLH/templates/404.html:10 src/themes/clean/templates/404.html:13
+#: src/themes/material/templates/404.html:10
+msgid "Sorry, the page you were looking for was not found."
+msgstr "Lo sentimos, no se encontró la página que buscabas."
+
+#: src/themes/OLH/templates/500.html:10 src/themes/OLH/templates/500.html:28
+#: src/themes/clean/templates/500.html:11
+#: src/themes/clean/templates/500.html:26
+#: src/themes/material/templates/500.html:9
+#: src/themes/material/templates/500.html:24
+msgid "Server Error"
+msgstr "Error del Servidor"
+
+#: src/themes/OLH/templates/500.html:29
+#: src/themes/material/templates/500.html:25
+msgid "A server error has occurred"
+msgstr ""
+
+#: src/themes/OLH/templates/cms/page.html:22
+#: src/themes/clean/templates/cms/page.html:19
+#: src/themes/clean/templates/journal/article.html:340
+#: src/themes/material/templates/cms/page.html:25
+#: src/themes/material/templates/journal/article.html:484
+#: src/themes/material/templates/journal/submissions.html:72
+msgid "Table of Contents"
+msgstr "Tabla de contenido"
+
+#: src/themes/OLH/templates/core/accounts/activate_account.html:29
+#: src/themes/clean/templates/core/accounts/activate_account.html:20
+#: src/themes/material/templates/core/accounts/activate_account.html:21
+msgid "You can complete the activation process by clicking the button below."
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/activate_account.html:33
+#: src/themes/clean/templates/core/accounts/activate_account.html:24
+#: src/themes/material/templates/core/accounts/activate_account.html:27
+msgid "Error"
+msgstr "Error"
+
+#: src/themes/OLH/templates/core/accounts/activate_account.html:35
+msgid ""
+"There was no inactive account with this activation code found. It is "
+"possible that your account is already active, you can check by attempting to"
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/activate_account.html:36
+#: src/themes/clean/templates/core/accounts/activate_account.html:26
+#: src/themes/material/templates/core/accounts/activate_account.html:30
+msgid "login"
+msgstr "iniciar sesión"
+
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:9
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:86
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:105
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:100
+msgid "Update"
+msgstr "Actualizar"
+
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:20
+#: src/themes/material/templates/core/accounts/get_reset_token.html:20
+msgid "Enter your email address to begin the reset process"
+msgstr "Ingrese su dirección de correo electrónico"
+
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:31
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:24
+#: src/themes/material/templates/core/accounts/get_reset_token.html:25
+msgid "Request Token"
+msgstr "Solicitar clave"
+
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:24
+msgid ""
+"The ORCiD you logged in with is not currently linked with an account in our "
+"system. You can either register a new account, or login with an existing "
+"account to link your ORCiD for future use."
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:40
+#: src/themes/OLH/templates/press/core/login.html:36
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:33
+msgid "Log In"
+msgstr "Iniciar sesión"
+
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:41
+#: src/themes/OLH/templates/press/core/login.html:37
+msgid "Forgot your password?"
+msgstr "¿Olvidaste tu contraseña?"
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:9
+#: src/themes/OLH/templates/core/nav.html:72
+#: src/themes/OLH/templates/elements/right_hand_menu.html:38
+#: src/themes/OLH/templates/press/elements/right_hand_menu.html:12
+#: src/themes/OLH/templates/press/nav.html:54
+#: src/themes/OLH/templates/repository/elements/right_hand_menu.html:10
+#: src/themes/clean/templates/core/accounts/public_profile.html:8
+#: src/themes/clean/templates/core/nav.html:98
+#: src/themes/clean/templates/press/nav.html:71
+#: src/themes/material/templates/core/accounts/public_profile.html:9
+#: src/themes/material/templates/core/nav.html:165
+#: src/themes/material/templates/core/nav.html:200
+#: src/themes/material/templates/press/nav.html:135
+#: src/themes/material/templates/press/nav.html:146
+msgid "Profile"
+msgstr "Perfil"
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:19
+#: src/themes/clean/templates/core/accounts/public_profile.html:17
+#: src/themes/material/templates/core/accounts/public_profile.html:17
+msgid "Roles"
+msgstr "Roles"
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:27
+#, fuzzy
+#| msgid "Editorial Team"
+msgid "Editorial groups"
+msgstr "Equipo editorial"
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:35
+msgid "Staff roles"
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:56
+#: src/themes/clean/templates/core/accounts/public_profile.html:29
+#: src/themes/material/templates/core/accounts/public_profile.html:29
+msgid "Publications"
+msgstr "Publicaciones"
+
+#: src/themes/OLH/templates/core/accounts/register.html:29
+#: src/themes/clean/templates/core/accounts/register.html:21
+#: src/themes/material/templates/core/accounts/register.html:19
+msgid "Register for an account with"
+msgstr "Registra una cuenta con"
+
+#: src/themes/OLH/templates/core/accounts/register.html:35
+#: src/themes/OLH/templates/core/accounts/reset_password.html:36
+msgid ""
+"For more information read our <a href=\"#\" data-open=\"password-"
+"modal\">password guide</a>."
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/register.html:111
+#: src/themes/OLH/templates/core/accounts/reset_password.html:53
+#: src/themes/clean/templates/core/accounts/reset_password.html:53
+#: src/themes/material/templates/core/accounts/register.html:54
+#: src/themes/material/templates/core/accounts/reset_password.html:44
+msgid "When it comes to passwords, length is better than complexity."
+msgstr ""
+"Cuando se trata de contraseñas, la longitud es mejor que la complejidad."
+
+#: src/themes/OLH/templates/core/accounts/register.html:112
+#: src/themes/OLH/templates/core/accounts/reset_password.html:54
+#: src/themes/material/templates/core/accounts/register.html:55
+#: src/themes/material/templates/core/accounts/reset_password.html:45
+msgid ""
+"Its a common myth that a short and complex password (Jfjfy&65^87) is more "
+"secure than a long and uncomplicated password (our awesome moon base rocks)."
+msgstr ""
+"Es un mito común que una contraseña corta y compleja (Jfjfy y 65 ^ 87) es "
+"más segura que una contraseña larga y sin complicaciones (nuestra "
+"impresionante base de la Luna)."
+
+#: src/themes/OLH/templates/core/accounts/register.html:113
+#: src/themes/OLH/templates/core/accounts/reset_password.html:55
+msgid ""
+"We recommend selecting a long, but easy to remember password such as our "
+"awesome moon base rocks which would take an estimated septillion years to "
+"crack as opposed to a complex one like Jfjfy&65^87 which would take just "
+"over 600 years on a standard computer."
+msgstr ""
+"Recomendamos seleccionar una contraseña larga, pero fácil de recordar, como "
+"nuestras impresionantes rocas de la base de la luna, que demorarían un "
+"septillón aproximadamente en comparación con una compleja como Jfjfy&y65^87 "
+"que llevaría un poco más de 600 años en una computadora estándar."
+
+#: src/themes/OLH/templates/core/accounts/reset_password.html:10
+#: src/themes/OLH/templates/core/accounts/reset_password.html:42
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:8
+#: src/themes/clean/templates/core/accounts/reset_password.html:9
+#: src/themes/clean/templates/core/accounts/reset_password.html:33
+#: src/themes/hourglass/templates/core/accounts/get_reset_token.html:9
+#: src/themes/hourglass/templates/core/accounts/reset_password.html:10
+#: src/themes/material/templates/core/accounts/get_reset_token.html:8
+#: src/themes/material/templates/core/accounts/reset_password.html:9
+#: src/themes/material/templates/core/accounts/reset_password.html:31
+msgid "Reset Password"
+msgstr "Restablecer la contraseña"
+
+#: src/themes/OLH/templates/core/accounts/reset_password.html:30
+#: src/themes/clean/templates/core/accounts/reset_password.html:20
+#: src/themes/material/templates/core/accounts/reset_password.html:20
+msgid "Enter your new password twice to complete the reset process"
+msgstr ""
+"Ingrese su nueva contraseña dos veces para completar el proceso de "
+"restablecimiento"
+
+#: src/themes/OLH/templates/core/base.html:61
+#: src/themes/OLH/templates/core/nav.html:7
+#: src/themes/OLH/templates/press/nav.html:6
+#: src/themes/OLH/templates/press/press_index.html:5
+#: src/themes/OLH/templates/repository/nav.html:3
+#: src/themes/clean/templates/core/nav.html:16
+#: src/themes/clean/templates/press/nav.html:14
+#: src/themes/material/templates/core/nav.html:24
+#: src/themes/material/templates/core/nav.html:85
+#: src/themes/material/templates/press/nav.html:19
+#: src/themes/material/templates/press/nav.html:72
+#: src/themes/material/templates/repository/nav.html:18
+#: src/themes/material/templates/repository/nav.html:42
+msgid "Home"
+msgstr "Inicio"
+
+#: src/themes/OLH/templates/core/login.html:31
+#: src/themes/OLH/templates/press/core/login.html:28
+#: src/themes/clean/templates/core/login.html:20
+#: src/themes/material/templates/core/login.html:22
+msgid "Login with"
+msgstr ""
+
+#: src/themes/OLH/templates/core/nav.html:44
+#: src/themes/OLH/templates/journal/become_reviewer.html:5
+#: src/themes/OLH/templates/journal/become_reviewer.html:10
+#: src/themes/OLH/templates/journal/become_reviewer.html:20
+#: src/themes/clean/templates/core/nav.html:74
+#: src/themes/clean/templates/journal/become_reviewer.html:4
+#: src/themes/clean/templates/journal/become_reviewer.html:5
+#: src/themes/clean/templates/journal/become_reviewer.html:17
+#: src/themes/material/templates/core/nav.html:64
+#: src/themes/material/templates/journal/become_reviewer.html:4
+#: src/themes/material/templates/journal/become_reviewer.html:5
+#: src/themes/material/templates/journal/become_reviewer.html:10
+#: src/themes/material/templates/journal/become_reviewer.html:21
+msgid "Become a Reviewer"
+msgstr "Conviértete en revisor"
+
+#: src/themes/OLH/templates/core/nav.html:47
+#: src/themes/OLH/templates/press/nav.html:43
+#: src/themes/clean/templates/press/nav.html:61
+#: src/themes/material/templates/core/nav.html:73
+#: src/themes/material/templates/core/nav.html:128
+#: src/themes/material/templates/press/nav.html:61
+#: src/themes/material/templates/press/nav.html:109
+#: src/themes/material/templates/repository/nav.html:54
+msgid "Account"
+msgstr "Cuenta"
+
+#: src/themes/OLH/templates/core/nav.html:50
+#: src/themes/OLH/templates/elements/right_hand_menu.html:4
+#: src/themes/OLH/templates/repository/elements/right_hand_menu.html:5
+#: src/themes/clean/templates/core/nav.html:85
+#: src/themes/material/templates/core/nav.html:149
+#: src/themes/material/templates/core/nav.html:170
+#: src/themes/material/templates/repository/nav.html:74
+#: src/themes/material/templates/repository/nav.html:87
+msgid "Dashboard"
+msgstr "Tablero"
+
+#: src/themes/OLH/templates/core/nav.html:52
+#: src/themes/OLH/templates/elements/right_hand_menu.html:8
+#: src/themes/OLH/templates/press/press_journals.html:58
+#: src/themes/OLH/templates/press/press_journals.html:65
+#: src/themes/clean/templates/core/nav.html:86
+#: src/themes/clean/templates/press/press_journals.html:29
+#: src/themes/clean/templates/press/press_journals.html:36
+#: src/themes/material/templates/core/nav.html:151
+#: src/themes/material/templates/core/nav.html:173
+#: src/themes/material/templates/press/press_journals.html:33
+#: src/themes/material/templates/press/press_journals.html:40
+#: src/themes/material/templates/repository/nav.html:22
+#: src/themes/material/templates/repository/nav.html:46
+msgid "Submit"
+msgstr "Enviar"
+
+#: src/themes/OLH/templates/core/nav.html:56
+#: src/themes/OLH/templates/elements/right_hand_menu.html:5
+#: src/themes/clean/templates/core/nav.html:89
+#: src/themes/material/templates/core/nav.html:153
+#: src/themes/material/templates/core/nav.html:171
+msgid "Kanban"
+msgstr "Kanban"
+
+#: src/themes/OLH/templates/core/nav.html:59
+#: src/themes/OLH/templates/elements/right_hand_menu.html:25
+#: src/themes/clean/templates/core/nav.html:92
+#: src/themes/material/templates/core/nav.html:156
+#: src/themes/material/templates/core/nav.html:188
+msgid "Edit Article"
+msgstr ""
+
+#: src/themes/OLH/templates/core/nav.html:62
+#: src/themes/OLH/templates/elements/right_hand_menu.html:28
+#: src/themes/material/templates/core/nav.html:159
+#: src/themes/material/templates/core/nav.html:191
+msgid "Edit Issue"
+msgstr ""
+
+#: src/themes/OLH/templates/core/nav.html:65
+#: src/themes/OLH/templates/elements/right_hand_menu.html:31
+#: src/themes/material/templates/core/nav.html:194
+msgid "Edit News Item"
+msgstr ""
+
+#: src/themes/OLH/templates/core/nav.html:69
+#: src/themes/OLH/templates/elements/right_hand_menu.html:35
+#: src/themes/OLH/templates/press/elements/right_hand_menu.html:8
+#: src/themes/OLH/templates/press/nav.html:51
+#: src/themes/OLH/templates/repository/elements/right_hand_menu.html:9
+#: src/themes/clean/templates/core/nav.html:96
+#: src/themes/clean/templates/press/nav.html:69
+#: src/themes/material/templates/core/nav.html:163
+#: src/themes/material/templates/core/nav.html:198
+#: src/themes/material/templates/press/nav.html:133
+#: src/themes/material/templates/press/nav.html:144
+#: src/themes/material/templates/repository/nav.html:81
+#: src/themes/material/templates/repository/nav.html:94
+msgid "Admin"
+msgstr "Administración"
+
+#: src/themes/OLH/templates/core/nav.html:73
+#: src/themes/OLH/templates/elements/right_hand_menu.html:39
+#: src/themes/OLH/templates/press/elements/right_hand_menu.html:13
+#: src/themes/OLH/templates/press/nav.html:55
+#: src/themes/OLH/templates/repository/elements/right_hand_menu.html:11
+#: src/themes/clean/templates/core/nav.html:99
+#: src/themes/clean/templates/press/nav.html:72
+#: src/themes/material/templates/core/nav.html:166
+#: src/themes/material/templates/core/nav.html:201
+#: src/themes/material/templates/press/nav.html:136
+#: src/themes/material/templates/press/nav.html:147
+#: src/themes/material/templates/repository/nav.html:83
+#: src/themes/material/templates/repository/nav.html:96
+msgid "Logout"
+msgstr "Cerrar sesión"
+
+#: src/themes/OLH/templates/core/news/index.html:12
+#: src/themes/material/templates/core/news/index.html:12
+#: src/themes/material/templates/press/core/news/index.html:11
+msgid "Filtering tag"
+msgstr "Etiqueta de filtrado"
+
+#: src/themes/OLH/templates/core/news/index.html:25
+#: src/themes/OLH/templates/core/news/item.html:25
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:28
+#: src/themes/OLH/templates/press/core/news/index.html:23
+#: src/themes/OLH/templates/press/core/news/item.html:25
+#: src/themes/OLH/templates/press/core/news/item.html:34
+#: src/themes/hourglass/templates/custom/news-item.html:16
+#: src/themes/material/templates/core/news/index.html:31
+#: src/themes/material/templates/core/news/item.html:31
+#: src/themes/material/templates/press/core/news/index.html:21
+#: src/themes/material/templates/press/core/news/item.html:18
+msgid "on"
+msgstr "en"
+
+#: src/themes/OLH/templates/core/news/index.html:27
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:30
+#: src/themes/OLH/templates/press/core/news/index.html:25
+#: src/themes/clean/templates/core/news/index.html:17
+#: src/themes/clean/templates/press/core/news/index.html:17
+#: src/themes/material/templates/core/news/index.html:35
+#: src/themes/material/templates/journal/homepage_elements/news.html:37
+#: src/themes/material/templates/press/core/news/index.html:25
+msgid "Read More"
+msgstr "Leer mas"
+
+#: src/themes/OLH/templates/core/news/index.html:34
+#: src/themes/material/templates/press/core/news/index.html:30
+msgid "This journal currently has no news items to display."
+msgstr "Esta revista no tiene nuevas noticias disponibles."
+
+#: src/themes/OLH/templates/core/news/item.html:41
 #: src/themes/clean/templates/core/news/item.html:20
 #: src/themes/clean/templates/press/core/news/item.html:16
 msgid "Tags "
+msgstr ""
+
+#: src/themes/OLH/templates/core/news/item.html:48
+#: src/themes/clean/templates/core/news/item.html:22
+#: src/themes/material/templates/core/news/item.html:44
+msgid "Back to"
+msgstr ""
+
+#: src/themes/OLH/templates/core/news/item.html:48
+#: src/themes/clean/templates/core/news/item.html:22
+#: src/themes/material/templates/core/news/item.html:44
+msgid "List"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:8
+msgid ""
+"\n"
+"                <p>If you want to change your email address you may do so "
+"below, however, you will be logged out and your\n"
+"                account will be marked as inactive until you follow the "
+"instructions in the verification email. <strong>Note: </strong>\n"
+"                Changing your email address will also change your username "
+"as these are one and the same.</p>\n"
+"                "
+msgstr ""
+
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:31
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:43
+msgid ""
+"Use the button below to register to receive notifications of new articles\n"
+"                            published in this journal "
+msgstr ""
+
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:53
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:66
+msgid ""
+"You can update your password by entering your existing password plus your "
+"new password."
+msgstr ""
+"Puede actualizar su contraseña ingresando su contraseña existente más su "
+"nueva contraseña."
+
+#: src/themes/OLH/templates/elements/accounts/user_form.html:5
+#: src/themes/clean/templates/elements/accounts/user_form.html:5
+#: src/themes/material/templates/elements/accounts/user_form.html:6
+msgid "Core Data"
+msgstr "Datos básicos"
+
+#: src/themes/OLH/templates/elements/edit_author.html:5
+msgid "NB."
+msgstr ""
+
+#: src/themes/OLH/templates/elements/edit_author.html:5
+msgid ""
+"You are editing the frozen metadata record for this author, not their live "
+"user profile."
+msgstr ""
+
+#: src/themes/OLH/templates/elements/edit_author.html:10
+msgid "Save Metadata"
 msgstr ""
 
 #: src/themes/OLH/templates/elements/forms/errors.html:2
@@ -4304,9 +3623,188 @@ msgstr ""
 msgid "Non Field Errors"
 msgstr ""
 
-#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
-#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
-msgid "Apply"
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:6
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:19
+#: src/themes/clean/templates/journal/articles.html:50
+#: src/themes/material/templates/journal/articles.html:82
+msgid "Show"
+msgstr "Show"
+
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:16
+#: src/themes/clean/templates/journal/articles.html:60
+#: src/themes/material/templates/journal/articles.html:85
+msgid "Sort"
+msgstr "Ordenar"
+
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:19
+#: src/themes/clean/templates/journal/articles.html:63
+#: src/themes/material/templates/journal/articles.html:88
+msgid "Date"
+msgstr "Fecha"
+
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:26
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:35
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:6
+#: src/themes/OLH/templates/elements/journal/search_form.html:19
+#: src/themes/OLH/templates/press/press_journals.html:93
+#: src/themes/OLH/templates/press/press_journals.html:94
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:7
+#: src/themes/clean/templates/journal/articles.html:82
+#: src/themes/clean/templates/journal/full-text-search.html:54
+#: src/themes/clean/templates/press/press_journals.html:56
+#: src/themes/material/templates/journal/articles.html:95
+#: src/themes/material/templates/journal/articles.html:106
+#: src/themes/material/templates/journal/full-text-search.html:61
+#: src/themes/material/templates/press/press_journals.html:59
+msgid "Filter"
+msgstr "Filtrar"
+
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:37
+#: src/themes/clean/templates/journal/articles.html:85
+#: src/themes/material/templates/journal/articles.html:109
+msgid "Clear Filters"
+msgstr "Borrar filtros"
+
+#: src/themes/OLH/templates/elements/journal/authors_block.html:4
+#: src/themes/clean/templates/elements/article_listing.html:27
+#: src/themes/clean/templates/elements/journal/authors_block.html:4
+#: src/themes/material/templates/elements/article_listing.html:25
+msgid "and"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/box_article.html:30
+#: src/themes/clean/templates/elements/article_listing.html:40
+#: src/themes/material/templates/elements/article_listing.html:41
+msgid "Also a part of:"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:5
+#: src/themes/clean/templates/elements/journal/citation_modals.html:6
+#: src/themes/clean/templates/journal/article.html:304
+msgid "Harvard-style Citation"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:9
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:30
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:54
+#: src/themes/material/templates/preprints/about.html:4
+#: src/themes/material/templates/preprints/about.html:9
+msgid "Preprints"
+msgstr "Preprints"
+
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:19
+#: src/themes/OLH/templates/journal/article.html:137
+msgid "Vancouver Citation Style"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:19
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:40
+#: src/themes/OLH/templates/journal/article.html:138
+msgid "APA Citation Style"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:27
+#: src/themes/clean/templates/elements/journal/citation_modals.html:28
+#: src/themes/clean/templates/journal/article.html:305
+msgid "Vancouver-style Citation"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:40
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:63
+#: src/themes/OLH/templates/journal/article.html:136
+msgid "Harvard Citation Style"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/citation_modals.html:49
+#: src/themes/clean/templates/elements/journal/citation_modals.html:49
+#: src/themes/clean/templates/journal/article.html:306
+msgid "APA-style Citation"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/editorial_social_content.html:4
+#: src/themes/clean/templates/elements/journal/editorial_social_content.html:4
+#: src/themes/clean/templates/journal/article.html:293
+msgid "Twitter"
+msgstr "Gorjeo"
+
+#: src/themes/OLH/templates/elements/journal/editorial_social_content.html:5
+#: src/themes/clean/templates/elements/journal/editorial_social_content.html:5
+msgid "Facebook"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/editorial_social_content.html:6
+#: src/themes/clean/templates/elements/journal/editorial_social_content.html:6
+msgid "Github"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/editorial_social_content.html:7
+#: src/themes/clean/templates/elements/journal/editorial_social_content.html:7
+msgid "Linkedin"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/issue_list.html:16
+#: src/themes/clean/templates/elements/journal/issue_list.html:5
+#: src/themes/clean/templates/journal/issues.html:14
+#: src/themes/material/templates/elements/journal/issue_list.html:16
+#: src/themes/material/templates/elements/journal/issue_list.html:20
+msgid "items"
+msgstr "artículos"
+
+#: src/themes/OLH/templates/elements/journal/issue_list.html:24
+msgid "There are no issues published in this journal yet."
+msgstr "Aún no hay temas publicados en esta revista."
+
+#: src/themes/OLH/templates/elements/journal/issue_list_by_decade.html:3
+#: src/themes/material/templates/elements/journal/issue_list_by_decade.html:3
+msgid ""
+"\n"
+"            Issues are grouped by decade. Select a decade to view the "
+"issues\n"
+"            published during that decade.\n"
+"        "
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/issue_sidebar.html:7
+#: src/themes/OLH/templates/journal/article.html:210
+#: src/themes/OLH/templates/journal/article.html:246
+#: src/themes/OLH/templates/journal/article.html:334
+#: src/themes/OLH/templates/repository/preprint.html:114
+#: src/themes/OLH/templates/repository/preprint.html:152
+#: src/themes/clean/templates/elements/journal/issue_sidebar.html:6
+#: src/themes/clean/templates/journal/article.html:101
+#: src/themes/clean/templates/journal/article.html:184
+#: src/themes/clean/templates/journal/article.html:291
+#: src/themes/material/templates/elements/journal/issue_sidebar.html:5
+#: src/themes/material/templates/journal/article.html:123
+#: src/themes/material/templates/journal/article.html:169
+#: src/themes/material/templates/journal/article.html:273
+#: src/themes/material/templates/preprints/article.html:133
+#: src/themes/material/templates/repository/preprint.html:130
+#: src/themes/material/templates/repository/preprint.html:203
+msgid "Downloads"
+msgstr "Descargas"
+
+#: src/themes/OLH/templates/elements/journal/issue_sidebar.html:8
+#: src/themes/clean/templates/elements/journal/issue_sidebar.html:7
+msgid "Download Issue"
+msgstr "Descargar Numero"
+
+#: src/themes/OLH/templates/elements/journal/issue_sidebar.html:11
+#: src/themes/clean/templates/elements/journal/issue_sidebar.html:10
+#: src/themes/material/templates/elements/journal/issue_sidebar.html:14
+msgid "Issue Archive"
+msgstr "Archivo de Números"
+
+#: src/themes/OLH/templates/elements/journal/keywords_block.html:4
+#: src/themes/clean/templates/elements/journal/keywords_block.html:4
+msgid ""
+"Keywords used by articles in this journal are listed below. Select a keyword "
+"to view which articles use it."
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/keywords_block.html:10
+#: src/themes/clean/templates/elements/journal/keywords_block.html:10
+msgid "This journal has no keywords to display."
 msgstr ""
 
 #: src/themes/OLH/templates/elements/journal/search_form.html:6
@@ -4314,18 +3812,104 @@ msgstr ""
 msgid "Search titles, keywords, and authors"
 msgstr ""
 
+#: src/themes/OLH/templates/elements/journal/search_form.html:9
+#: src/themes/clean/templates/journal/full-text-search.html:39
+msgid "You are currently browsing by keyword"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/search_form.html:10
+#: src/themes/OLH/templates/journal/full-text-search.html:64
+#: src/themes/clean/templates/journal/article_list.html:36
+#: src/themes/clean/templates/journal/full-text-search.html:39
+#: src/themes/clean/templates/journal/search.html:42
+msgid "Search for an article"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/search_form.html:14
+#: src/themes/clean/templates/journal/search.html:55
+#: src/themes/material/templates/journal/new_search.html:36
+#: src/themes/material/templates/journal/search.html:44
+msgid "Sort articles by"
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/summary_modal.html:3
+#: src/themes/OLH/templates/journal/article.html:428
+#: src/themes/clean/templates/elements/journal/summary_modal.html:6
+#: src/themes/clean/templates/journal/article.html:260
+#: src/themes/material/templates/elements/summary_modal.html:5
+#: src/themes/material/templates/journal/article.html:382
+msgid "Non Specialist Summary"
+msgstr "Resumen no especializado"
+
+#: src/themes/OLH/templates/elements/journal/summary_modal.html:7
+#: src/themes/clean/templates/elements/journal/summary_modal.html:15
+#: src/themes/material/templates/elements/summary_modal.html:9
+msgid "This article has no summary"
+msgstr "Este artículo no tiene resumen."
+
+#: src/themes/OLH/templates/elements/journal_footer.html:6
+#: src/themes/clean/templates/elements/journal_footer.html:8
+#: src/themes/material/templates/elements/journal_footer.html:6
+msgid "Published by"
+msgstr ""
+
 #: src/themes/OLH/templates/elements/public_reviews.html:21
-msgid "\n"
-"                    <p><b>Note:</b><br/>This review refers to round %(review.review_round.round_number)s of peer\n"
-"                        review and may pertain to an earlier version of the document.</p>\n"
+#, python-format
+msgid ""
+"\n"
+"                    <p><b>Note:</b><br/>This review refers to round "
+"%(review.review_round.round_number)s of peer\n"
+"                        review and may pertain to an earlier version of the "
+"document.</p>\n"
 "                    "
 msgstr ""
+
+#: src/themes/OLH/templates/elements/right_hand_menu.html:15
+#: src/themes/material/templates/core/nav.html:178
+msgid "Edit Submissions Page"
+msgstr "Editar página de envíos"
+
+#: src/themes/OLH/templates/elements/right_hand_menu.html:16
+#: src/themes/material/templates/core/nav.html:179
+msgid "Edit Journal Info"
+msgstr "Editar información del diario"
+
+#: src/themes/OLH/templates/elements/right_hand_menu.html:19
+#: src/themes/OLH/templates/press/elements/right_hand_menu.html:10
+#: src/themes/material/templates/core/nav.html:182
+msgid "Edit Page"
+msgstr "Editar página"
+
+#: src/themes/OLH/templates/elements/right_hand_menu.html:22
+#: src/themes/material/templates/core/nav.html:185
+msgid "Manage Editorial Team"
+msgstr "Administrar equipo editorial"
 
 #: src/themes/OLH/templates/elements/section_block.html:6
 #: src/themes/clean/templates/elements/sections_block.html:7
 #: src/themes/material/templates/elements/sections_display.html:5
 msgid "Section or article type"
 msgstr ""
+
+#: src/themes/OLH/templates/elements/section_block.html:9
+#: src/themes/clean/templates/elements/sections_block.html:8
+#: src/themes/material/templates/elements/sections_display.html:8
+msgid "Public Submissions"
+msgstr "Sumisiones públicas"
+
+#: src/themes/OLH/templates/elements/section_block.html:12
+#: src/themes/OLH/templates/journal/article.html:279
+#: src/themes/clean/templates/elements/sections_block.html:9
+#: src/themes/clean/templates/journal/article.html:252
+#: src/themes/material/templates/elements/sections_display.html:11
+msgid "Peer Reviewed"
+msgstr "Revisión por pares"
+
+#: src/themes/OLH/templates/elements/section_block.html:15
+#: src/themes/clean/templates/elements/sections_block.html:10
+#: src/themes/material/templates/elements/sections_display.html:14
+msgid "Indexed"
+msgstr "Indexado"
 
 #: src/themes/OLH/templates/elements/section_block.html:27
 #: src/themes/OLH/templates/elements/section_block.html:36
@@ -4345,29 +3929,334 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:138
+#: src/themes/OLH/templates/elements/submit/file.html:8
+msgid ""
+"Please supply any original figure files or supporting information. The "
+"journal urges you to submit this document to a repository such as Figshare "
+"so that a DOI can be assigned to it, but this is not required."
+msgstr ""
+"Por favor, proporciona todos las imagenes o documentos de apoyo. "
+"Recomendamos  subir estos documentos a un repositorio como Figshare para que "
+"se le pueda asignar un DOI, pero no es obligatorio."
+
+#: src/themes/OLH/templates/elements/submit/file.html:11
+msgid ""
+"Please upload your manuscript file, it should be in PDF, RTF, ODT or DOC/X "
+"format. LaTeX may be accepted later in the process but a simple, readable "
+"file is required at this stage."
+msgstr ""
+"Suba su archivo manuscrito, debe estar en formato PDF, RTF, ODT o DOC / X. "
+"LaTeX puede aceptarse más adelante en el proceso, pero se requiere un "
+"archivo simple y legible en esta etapa."
+
+#: src/themes/OLH/templates/elements/submit/file.html:13
+msgid ""
+"Please upload your manuscript file, it should be in RTF, ODT or DOC/X "
+"format. LaTeX may be accepted later in the process but a simple, readable "
+"file is required at this stage."
+msgstr ""
+"Suba su archivo manuscrito, debe estar en formato RTF, ODT o DOC / X. LaTeX "
+"puede aceptarse más adelante en el proceso, pero se requiere un archivo "
+"simple y legible en esta etapa."
+
+#: src/themes/OLH/templates/elements/submit/preprint_file.html:8
+msgid "Please supply any supporting information or data files."
+msgstr ""
+"Por favor, proporcione cualquier información de apoyo o archivos de datos."
+
+#: src/themes/OLH/templates/elements/submit/preprint_file.html:11
+msgid "Please upload your manuscript file, it should be in PDF format."
+msgstr "Por favor, cargue su archivo manuscrito, debe estar en formato PDF."
+
+#: src/themes/OLH/templates/elements/submit/preprint_file.html:13
+msgid ""
+"Please upload your manuscript file, it should be in PDF, RTF, ODT or DOC/X "
+"format."
+msgstr ""
+"Suba su archivo manuscrito, debe estar en formato PDF, RTF, ODT o DOC / X."
+
+#: src/themes/OLH/templates/journal/article.html:6
+#: src/themes/material/templates/journal/article.html:7
+msgid "Preprint"
+msgstr "Preimpresión"
+
+#: src/themes/OLH/templates/journal/article.html:6
+#: src/themes/material/templates/journal/article.html:7
+msgid "Article"
+msgstr "Artículo"
+
+#: src/themes/OLH/templates/journal/article.html:28
+#: src/themes/OLH/templates/journal/article.html:64
+#: src/themes/OLH/templates/journal/article.html:162
+#: src/themes/OLH/templates/journal/print.html:15
+#: src/themes/clean/templates/journal/article.html:38
+#: src/themes/clean/templates/journal/print.html:15
+msgid "Author"
+msgstr "Autor"
+
+#: src/themes/OLH/templates/journal/article.html:115
+#: src/themes/clean/templates/journal/article.html:172
+#: src/themes/material/templates/journal/article.html:231
+msgid "Share"
+msgstr "Compartir"
+
+#: src/themes/OLH/templates/journal/article.html:116
+#: src/themes/clean/templates/journal/article.html:176
+#: src/themes/material/templates/journal/article.html:236
+msgid "Share on Facebook"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:118
+#: src/themes/clean/templates/journal/article.html:179
+#: src/themes/material/templates/journal/article.html:239
+#, fuzzy
+#| msgid "Share"
+msgid "Share on X"
+msgstr "Compartir"
+
+#: src/themes/OLH/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:182
+#: src/themes/material/templates/journal/article.html:242
+msgid "Share on LinkedIn"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:128
+#, fuzzy
+#| msgid "Submit an Article"
+msgid "print article"
+msgstr "Enviar un artículo"
+
+#: src/themes/OLH/templates/journal/article.html:129
+msgid "decrease text size"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:130
+msgid "increase text size"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:132
+#, fuzzy
+#| msgid "Dyslexia"
+msgid "Dyslexia mode"
+msgstr "Dislexia"
+
+#: src/themes/OLH/templates/journal/article.html:132
+msgid "Dyslexia"
+msgstr "Dislexia"
+
+#: src/themes/OLH/templates/journal/article.html:134
+#, fuzzy
+#| msgid "Submit an Article"
+msgid "Cite article"
+msgstr "Enviar un artículo"
+
+#: src/themes/OLH/templates/journal/article.html:139
+#: src/themes/OLH/templates/journal/article.html:213
+#: src/themes/OLH/templates/journal/article.html:339
+#: src/themes/clean/templates/journal/article.html:104
+#: src/themes/clean/templates/journal/article.html:190
+#: src/themes/clean/templates/journal/article.html:308
+#: src/themes/clean/templates/journal/article.html:311
+#: src/themes/material/templates/elements/journal/issue_sidebar.html:8
+#: src/themes/material/templates/journal/article.html:127
+#: src/themes/material/templates/journal/article.html:279
+#: src/themes/material/templates/preprints/article.html:113
+#: src/themes/material/templates/preprints/article.html:117
+#: src/themes/material/templates/preprints/article.html:139
+msgid "Download"
+msgstr "Descargar"
+
+#: src/themes/OLH/templates/journal/article.html:140
 msgid " Download"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:213
-#: src/themes/OLH/templates/journal/article.html:361
+#: src/themes/OLH/templates/journal/article.html:186
+#: src/themes/OLH/templates/journal/print.html:35
+#: src/themes/clean/templates/journal/article.html:89
+#: src/themes/clean/templates/journal/print.html:35
+#: src/themes/material/templates/journal/article.html:91
+msgid "How to Cite"
+msgstr "Como citar"
+
+#: src/themes/OLH/templates/journal/article.html:193
+#: src/themes/clean/templates/journal/article.html:95
+#: src/themes/material/templates/journal/article.html:101
+msgid "Rights"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:198
+#: src/themes/clean/templates/journal/article.html:129
+#: src/themes/material/templates/journal/article.html:110
+msgid "Publisher Notes"
+msgstr "Notas del editor"
+
+#: src/themes/OLH/templates/journal/article.html:216
+#: src/themes/OLH/templates/journal/article.html:343
 msgid "View PDF"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:239
-msgid "\n"
-"                                                        (grant %(id)s)\n"
-""
+#: src/themes/OLH/templates/journal/article.html:227
+#: src/themes/OLH/templates/journal/article.html:356
+#: src/themes/clean/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:207
+#: src/themes/material/templates/journal/article.html:143
+#: src/themes/material/templates/journal/article.html:298
+msgid "Downloads are not available for this article."
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:374
+#: src/themes/OLH/templates/journal/article.html:240
+#: src/themes/OLH/templates/repository/preprint.html:151
+#: src/themes/clean/templates/journal/article.html:290
+#: src/themes/material/templates/journal/article.html:163
+#: src/themes/material/templates/preprints/article.html:132
+#: src/themes/material/templates/repository/preprint.html:202
+msgid "Views"
+msgstr "Visitas"
+
+#: src/themes/OLH/templates/journal/article.html:253
+#: src/themes/clean/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:201
+msgid "Citations"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:267
+#: src/themes/clean/templates/journal/article.html:233
+#: src/themes/material/templates/journal/article.html:354
+#: src/themes/material/templates/preprints/article.html:123
+msgid "Published on"
+msgstr "Publicado el"
+
+#: src/themes/OLH/templates/journal/article.html:287
+#: src/themes/OLH/templates/repository/preprint.html:127
+#: src/themes/clean/templates/journal/article.html:255
+#: src/themes/material/templates/preprints/article.html:124
+#: src/themes/material/templates/repository/preprint.html:189
+msgid "License"
+msgstr "Licencia"
+
+#: src/themes/OLH/templates/journal/article.html:359
 msgid "Downloads are not available until this article is published "
 msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:368
+#: src/themes/material/templates/journal/article.html:410
+msgid "Identifiers"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:378
+#: src/themes/material/templates/journal/article.html:308
+msgid "Publication details"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:381
+#: src/themes/clean/templates/journal/article.html:237
+#: src/themes/material/templates/journal/article.html:312
+msgid "Pages"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:384
+#: src/themes/clean/templates/journal/article.html:240
+msgid "Article Number"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:387
+#: src/themes/clean/templates/journal/article.html:243
+#: src/themes/material/templates/journal/article.html:324
+msgid "Publisher"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:390
+#: src/themes/clean/templates/journal/article.html:246
+msgid "Original Publication"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:393
+#: src/themes/clean/templates/journal/article.html:249
+#: src/themes/material/templates/journal/article.html:336
+msgid "Original ISSN"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:396
+#: src/themes/clean/templates/journal/article.html:223
+#: src/themes/material/templates/journal/article.html:342
+#, fuzzy
+#| msgid "Submit"
+msgid "Submitted on"
+msgstr "Enviar"
+
+#: src/themes/OLH/templates/journal/article.html:399
+#: src/themes/clean/templates/journal/article.html:228
+#: src/themes/material/templates/journal/article.html:348
+msgid "Accepted on"
+msgstr "Aceptado en"
+
+#: src/themes/OLH/templates/journal/article.html:407
+#: src/themes/clean/templates/journal/article.html:211
+#: src/themes/material/templates/journal/article.html:368
+#: src/themes/material/templates/repository/preprint.html:138
+msgid "Supplementary Files"
+msgstr "Archivos suplementarios"
+
+#: src/themes/OLH/templates/journal/article.html:430
+#: src/themes/material/templates/journal/article.html:383
+msgid "View Summary"
+msgstr "Ver resumen"
+
+#: src/themes/OLH/templates/journal/article.html:437
+msgid "Jump to"
+msgstr "Saltar a"
+
+#: src/themes/OLH/templates/journal/article.html:463
+#: src/themes/clean/templates/journal/article.html:324
+#: src/themes/material/templates/journal/article.html:464
+msgid "File Checksums"
+msgstr "File Checksums"
+
+#: src/themes/OLH/templates/journal/article.html:473
+#: src/themes/clean/templates/journal/article.html:334
+#: src/themes/material/templates/journal/article.html:475
+msgid "File Checksums are not available for this article."
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:480
+#: src/themes/material/templates/journal/article.html:422
+msgid "Peer Review"
+msgstr "Revisión por pares"
 
 #: src/themes/OLH/templates/journal/article_list.html:15
 #: src/themes/OLH/templates/journal/articles.html:22
 msgid "Show Filter Options"
 msgstr ""
+
+#: src/themes/OLH/templates/journal/article_list.html:27
+#: src/themes/clean/templates/journal/article_list.html:19
+#: src/themes/material/templates/journal/article_list.html:26
+#: src/themes/material/templates/journal/full-text-search.html:26
+#: src/themes/material/templates/journal/new_search.html:21
+#: src/themes/material/templates/journal/search.html:23
+msgid "No articles to display."
+msgstr "No hay artículos para mostrar."
+
+#: src/themes/OLH/templates/journal/articles.html:30
+msgid "Pinned Articles"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/articles.html:39
+msgid "There are no articles published in this journal yet"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/collections.html:28
+#: src/themes/OLH/templates/journal/issue.html:7
+#: src/themes/clean/templates/journal/issue.html:6
+#: src/themes/material/templates/elements/journal/issue_sidebar.html:8
+#: src/themes/material/templates/journal/issue.html:6
+msgid "Collection"
+msgstr "Colección"
+
+#: src/themes/OLH/templates/journal/collections.html:29
+#: src/themes/OLH/templates/repository/preprint.html:124
+msgid "Published"
+msgstr "Publicado"
 
 #: src/themes/OLH/templates/journal/full-text-search.html:26
 #: src/themes/clean/templates/journal/articles.html:24
@@ -4376,32 +4265,408 @@ msgstr ""
 msgid "No articles to display"
 msgstr ""
 
+#: src/themes/OLH/templates/journal/homepage_elements/featured.html:6
+#: src/themes/clean/templates/journal/homepage_elements/featured.html:6
+#: src/themes/clean/templates/journal/homepage_elements/popular.html:9
+#: src/themes/material/templates/journal/homepage_elements/featured.html:6
+msgid "Featured Articles"
+msgstr "Artículos relacionados"
+
+#: src/themes/OLH/templates/journal/homepage_elements/journals.html:5
+#: src/themes/OLH/templates/press/homepage_elements/journals_and_html.html:7
+#: src/themes/clean/templates/journal/homepage_elements/journals.html:4
+#: src/themes/clean/templates/press/homepage_elements/journals_and_html.html:4
+#: src/themes/material/templates/journal/homepage_elements/journals.html:6
+#: src/themes/material/templates/press/homepage_elements/journals_and_html.html:5
+msgid "Featured Journals"
+msgstr "Revistas destacadas"
+
+#: src/themes/OLH/templates/journal/homepage_elements/journals.html:23
+#: src/themes/OLH/templates/journal/homepage_elements/journals.html:28
+#: src/themes/OLH/templates/press/homepage_elements/journals_and_html.html:30
+msgid "Unnamed Journal"
+msgstr "Revista sin nombre"
+
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
+#: src/themes/clean/templates/journal/homepage_elements/news.html:8
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
+msgid "Latest"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
+#: src/themes/clean/templates/journal/homepage_elements/news.html:8
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
+msgid "Posts"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:36
+#: src/themes/clean/templates/press/core/news/index.html:21
+msgid "This journal currently has no news items to display"
+msgstr "Esta revista actualmente no tiene noticias para mostrar"
+
+#: src/themes/OLH/templates/journal/homepage_elements/popular.html:6
+#: src/themes/clean/templates/journal/homepage_elements/popular.html:7
+#: src/themes/material/templates/journal/homepage_elements/popular.html:6
+msgid "Most Popular Articles"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/homepage_elements/preprints.html:6
+#: src/themes/clean/templates/journal/homepage_elements/preprints.html:6
+msgid "Featured Preprints"
+msgstr "Preprints destacados"
+
+#: src/themes/OLH/templates/journal/keyword.html:6
+#: src/themes/OLH/templates/journal/keyword.html:12
+#: src/themes/OLH/templates/journal/search.html:23
+#: src/themes/clean/templates/journal/keyword.html:4
+#: src/themes/clean/templates/journal/keyword.html:5
+#: src/themes/material/templates/journal/full-text-search.html:17
+#: src/themes/material/templates/journal/keyword.html:4
+#: src/themes/material/templates/journal/keyword.html:5
+#: src/themes/material/templates/journal/search.html:14
+msgid "Keyword"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/keyword.html:14
+#: src/themes/clean/templates/journal/keyword.html:10
+#: src/themes/material/templates/journal/keyword.html:9
+msgid "Back to Keywords List"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/keyword.html:16
+#: src/themes/clean/templates/journal/keyword.html:12
+#: src/themes/material/templates/journal/keyword.html:10
+msgid "Articles that use this keyword are listed below."
+msgstr ""
+
+#: src/themes/OLH/templates/journal/search.html:21
+#: src/themes/material/templates/journal/full-text-search.html:15
+#: src/themes/material/templates/journal/new_search.html:12
+#: src/themes/material/templates/journal/search.html:12
+msgid "Searching for"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/submissions.html:5
+#: src/themes/OLH/templates/journal/submissions.html:22
+#: src/themes/clean/templates/journal/submissions.html:5
+#: src/themes/clean/templates/journal/submissions.html:10
+#: src/themes/material/templates/journal/submissions.html:6
+#: src/themes/material/templates/journal/submissions.html:23
+msgid "Submissions"
+msgstr "Artículos"
+
+#: src/themes/OLH/templates/press/core/login.html:26
+msgid "Login with ORCiD"
+msgstr "Iniciar sesión con ORCiD"
+
+#: src/themes/OLH/templates/press/core/news/index.html:6
+#: src/themes/OLH/templates/press/core/news/index.html:11
+#: src/themes/OLH/templates/press/core/news/item.html:6
+#: src/themes/clean/templates/press/core/news/index.html:9
+#: src/themes/clean/templates/press/nav.html:16
+#: src/themes/hourglass/templates/press/news/index.html:4
+#: src/themes/material/templates/core/nav.html:88
+#: src/themes/material/templates/press/core/news/index.html:5
+#: src/themes/material/templates/press/core/news/index.html:10
+#: src/themes/material/templates/press/core/news/item.html:6
+msgid "News"
+msgstr "Noticias"
+
+#: src/themes/OLH/templates/press/core/news/index.html:32
+msgid "This press currently has no news items to display."
+msgstr "Esta prensa actualmente no tiene noticias para mostrar."
+
+#: src/themes/OLH/templates/press/core/news/item.html:34
+#: src/themes/material/templates/press/core/news/index.html:21
+#: src/themes/material/templates/press/core/news/item.html:18
+msgid "Posted by"
+msgstr "Publicado por"
+
+#: src/themes/OLH/templates/press/core/news/item.html:41
+#: src/themes/material/templates/core/news/item.html:36
+#: src/themes/material/templates/press/core/news/item.html:23
+msgid "Tags"
+msgstr "Etiquetas"
+
+#: src/themes/OLH/templates/press/core/news/item.html:46
+#: src/themes/clean/templates/press/core/news/item.html:18
+#: src/themes/material/templates/press/core/news/item.html:31
+msgid "Back to News List"
+msgstr "Volver a la lista de noticias"
+
+#: src/themes/OLH/templates/press/elements/press_footer.html:13
+#: src/themes/clean/templates/elements/press_footer.html:16
+msgid "Sitemap"
+msgstr "Mapa del sitio"
+
+#: src/themes/OLH/templates/press/nav.html:23
+#: src/themes/OLH/templates/press/press_journals.html:5
+#: src/themes/clean/templates/press/nav.html:37
+#: src/themes/clean/templates/press/press_journals.html:10
+#: src/themes/hourglass/templates/press/press_journals.html:9
+#: src/themes/material/templates/press/press_journals.html:9
+msgid "Journals"
+msgstr "Revistas"
+
+#: src/themes/OLH/templates/press/nav.html:26
+msgid "Conferences"
+msgstr ""
+
+#: src/themes/OLH/templates/press/nav.html:30
+#: src/themes/clean/templates/press/nav.html:43
+#: src/themes/material/templates/press/nav.html:46
+#: src/themes/material/templates/press/nav.html:97
+msgid "Repositories"
+msgstr ""
+
+#: src/themes/OLH/templates/press/nav.html:39
+#: src/themes/material/templates/preprints/editors.html:5
+#: src/themes/material/templates/preprints/editors.html:6
+msgid "Editorial Team"
+msgstr "Equipo editorial"
+
+#: src/themes/OLH/templates/press/press_journals.html:48
+msgid "Disciplines"
+msgstr ""
+
+#: src/themes/OLH/templates/press/press_journals.html:61
+#: src/themes/OLH/templates/press/press_journals.html:68
+#: src/themes/clean/templates/journal/article.html:194
+#: src/themes/clean/templates/press/press_journals.html:32
+#: src/themes/clean/templates/press/press_journals.html:39
+#: src/themes/material/templates/journal/article.html:283
+#: src/themes/material/templates/press/press_journals.html:36
+#: src/themes/material/templates/press/press_journals.html:43
+msgid "View"
+msgstr "Ver"
+
+#: src/themes/OLH/templates/repository/about.html:15
+#: src/themes/OLH/templates/repository/nav.html:4
+#: src/themes/material/templates/preprints/about.html:4
+#: src/themes/material/templates/preprints/about.html:9
+#: src/themes/material/templates/repository/about.html:4
+#: src/themes/material/templates/repository/about.html:9
+#: src/themes/material/templates/repository/nav.html:19
+#: src/themes/material/templates/repository/nav.html:43
+msgid "About"
+msgstr "Acerca de"
+
+#: src/themes/OLH/templates/repository/home.html:29
+#: src/themes/material/templates/repository/home.html:37
+msgid "Read about"
+msgstr "Leer acerca de"
+
+#: src/themes/OLH/templates/repository/home.html:30
+#: src/themes/material/templates/repository/home.html:38
+msgid "or view list of"
+msgstr "o ver la lista de"
+
+#: src/themes/OLH/templates/repository/home.html:36
+msgid "Latest Preprints"
+msgstr "Últimos Preprints"
+
+#: src/themes/OLH/templates/repository/home.html:43
+#: src/themes/OLH/templates/repository/list.html:95
+msgid "Filter by Subject"
+msgstr "Filtrar por tema"
+
+#: src/themes/OLH/templates/repository/list.html:7
+msgid "All"
+msgstr "Todos"
+
+#: src/themes/OLH/templates/repository/list.html:69
+msgid "Search preprints"
+msgstr "Buscar preprints"
+
+#: src/themes/OLH/templates/repository/list.html:73
+msgid "Searching by"
+msgstr "Buscando por"
+
+#: src/themes/OLH/templates/repository/list.html:78
+#: src/themes/material/templates/repository/list.html:62
+msgid "Author Affiliation"
+msgstr "Afiliación del autor"
+
+#: src/themes/OLH/templates/repository/nav.html:6
+#: src/themes/material/templates/repository/nav.html:21
+#: src/themes/material/templates/repository/nav.html:45
+#: src/themes/material/templates/repository/preprint.html:166
+msgid "Subjects"
+msgstr ""
+
+#: src/themes/OLH/templates/repository/preprint.html:53
+#: src/themes/material/templates/preprints/article.html:51
+msgid "Preprint Body"
+msgstr ""
+
+#: src/themes/OLH/templates/repository/preprint.html:60
+#: src/themes/material/templates/preprints/article.html:63
+#: src/themes/material/templates/repository/preprint.html:85
+msgid "Comments"
+msgstr "Comentarios"
+
+#: src/themes/OLH/templates/repository/preprint.html:66
+#: src/themes/material/templates/preprints/article.html:69
+msgid "Add Comment"
+msgstr ""
+
+#: src/themes/OLH/templates/repository/preprint.html:104
+msgid ""
+"There are no comments or no comments have been made public for this article."
+msgstr "No hay comentarios o no se han hecho comentarios para este artículo."
+
 #: src/themes/OLH/templates/repository/preprint.html:125
 msgid "Last Updated"
 msgstr ""
+
+#: src/themes/OLH/templates/repository/preprint.html:138
+#: src/themes/material/templates/preprints/article.html:135
+msgid "Versions"
+msgstr "Versiones"
+
+#: src/themes/OLH/templates/repository/preprint.html:143
+msgid "This is the only version of the preprint."
+msgstr "Esta es la única versión de la preimpresión."
+
+#: src/themes/OLH/templates/repository/preprint.html:149
+#: src/themes/clean/templates/journal/article.html:288
+#: src/themes/material/templates/preprints/article.html:130
+#: src/themes/material/templates/repository/preprint.html:201
+msgid "Metrics"
+msgstr "Métrica"
+
+#: src/themes/OLH/templates/repository/preprint.html:156
+#: src/themes/material/templates/preprints/article.html:152
+#: src/themes/material/templates/preprints/list.html:6
+#: src/themes/material/templates/preprints/list.html:14
+msgid "All Preprints"
+msgstr "Todos los Preprints"
 
 #: src/themes/clean/templates/403.html:18
 msgid "You do not have permission to view this page"
 msgstr ""
 
-#: src/themes/clean/templates/500.html:21
-#: src/themes/clean/templates/core/base.html:37
-msgid "Skip to main content"
+#: src/themes/clean/templates/500.html:27
+msgid "A server error has occurred."
+msgstr ""
+
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:14
+msgid ""
+"The ORCiD you logged in with is not currently linked with an account in our "
+"system. You can either\n"
+"            register a new account, or login with an existing account to "
+"link your ORCiD for future use."
+msgstr ""
+
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:34
+msgid "Forgot your password"
+msgstr ""
+
+#: src/themes/clean/templates/core/accounts/register.html:26
+#: src/themes/clean/templates/core/accounts/reset_password.html:26
+msgid ""
+"For more information read our <a href=\"#\" data-toggle=\"modal\" data-"
+"target=\"#passwordmodal\">password guide</a>."
 msgstr ""
 
 #: src/themes/clean/templates/core/accounts/register.html:60
-msgid "\n"
-"                    <p class=\"lead\">When it comes to passwords, length is better than complexity.</p>\n"
-"                    <p>Its a common myth that a short and complex password (Jfjfy&65^87) is more secure than a long and\n"
-"                        uncomplicated password (our awesome moon base rocks).</p>\n"
-"                    <p>We recommend selecting a long, but easy to remember password such as <em>our awesome moon base\n"
-"                        rocks</em> which would take an estimated septillion years to crack as opposed to a complex one\n"
-"                        like <em>Jfjfy&65^87</em> which would take just over 600 years on a standard computer.</p>\n"
+msgid ""
+"\n"
+"                    <p class=\"lead\">When it comes to passwords, length is "
+"better than complexity.</p>\n"
+"                    <p>Its a common myth that a short and complex password "
+"(Jfjfy&65^87) is more secure than a long and\n"
+"                        uncomplicated password (our awesome moon base rocks)."
+"</p>\n"
+"                    <p>We recommend selecting a long, but easy to remember "
+"password such as <em>our awesome moon base\n"
+"                        rocks</em> which would take an estimated septillion "
+"years to crack as opposed to a complex one\n"
+"                        like <em>Jfjfy&65^87</em> which would take just over "
+"600 years on a standard computer.</p>\n"
 "                    "
+msgstr ""
+
+#: src/themes/clean/templates/core/accounts/reset_password.html:54
+msgid ""
+"Its a common myth that a short and complex password (Jfjfy&65^87) is more "
+"secure than a long and\n"
+"                        uncomplicated password (our awesome moon base rocks)."
+msgstr ""
+
+#: src/themes/clean/templates/core/accounts/reset_password.html:56
+msgid ""
+"We recommend selecting a long, but easy to remember password such as <em>our "
+"awesome moon base\n"
+"                        rocks</em> which would take an estimated septillion "
+"years to crack as opposed to a complex one\n"
+"                        like <em>Jfjfy&65^87</em> which would take just over "
+"600 years on a standard computer."
 msgstr ""
 
 #: src/themes/clean/templates/core/nav.html:82
 msgid "Account "
+msgstr ""
+
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:9
+msgid ""
+"If you want to change your email address you may do so\n"
+"                    below, however, you will be logged out and\n"
+"                    your account will be marked as inactive until you follow "
+"the\n"
+"                    instructions in the verfication email."
+msgstr ""
+
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:13
+msgid "Note"
+msgstr ""
+
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:14
+msgid ""
+"Changing your email address will also change your username\n"
+"                    as these are one and the same."
+msgstr ""
+
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:19
+msgid "Current email address"
+msgstr ""
+
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:68
+msgid ""
+"You can update your password by entering your existing password plus your "
+"new password"
+msgstr ""
+
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:77
+msgid "Enter New Password"
+msgstr ""
+
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:81
+msgid "Enter New Password Again"
+msgstr ""
+
+#: src/themes/clean/templates/elements/journal/issue_list.html:8
+msgid "This journal has no issues"
+msgstr ""
+
+#: src/themes/clean/templates/elements/journal/issue_list_by_decade.html:2
+msgid ""
+"\n"
+"        Issues are grouped by decade. Select a decade to view the issues\n"
+"        published during that decade.\n"
+"    "
+msgstr ""
+
+#: src/themes/clean/templates/elements/journal/table_modal.html:12
+#: src/themes/clean/templates/elements/public_reviews.html:35
+#: src/themes/material/templates/core/accounts/register.html:61
+#: src/themes/material/templates/core/accounts/reset_password.html:51
+#: src/themes/material/templates/elements/summary_modal.html:13
+msgid "Close"
+msgstr "Cerrar"
+
+#: src/themes/clean/templates/elements/journal_footer.html:7
+msgid "Print ISSN"
 msgstr ""
 
 #: src/themes/clean/templates/elements/pagination.html:62
@@ -4409,123 +4674,487 @@ msgid "all"
 msgstr ""
 
 #: src/themes/clean/templates/elements/public_reviews.html:28
-msgid "\n"
-"                    <p><b>Note:<br/>This review refers to round %(review.review_round.round_number)s of peer\n"
-"                        review and may pertain to an earlier version of the document.</p>\n"
+#, python-format
+msgid ""
+"\n"
+"                    <p><b>Note:<br/>This review refers to round "
+"%(review.review_round.round_number)s of peer\n"
+"                        review and may pertain to an earlier version of the "
+"document.</p>\n"
 "                    "
 msgstr ""
 
-#: src/themes/clean/templates/journal/article.html:133
-msgid "\n"
-"                                        (grant %(id)s)\n"
-"                                    "
+#: src/themes/clean/templates/elements/sections_block.html:4
+msgid "Sections submission information"
 msgstr ""
 
-#: src/themes/clean/templates/journal/article.html:343
+#: src/themes/clean/templates/journal/article.html:278
+msgid "Open Peer Reviews"
+msgstr ""
+
+#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/material/templates/journal/article.html:184
+msgid "Wikipedia"
+msgstr "Wikipedia"
+
+#: src/themes/clean/templates/journal/article.html:297
+#: src/themes/material/templates/journal/article.html:192
+msgid "Reddit"
+msgstr "Reddit"
+
+#: src/themes/clean/templates/journal/article.html:302
+#: src/themes/material/templates/preprints/article.html:145
+msgid "Citation"
+msgstr "Cita"
+
+#: src/themes/clean/templates/journal/article.html:366
 msgid "View Larger Table"
+msgstr ""
+
+#: src/themes/clean/templates/journal/articles.html:48
+msgid "Sort and Filter"
 msgstr ""
 
 #: src/themes/clean/templates/journal/articles.html:71
 msgid "Section Filters"
 msgstr ""
 
+#: src/themes/clean/templates/journal/authors.html:26
+#: src/themes/material/templates/journal/authors.html:31
+#: src/themes/material/templates/journal/editorial_team.html:34
+msgid "View Profile"
+msgstr ""
+
+#: src/themes/clean/templates/journal/collections.html:36
+#: src/themes/material/templates/journal/collections.html:38
+msgid "There are no collections to display"
+msgstr "No hay colecciones para mostrar"
+
+#: src/themes/clean/templates/journal/contact.html:10
+msgid "Journal Contacts"
+msgstr ""
+
+#: src/themes/clean/templates/journal/homepage_elements/carousel.html:5
+msgid "Latest Articles & News"
+msgstr ""
+
+#: src/themes/clean/templates/journal/homepage_elements/carousel.html:32
+msgid "Previous"
+msgstr ""
+
+#: src/themes/clean/templates/journal/homepage_elements/carousel.html:36
+msgid "Next"
+msgstr ""
+
+#: src/themes/clean/templates/journal/homepage_elements/carousel.html:41
+#: src/themes/clean/templates/journal/homepage_elements/carousel.html:46
+msgid "Play"
+msgstr ""
+
+#: src/themes/clean/templates/journal/issues.html:14
+msgid "The current issue is"
+msgstr ""
+
 #: src/themes/clean/templates/press/press_journals.html:52
 msgid "No journals to list"
 msgstr ""
 
-#: src/themes/material/templates/journal/article.html:161
-msgid "\n"
-"                                                (grant %(id)s)\n"
-""
+#: src/themes/clean/templates/press/press_journals.html:57
+#: src/themes/material/templates/press/press_journals.html:60
+msgid "Start typing to filter."
 msgstr ""
 
-#: src/core/views.py:355
-msgid "Your account has been created. Please follow the instructions in the email that has been sent to you."
+#: src/themes/hourglass/templates/core/accounts/orcid_registration.html:10
+#, fuzzy
+#| msgid "Unregistered ORCiD"
+msgid "Unregistered ORCID"
+msgstr "ORCID no registrado"
+
+#: src/themes/hourglass/templates/custom/get-reset-token.html:27
+#, fuzzy
+#| msgid "Enter your email address to begin the reset process"
+msgid ""
+"\n"
+"                  Enter your email address to begin the reset process\n"
+"                "
+msgstr "Ingrese su dirección de correo electrónico"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:19
+msgid ""
+"\n"
+"          <p>The ORCiD you logged in with is not currently linked with\n"
+"          an account in our system. You can either register a new account, "
+"or\n"
+"          login with an existing account to link your ORCiD for future use.</"
+"p>\n"
+"        "
 msgstr ""
 
-#: src/core/views.py:400
-msgid "Account activated"
+#: src/themes/hourglass/templates/custom/orcid-registration.html:43
+#, fuzzy
+#| msgid "Register an Account"
+msgid "Register an account"
+msgstr "Registrar una cuenta"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:46
+#, fuzzy
+#| msgid "Reset Your Password"
+msgid "Reset your password"
+msgstr "Restablecer su contraseña"
+
+#: src/themes/hourglass/templates/custom/profile.html:40
+msgid ""
+"\n"
+"                    Please note: If you update your email,\n"
+"                    You will be logged out, and you won't be\n"
+"                    able to log in again until you follow\n"
+"                    the verification link in an email\n"
+"                    sent to your new email address.\n"
+"                  "
 msgstr ""
 
-#: src/core/views.py:442
-msgid "An account with that email address already exists."
+#: src/themes/material/templates/core/accounts/activate_account.html:29
+msgid ""
+"There was no inactive account with this activation code found. It is "
+"possible that your account is already active, you can check by attempting to "
 msgstr ""
 
-#: src/core/views.py:448
-msgid "Email address is not valid."
+#: src/themes/material/templates/core/accounts/register.html:29
+#: src/themes/material/templates/core/accounts/reset_password.html:26
+msgid ""
+"For more information read our <a href=\"#\" data-target=\"passwordmodal\" "
+"class=\"modal-trigger\">password guide</a>."
 msgstr ""
 
-#: src/core/views.py:463
-msgid "Password updated."
+#: src/themes/material/templates/core/accounts/register.html:56
+#: src/themes/material/templates/core/accounts/reset_password.html:46
+msgid ""
+"We recommend selecting a long, but easy to remember password such as <i>our "
+"awesome moon base\n"
+"                rocks</i> which would take an estimated septillion years to "
+"crack as opposed to a complex one\n"
+"                like <i>Jfjfy&65^87</i> which would take just over 600 years "
+"on a standard computer."
+msgstr ""
+"Recomendamos seleccionar una contraseña larga, pero fácil de recordar, como "
+"<i> nuestra impresionante base lunar\n"
+"                rocas </i> que tardarían un septilón estimado en romperse en "
+"comparación con una compleja\n"
+"                como <i> Jfjfy & 65 ^ 87 </i> que llevaría un poco más de "
+"600 años en una computadora estándar."
+
+#: src/themes/material/templates/core/login.html:15
+msgid "Login with your account"
 msgstr ""
 
-#: src/core/views.py:467
-msgid "Passwords do not match"
+#: src/themes/material/templates/core/login.html:45
+msgid "Register an Account"
+msgstr "Registrar una cuenta"
+
+#: src/themes/material/templates/core/login.html:48
+msgid "Reset Your Password"
+msgstr "Restablecer su contraseña"
+
+#: src/themes/material/templates/core/news/index.html:40
+msgid "This journal currently has no items to display."
 msgstr ""
 
-#: src/core/views.py:470
-msgid "Old password is not correct."
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:9
+msgid ""
+"If you want to change your email address you may do so below, however, you "
+"will be logged out and your account will be marked as inactive until you "
+"follow the instructions in the verification email."
+msgstr ""
+"Sin embargo, si desea cambiar su dirección de correo electrónico, puede "
+"hacerlo a continuación, se desconectará y su cuenta se marcará como inactiva "
+"hasta que siga las instrucciones del correo electrónico de verificación."
+
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:10
+msgid "Note:"
+msgstr "Nota:"
+
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:11
+msgid ""
+"Changing your email address will also change your username as these are one "
+"and the same."
+msgstr ""
+"Cambiar su dirección de correo electrónico también cambiará su nombre de "
+"usuario ya que estos son uno y el mismo."
+
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:32
+msgid ""
+"Use the button below to register to receive notifications of new articles\n"
+"                                published in this journal "
 msgstr ""
 
-#: src/core/views.py:480
-msgid "Successfully subscribed to article notifications."
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:50
+msgid "Data Export"
+msgstr "Exportación de datos"
+
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:51
+msgid "You may export your data into a JSON file for reuse."
+msgstr "Puede exportar sus datos a un archivo JSON para reutilizarlos."
+
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:54
+msgid "Export"
+msgstr "Exportar"
+
+#: src/themes/material/templates/elements/journal/issue_list.html:26
+msgid "close"
 msgstr ""
 
-#: src/core/views.py:491
-msgid "Successfully unsubscribed from article notifications."
+#: src/themes/material/templates/elements/journal/issue_list.html:30
+msgid "View Issue"
+msgstr "Ver problema"
+
+#: src/themes/material/templates/elements/license_block.html:4
+msgid "More Information "
 msgstr ""
 
-#: src/plugins_bak/typesetting/forms.py:16
-msgid "Are you sure you want to create a typesetting assignment?"
+#: src/themes/material/templates/journal/article.html:176
+msgid "Tweets"
 msgstr ""
 
-#: src/plugins_bak/typesetting/forms.py:90
-msgid "Are you sure you want to create a proofreading assignment?"
+#: src/themes/material/templates/journal/article.html:318
+msgid "Article No."
 msgstr ""
 
-#: src/plugins_bak/typesetting/forms.py:160
-msgid "Text to show as the download link on the article page"
+#: src/themes/material/templates/journal/article.html:330
+msgid "Publication"
 msgstr ""
 
-#: src/plugins_bak/typesetting/forms.py:199
-msgid "Are you sure you want to complete the proofreading task?"
+#: src/themes/material/templates/journal/article.html:426
+msgid "This article has been peer reviewed."
 msgstr ""
 
-#: src/plugins_bak/typesetting/forms.py:224
-msgid "You have not proofed some galleys:"
+#: src/themes/material/templates/journal/collections.html:33
+msgid "View Collection"
+msgstr "Ver colección"
+
+#: src/themes/material/templates/journal/new_search.html:26
+#: src/themes/material/templates/journal/search.html:28
+msgid "Searching"
+msgstr "buscando"
+
+#: src/themes/material/templates/preprints/article.html:19
+msgid ""
+"This article is a preprint, it has not been peer reviewed or had any "
+"extensive editorial over-sight."
 msgstr ""
 
-#: src/plugins_bak/typesetting/logic.py:164
-msgid "Article has no typeset files"
+#: src/themes/material/templates/preprints/article.html:147
+msgid "Harvard Citation"
 msgstr ""
 
-#: src/plugins_bak/typesetting/logic.py:165
-msgid "One or more typeset files are missing images"
+#: src/themes/material/templates/preprints/article.html:148
+msgid "Vancouver Citation"
 msgstr ""
 
-#: src/plugins_bak/typesetting/logic.py:167
-msgid "One or more typesetting or proofing tasks haven't been completed"
+#: src/themes/material/templates/preprints/article.html:149
+msgid "APA Citation"
 msgstr ""
 
-#: src/plugins_bak/typesetting/templates/typesetting/typesetting_proofreading_assignment.html:116
-msgid "Mark Task as Complete"
+#: src/themes/material/templates/preprints/editors.html:10
+msgid "Subject Area Editors"
+msgstr "Editores del área temática"
+
+#: src/themes/material/templates/preprints/list.html:37
+msgid "There are no preprints to display"
+msgstr "No hay preimpresos para mostrar"
+
+#: src/themes/material/templates/preprints/list.html:69
+msgid "search"
+msgstr "buscar"
+
+#: src/themes/material/templates/preprints/list.html:71
+#: src/themes/material/templates/repository/list.html:52
+msgid "Search Preprints"
+msgstr "Buscar Preprints"
+
+#: src/themes/material/templates/preprints/list.html:74
+#: src/themes/material/templates/repository/list.html:55
+msgid "You can search by:"
+msgstr "Puedes buscar por:"
+
+#: src/themes/material/templates/preprints/list.html:81
+msgid "Author Institution"
+msgstr "Institución del autor"
+
+#: src/themes/material/templates/repository/home.html:34
+msgid "Start New Submission"
 msgstr ""
 
-#: src/themes/OLH/templates/elements/journal_footer.html:6
-#: src/themes/clean/templates/elements/journal_footer.html:8
-#: src/themes/material/templates/elements/journal_footer.html:6
-msgid "Published by"
+#: src/themes/material/templates/repository/preprint.html:68
+msgid "Add a Comment"
 msgstr ""
 
-#: src/themes/clean/templates/elements/journal_footer.html:7
-msgid "Print ISSN"
+#: src/utils/forms.py:107
+#, python-format
+msgid "What is %(num1)i %(operator)s %(num2)i? "
+msgstr ""
+"¿Cual es el resultado de la siguiente operacion: %(num1)i %(operator)s "
+"%(num2)i?"
+
+#: src/utils/forms.py:108
+msgid "Answer this question: "
+msgstr "Responda a esta pregunta:"
+
+#: src/utils/forms.py:153
+msgid "HTML is not allowed in this field"
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:7
-#: src/templates/admin/submission/timeline.html:43
-#: src/templates/admin/submission/timeline.html:44
-#: src/templates/admin/submission/timeline.html:51
-#: src/templates/admin/submission/timeline.html:52
-msgid "Review your submission"
+#: src/utils/transactional_emails.py:385
+msgid "accepted"
 msgstr ""
 
+#: src/utils/transactional_emails.py:395
+msgid "declined"
+msgstr ""
+
+#~ msgid "Password 1"
+#~ msgstr "Contraseña 1"
+
+#~ msgid "Password 2"
+#~ msgstr "Contraseña 2"
+
+#~ msgid "Subtitle of the article display format; Title: Subtitle"
+#~ msgstr "Subtítulo del artículo (formato final: Título: Subtítulo)"
+
+#~ msgid "somebody"
+#~ msgstr "alguien"
+
+#~ msgid "Focus and Scope for"
+#~ msgstr "Enfoque y alcance para"
+
+#~ msgid "Publication Cycle"
+#~ msgstr "Ciclo de publicacion"
+
+#~ msgid "Submission guidelines"
+#~ msgstr "Directrices para el envío"
+
+#~ msgid ""
+#~ "To upload a file, select it\n"
+#~ "                    using one of the 'Choose file' buttons, then upload "
+#~ "it with the 'Upload file' button next to it. You\n"
+#~ "                    will then be asked for some additional information "
+#~ "(label, description etc.)"
+#~ msgstr ""
+#~ "Para subir un archivo, selecciónelo.\n"
+#~ "                    utilizando uno de los botones 'Elegir archivo', luego "
+#~ "cárguelo con el botón 'Cargar archivo' que se encuentra al lado. Tú\n"
+#~ "                    luego se le pedirá información adicional (etiqueta, "
+#~ "descripción, etc.)"
+
+#~ msgid "Comments to Editor"
+#~ msgstr "Comentarios para el editor"
+
+#~ msgid "No authors yet! Add one."
+#~ msgstr "¡Aún no hay autores! Agrega uno."
+
+#~ msgid "Manuscript Files"
+#~ msgstr "Archivos de manuscritos"
+
+#~ msgid ""
+#~ "Your password should be at minimum 12 characters long. It does not\n"
+#~ "                                    need to contain specific\n"
+#~ "                                    characters but you should make it as "
+#~ "long as possible. For more information read our\n"
+#~ "                                    <a href=\"#\" data-toggle=\"modal\" "
+#~ "data-target=\"#passwordmodal\">password\n"
+#~ "                                        guide</a>."
+#~ msgstr ""
+#~ "Su contraseña debe tener una longitud mínima de 12 caracteres. No es asi\n"
+#~ "                                    necesita contener específica\n"
+#~ "                                    Caracteres pero deberías hacerlo lo "
+#~ "más largo posible. Para más información lea nuestra\n"
+#~ "                                    <a href=\"#\" data-toggle=\"modal\" "
+#~ "data-target=\"#passwordmodal\"> contraseña\n"
+#~ "                                        guía </a>."
+
+#~ msgid "allows the following licenses for submission"
+#~ msgstr "Licencias disponibles para nuevos envíos"
+
+#~ msgid "Sorry, there was a server error. Our team has been notified."
+#~ msgstr ""
+#~ "Lo sentimos, hubo un error en el servidor. Nuestro equipo ha sido "
+#~ "notificado."
+
+#~ msgid ""
+#~ "Your password should be at minimum 12 characters long. It does not need "
+#~ "to\n"
+#~ "                            contain specific\n"
+#~ "                            characters but you should make it as long as "
+#~ "possible. For more information read our\n"
+#~ "                            <a href=\"#\" data-open=\"password-"
+#~ "modal\">password guide</a>"
+#~ msgstr ""
+#~ "Su contraseña debe tener una longitud mínima de 12 caracteres. No "
+#~ "necesita\n"
+#~ "                            contener especifico\n"
+#~ "                            Caracteres pero deberías hacerlo lo más largo "
+#~ "posible. Para más información lea nuestra\n"
+#~ "                            <a href=\"#\" data-open=\"password-modal\"> "
+#~ "guía de contraseñas </a>"
+
+#~ msgid "File Checksums (MD5)"
+#~ msgstr "Sumas de comprobación de archivos (MD5)"
+
+#~ msgid "Preprint Authors"
+#~ msgstr "Autores de preimpresión"
+
+#~ msgid "Add authors to"
+#~ msgstr "Añadir autores a"
+
+#~ msgid ""
+#~ "When you've added all the authors, select Save and Continue to move to "
+#~ "the next step of your submission."
+#~ msgstr ""
+#~ "Cuando haya agregado todos los autores, seleccione Guardar y continuar "
+#~ "para pasar al siguiente paso de su envío."
+
+#~ msgid "Preprint Editors"
+#~ msgstr "Editores de preimpresión"
+
+#~ msgid "This repository has no subjects or editors to display."
+#~ msgstr "Este repositorio no tiene temas o editores para mostrar."
+
+#~ msgid "preprints"
+#~ msgstr "preprints"
+
+#~ msgid "all preprints"
+#~ msgstr "todos los preprints"
+
+#~ msgid "Review Preprint Submission"
+#~ msgstr "Revisar la presentación de preimpresión"
+
+#~ msgid "Preprint Files"
+#~ msgstr "Archivos de preimpresión"
+
+#~ msgid "Submit a Preprint"
+#~ msgstr "Presentar una preimpresión"
+
+#~ msgid ""
+#~ "Please read the following carefully before you submit your preprints."
+#~ msgstr "Lea atentamente lo siguiente antes de enviar sus preimpresiones."
+
+#~ msgid ""
+#~ "If you have any additional information you'd like to supply to the "
+#~ "preprints editor, do so here"
+#~ msgstr ""
+#~ "Si tiene alguna información adicional que le gustaría proporcionar al "
+#~ "editor de preprints, hágalo aquí"
+
+#~ msgid "Dates"
+#~ msgstr "fechas"
+
+#~ msgid "This article has not been peer reviewed."
+#~ msgstr "Este artículo no ha sido revisado por pares."
+
+#~ msgid "Acceptance Criteria"
+#~ msgstr "Criterios de aceptación"
+
+#~ msgid "Read about "
+#~ msgstr "Leer acerca de"
+
+#~ msgid "menu"
+#~ msgstr "menú"

--- a/src/core/locales/fr/LC_MESSAGES/django.po
+++ b/src/core/locales/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-12 16:34+0000\n"
+"POT-Creation-Date: 2024-12-05 10:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,69 +18,76 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/comms/models.py:94
+#: src/comms/models.py:119
 #, fuzzy, python-brace-format
 #| msgid "Posted by"
 msgid "Posted by {byline}"
 msgstr "Posté par"
 
-#: src/comms/models.py:95
+#: src/comms/models.py:120
 #, fuzzy, python-brace-format
 #| msgid "Posted by"
 msgid "Posted by  {byline}"
 msgstr "Posté par"
 
-#: src/copyediting/forms.py:16
+#: src/copyediting/forms.py:17
 msgid "Are you sure you want to create a copyediting assignment?"
 msgstr ""
 
-#: src/copyediting/forms.py:99
+#: src/copyediting/forms.py:104
 msgid "Are you sure you want to ask the author to review copyedits?"
 msgstr ""
 
-#: src/copyediting/forms.py:146
+#: src/copyediting/forms.py:151
 msgid "Are you sure you want to complete the copyedit task?"
 msgstr ""
 
-#: src/core/forms/forms.py:110
-msgid "Password 1"
-msgstr "Mot de passe"
-
-#: src/core/forms/forms.py:111
-msgid "Password 2"
-msgstr "Répéter le mot de passe"
-
-#: src/core/forms/forms.py:129
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/core/forms/forms.py:114 src/core/forms/forms.py:162
+#: src/templates/admin/core/accounts/orcid_registration.html:29
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
 #: src/themes/OLH/templates/press/core/login.html:33
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:24
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:28
 #: src/themes/clean/templates/core/login.html:34
+#: src/themes/hourglass/templates/custom/orcid-registration.html:32
 #, fuzzy
 #| msgid "Password 1"
 msgid "Password"
 msgstr "Mot de passe"
 
-#: src/core/forms/forms.py:130
+#: src/core/forms/forms.py:123 src/core/forms/forms.py:170
 msgid "Repeat Password"
 msgstr "Répéter le mot de passe"
 
-#: src/core/forms/forms.py:133
+#: src/core/forms/forms.py:148 src/core/models.py:235
+#: src/templates/admin/core/accounts/orcid_registration.html:25
+#: src/templates/admin/repository/article.html:213
+#: src/templates/admin/repository/author_article.html:92
+#: src/templates/admin/repository/submit/authors.html:77
+#: src/templates/admin/submission/submit_authors.html:70
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:33
+#: src/themes/OLH/templates/press/core/login.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:25
+#: src/themes/hourglass/templates/custom/orcid-registration.html:28
+msgid "Email"
+msgstr "Email"
+
+#: src/core/forms/forms.py:179
 msgid ""
 "Check this box if you would like to receive notifications of new articles "
 "published in this journal"
 msgstr ""
 
-#: src/core/forms/forms.py:495
+#: src/core/forms/forms.py:578
 #, fuzzy
 #| msgid "Email"
 msgid "E-mail"
 msgstr "Email"
 
-#: src/core/forms/forms.py:694
+#: src/core/forms/forms.py:783
 msgid "Are you sure?"
 msgstr ""
 
-#: src/core/forms/forms.py:725
+#: src/core/forms/forms.py:814
 #, python-format
 msgid ""
 "The account belonging to %(email)s has not yet been activated, so the "
@@ -125,233 +132,225 @@ msgstr ""
 msgid "Issues and Collections"
 msgstr "Collections"
 
-#: src/core/janeway_global_settings.py:252
+#: src/core/janeway_global_settings.py:254
 #, fuzzy
 #| msgid "English"
 msgid "English"
 msgstr "Anglais"
 
-#: src/core/janeway_global_settings.py:253
+#: src/core/janeway_global_settings.py:255
 #, fuzzy
 #| msgid "English"
 msgid "English (US)"
 msgstr "Anglais"
 
-#: src/core/janeway_global_settings.py:254
+#: src/core/janeway_global_settings.py:256
 msgid "French"
 msgstr "Français"
 
-#: src/core/janeway_global_settings.py:255
+#: src/core/janeway_global_settings.py:257
 msgid "German"
 msgstr "Allemand"
 
-#: src/core/janeway_global_settings.py:256
+#: src/core/janeway_global_settings.py:258
 msgid "Dutch"
 msgstr ""
 
-#: src/core/janeway_global_settings.py:257
+#: src/core/janeway_global_settings.py:259
 msgid "Welsh"
 msgstr ""
 
-#: src/core/logic.py:810
+#: src/core/logic.py:833
 msgid "Your password must be {} characters long"
 msgstr ""
 
-#: src/core/logic.py:814
+#: src/core/logic.py:837
 msgid "An uppercase character is required"
 msgstr ""
 
-#: src/core/logic.py:817
+#: src/core/logic.py:840
 msgid "A number is required"
 msgstr ""
 
-#: src/core/models.py:69
+#: src/core/models.py:77
 msgid "Miss"
 msgstr ""
 
-#: src/core/models.py:70
+#: src/core/models.py:78
 msgid "Ms"
 msgstr ""
 
-#: src/core/models.py:71
+#: src/core/models.py:79
 #, fuzzy
 #| msgid "Altmetrics"
 msgid "Mrs"
 msgstr "Altmetrics"
 
-#: src/core/models.py:72
+#: src/core/models.py:80
 msgid "Mr"
 msgstr ""
 
-#: src/core/models.py:73
+#: src/core/models.py:81
 msgid "Mx"
 msgstr ""
 
-#: src/core/models.py:74
+#: src/core/models.py:82
 msgid "Dr"
 msgstr ""
 
-#: src/core/models.py:75
+#: src/core/models.py:83
 msgid "Prof."
 msgstr ""
 
-#: src/core/models.py:208 src/templates/admin/repository/article.html:213
-#: src/templates/admin/repository/author_article.html:92
-#: src/templates/admin/repository/submit/authors.html:80
-#: src/templates/admin/submission/submit_authors.html:65
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:26
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:29
-#: src/themes/OLH/templates/press/core/login.html:30
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:16
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:18
-msgid "Email"
-msgstr "Email"
-
-#: src/core/models.py:209
+#: src/core/models.py:236
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: src/core/models.py:211
+#: src/core/models.py:242
 msgid "First name"
 msgstr "Prénom"
 
-#: src/core/models.py:212 src/submission/forms.py:271
+#: src/core/models.py:248 src/submission/forms.py:286
 msgid "Middle name"
 msgstr "Deuxième nom"
 
-#: src/core/models.py:213 src/submission/forms.py:272
+#: src/core/models.py:254 src/submission/forms.py:287
 msgid "Last name"
 msgstr "Nom de famille"
 
-#: src/core/models.py:217
+#: src/core/models.py:263
 msgid "Salutation"
 msgstr "Salutation"
 
-#: src/core/models.py:222
+#: src/core/models.py:269
 msgid "Name suffix"
 msgstr ""
 
-#: src/core/models.py:224
-#: src/themes/OLH/templates/core/accounts/public_profile.html:19
-#: src/themes/clean/templates/core/accounts/public_profile.html:19
-#: src/themes/material/templates/core/accounts/public_profile.html:19
+#: src/core/models.py:274
+#: src/themes/OLH/templates/core/accounts/public_profile.html:50
+#: src/themes/clean/templates/core/accounts/public_profile.html:23
+#: src/themes/material/templates/core/accounts/public_profile.html:23
 msgid "Biography"
 msgstr "La Biographie"
 
-#: src/core/models.py:225 src/submission/models.py:1943
+#: src/core/models.py:276 src/submission/models.py:2014
 msgid "ORCiD"
 msgstr ""
 
-#: src/core/models.py:226 src/submission/forms.py:275
+#: src/core/models.py:280 src/submission/forms.py:290
 msgid "Institution"
 msgstr "Institution"
 
-#: src/core/models.py:227 src/submission/forms.py:276
+#: src/core/models.py:286 src/submission/forms.py:291
 msgid "Department"
 msgstr "Département"
 
-#: src/core/models.py:228
+#: src/core/models.py:289
 msgid "Twitter Handle"
 msgstr ""
 
-#: src/core/models.py:229
+#: src/core/models.py:290
 msgid "Facebook Handle"
 msgstr ""
 
-#: src/core/models.py:230
+#: src/core/models.py:291
 msgid "Linkedin Profile"
 msgstr ""
 
-#: src/core/models.py:231
+#: src/core/models.py:292
 #: src/themes/OLH/templates/elements/journal/editorial_social_content.html:3
 #: src/themes/clean/templates/elements/journal/editorial_social_content.html:3
 msgid "Website"
 msgstr ""
 
-#: src/core/models.py:232
+#: src/core/models.py:293
 #, fuzzy
 #| msgid "Username"
 msgid "Github Username"
 msgstr "Nom d'utilisateur"
 
-#: src/core/models.py:236
+#: src/core/models.py:297
 #, fuzzy
 #| msgid "Author Information"
 msgid "Confirmation Code"
 msgstr "Informations de l'auteur"
 
-#: src/core/models.py:237
+#: src/core/models.py:300
 msgid "Signature"
 msgstr ""
 
-#: src/core/models.py:243
-#: src/themes/OLH/templates/core/accounts/public_profile.html:15
-#: src/themes/clean/templates/core/accounts/public_profile.html:15
-#: src/themes/material/templates/core/accounts/public_profile.html:15
+#: src/core/models.py:307
+#: src/themes/OLH/templates/core/accounts/public_profile.html:45
+#: src/themes/clean/templates/core/accounts/public_profile.html:19
+#: src/themes/material/templates/core/accounts/public_profile.html:19
 msgid "Country"
 msgstr "Pays"
 
-#: src/core/models.py:246
+#: src/core/models.py:314
 msgid "Preferred Timezone"
 msgstr ""
 
-#: src/core/models.py:254
+#: src/core/models.py:323
 msgid "Enable Digest"
 msgstr ""
 
-#: src/core/models.py:259
+#: src/core/models.py:328
 msgid "If enabled, your basic profile will be available to the public."
 msgstr ""
 
-#: src/core/models.py:261
+#: src/core/models.py:330
 msgid "Enable public profile"
 msgstr ""
 
-#: src/core/models.py:566 src/core/models.py:578
+#: src/core/models.py:639 src/core/models.py:651
 msgid "Expires on"
 msgstr ""
 
-#: src/core/models.py:840 src/core/models.py:1118
+#: src/core/models.py:915 src/core/models.py:1193
 #, fuzzy
 #| msgid "Article"
 msgid "Article PK"
 msgstr "Article"
 
-#: src/core/models.py:845 src/core/models.py:1123 src/repository/models.py:838
-#: src/templates/admin/elements/submit/file.html:24
-#: src/templates/admin/submission/submit_files.html:40
-#: src/templates/admin/submission/submit_files.html:80
-#: src/templates/admin/submission/submit_review.html:120
+#: src/core/models.py:920 src/core/models.py:1198 src/repository/models.py:848
+#: src/templates/admin/submission/submit_files.html:46
+#: src/templates/admin/submission/submit_files.html:86
+#: src/templates/admin/submission/submit_review.html:136
 msgid "Label"
 msgstr "Étiquette"
 
-#: src/core/models.py:846 src/core/models.py:1124
-#: src/templates/admin/elements/submit/file.html:31
+#: src/core/models.py:921 src/core/models.py:1199
 msgid "Description"
 msgstr "La description"
 
-#: src/core/models.py:857
+#: src/core/models.py:932
 msgid "Remote URL of file"
 msgstr ""
 
-#: src/core/models.py:1150
+#: src/core/models.py:1225
 msgid "Other"
 msgstr ""
 
-#: src/core/models.py:1151
+#: src/core/models.py:1226
 msgid "Image"
 msgstr ""
 
-#: src/core/models.py:1493
+#: src/core/models.py:1594 src/templates/admin/journal/contact.html:38
+#: src/themes/OLH/templates/journal/contact.html:30
+#: src/themes/OLH/templates/press/journal/contact.html:22
+#: src/themes/clean/templates/journal/contact.html:27
+msgid "Who would you like to contact?"
+msgstr "Qui souhaitez-vous contacter?"
+
+#: src/core/models.py:1595
 msgid "Your contact email address"
 msgstr "Votre adresse email de contact"
 
-#: src/core/models.py:1494
+#: src/core/models.py:1596
 msgid "Subject"
 msgstr "Assujettir"
 
-#: src/core/models.py:1495
+#: src/core/models.py:1597
 msgid "Your message"
 msgstr "Votre message"
 
@@ -368,151 +367,163 @@ msgid ""
 "MIME type {mimetype} is not valid. Valid types are: {validator.mimetypes}"
 msgstr ""
 
-#: src/core/views.py:78
+#: src/core/views.py:80
 msgid "You have been banned from logging in due to failed attempts."
 msgstr ""
 
-#: src/core/views.py:122
+#: src/core/views.py:124
 msgid ""
 "Password reset process has been initiated, please check your inbox for a "
 "reset request link."
 msgstr ""
 
-#: src/core/views.py:132
+#: src/core/views.py:134
 msgid ""
 "Wrong email/password combination or your email address has not been "
 "confirmed yet."
 msgstr ""
 
-#: src/core/views.py:219
+#: src/core/views.py:226
 msgid "You have been logged out."
 msgstr ""
 
-#: src/core/views.py:236
+#: src/core/views.py:249
 msgid "If your account was found, an email has been sent to you."
 msgstr ""
 
-#: src/core/views.py:355
+#: src/core/views.py:377
 msgid ""
 "Your account has been created. Please follow the instructions in the email "
 "that has been sent to you."
 msgstr ""
 
-#: src/core/views.py:400
+#: src/core/views.py:420
 msgid "Account activated"
 msgstr ""
 
-#: src/core/views.py:442
+#: src/core/views.py:469
 msgid "An account with that email address already exists."
 msgstr ""
 
-#: src/core/views.py:448
+#: src/core/views.py:475
 #, fuzzy
 #| msgid "Your contact email address"
 msgid "Email address is not valid."
 msgstr "Votre adresse email de contact"
 
-#: src/core/views.py:463
+#: src/core/views.py:490
 #, fuzzy
 #| msgid "Password 1"
 msgid "Password updated."
 msgstr "Mot de passe"
 
-#: src/core/views.py:467
+#: src/core/views.py:494
 msgid "Passwords do not match"
 msgstr ""
 
-#: src/core/views.py:470
+#: src/core/views.py:497
 msgid "Old password is not correct."
 msgstr ""
 
-#: src/core/views.py:480
+#: src/core/views.py:507
 #, fuzzy
 #| msgid "Regsiter for"
 msgid "Successfully subscribed to article notifications."
 msgstr "S'inscrire à"
 
-#: src/core/views.py:491
+#: src/core/views.py:518
 msgid "Successfully unsubscribed from article notifications."
 msgstr ""
 
-#: src/core/views.py:1943
+#: src/core/views.py:2079
 msgid ""
 "You cannot remove a section that contains articles. Remove articles from the "
 "section if you want to delete it."
 msgstr ""
+
+#: src/core/views.py:2711 src/journal/forms.py:24 src/journal/views.py:2866
+msgid "Newest"
+msgstr ""
+
+#: src/core/views.py:2712 src/journal/forms.py:25 src/journal/views.py:2867
+msgid "Oldest"
+msgstr ""
+
+#: src/core/views.py:2713
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name A-Z"
+msgstr "Nom de famille"
+
+#: src/core/views.py:2714
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name Z-A"
+msgstr "Nom de famille"
 
 #: src/discussion/models.py:27
 msgid "Max. 300 characters."
 msgstr ""
 
 #. Translators: Search order options
-#: src/journal/forms.py:20
+#: src/journal/forms.py:21
 msgid "Relevance"
 msgstr ""
 
-#: src/journal/forms.py:21 src/journal/views.py:2629
+#: src/journal/forms.py:22 src/journal/views.py:2868
 #, fuzzy
 #| msgid "Title"
 msgid "Titles A-Z"
 msgstr "Titre"
 
-#: src/journal/forms.py:22 src/journal/views.py:2630
+#: src/journal/forms.py:23 src/journal/views.py:2869
 #, fuzzy
 #| msgid "Title"
 msgid "Titles Z-A"
 msgstr "Titre"
 
-#: src/journal/forms.py:23 src/journal/views.py:2627
-msgid "Newest"
-msgstr ""
-
-#: src/journal/forms.py:24 src/journal/views.py:2628
-msgid "Oldest"
-msgstr ""
-
-#: src/journal/forms.py:97
+#: src/journal/forms.py:98
 #: src/themes/clean/templates/core/homepage_elements/search_bar.html:20
 #, fuzzy
 #| msgid "Search"
 msgid "Search term"
 msgstr "Chercher"
 
-#: src/journal/forms.py:98
+#: src/journal/forms.py:99
 #, fuzzy
 #| msgid "Featured Articles"
 msgid "Search Titles"
 msgstr "Article vedette"
 
-#: src/journal/forms.py:99
+#: src/journal/forms.py:100
 #, fuzzy
 #| msgid "Abstract"
 msgid "Search Abstract"
 msgstr "Abstrait"
 
-#: src/journal/forms.py:100
+#: src/journal/forms.py:101
 #, fuzzy
 #| msgid "Search for Existing Authors"
 msgid "Search Authors"
 msgstr "Recherche d'auteurs existants"
 
-#: src/journal/forms.py:101
+#: src/journal/forms.py:102
 #, fuzzy
 #| msgid "Keywords"
 msgid "Search Keywords"
 msgstr "Mots clés"
 
-#: src/journal/forms.py:102
+#: src/journal/forms.py:103
 msgid "Search Full Text"
 msgstr ""
 
-#: src/journal/forms.py:103
+#: src/journal/forms.py:104
 #, fuzzy
 #| msgid "Search"
 msgid "Search ORCIDs"
 msgstr "Chercher"
 
-#: src/journal/forms.py:104 src/templates/common/elements/sorting.html:16
+#: src/journal/forms.py:105 src/templates/common/elements/sorting.html:16
 #: src/themes/clean/templates/elements/sorting.html:17
 #: src/themes/material/templates/elements/sorting.html:31
 #, fuzzy
@@ -520,104 +531,110 @@ msgstr "Chercher"
 msgid "Sort results by"
 msgstr "Fichiers d'article"
 
-#: src/journal/logic.py:212
+#: src/journal/logic.py:216
 msgid "Articles without a section cannot be added to an issue."
 msgstr ""
 
-#: src/journal/models.py:80
+#: src/journal/models.py:101
 msgid ""
 "Short acronym for the journal. Used as part of the journal URLin path mode "
 "and to uniquely identify the journal"
 msgstr ""
 
-#: src/journal/models.py:98
+#: src/journal/models.py:119
 msgid ""
 "The default thumbnail for articles, not to be confused with 'Default cover "
 "image'."
 msgstr ""
 
-#: src/journal/models.py:106
+#: src/journal/models.py:127
 msgid "Replaces the press logo in the footer."
 msgstr ""
 
-#: src/journal/models.py:113
+#: src/journal/models.py:134
 msgid ""
 "The default cover image for journal issues and for the journal's listing on "
 "the press-level website."
 msgstr ""
 
-#: src/journal/models.py:121
+#: src/journal/models.py:142
 msgid "The default background image for article openers and carousel items."
 msgstr ""
 
-#: src/journal/models.py:129
+#: src/journal/models.py:150
 msgid ""
 "The logo-sized image at the top of all pages, typically used for journal "
 "logos."
 msgstr ""
 
-#: src/journal/models.py:137
+#: src/journal/models.py:158
 msgid ""
 "The tiny round or square image appearing in browser tabs before the webpage "
 "title"
 msgstr ""
 
-#: src/journal/models.py:148
+#: src/journal/models.py:166
+msgid ""
+"A default image displayed on the profile and editorial team pages when the "
+"user has no set profile image."
+msgstr ""
+
+#: src/journal/models.py:183
 #, fuzzy
 #| msgid "This article is a preprints"
 msgid "This field has been deprecated in v1.4.3"
 msgstr "Cet article est une preprints"
 
-#: src/journal/models.py:158
+#: src/journal/models.py:193
 msgid "When enabled, the journal is marked as not hosted in Janeway."
 msgstr ""
 
-#: src/journal/models.py:169
+#: src/journal/models.py:204
 msgid "If the journal is remote you can link to its submission page."
 msgstr ""
 
-#: src/journal/models.py:174
+#: src/journal/models.py:209
 msgid "If the journal is remote you can link to its home page."
 msgstr ""
 
-#: src/journal/models.py:178
+#: src/journal/models.py:213
 msgid "Enables a \"View PDF\" link on article pages."
 msgstr ""
 
-#: src/journal/models.py:220
+#: src/journal/models.py:255
 msgid ""
 "Whether to display article numbers. Article numbers are distinct from "
 "article ID and can be set in Edit Metadata."
 msgstr ""
 
-#: src/journal/models.py:532
+#: src/journal/models.py:600
 msgid "Please add as much detail as you can."
 msgstr ""
 
-#: src/journal/models.py:573
+#: src/journal/models.py:724
 msgid "Autogenerated cache of the display format of an issue title"
 msgstr ""
 
-#: src/journal/models.py:588
+#: src/journal/models.py:739
 msgid "Image representing the cover of a printed issue or volume"
 msgstr ""
 
-#: src/journal/models.py:594
+#: src/journal/models.py:745
 msgid "landscape hero image used in the carousel and issue page"
 msgstr ""
 
-#: src/journal/models.py:613
+#: src/journal/models.py:764
 msgid ""
 "An optional alphanumeric code (Slug) used to generate a verbose  url for "
 "this issue. e.g: 'winter-special-issue'."
 msgstr ""
 
-#: src/journal/models.py:635
+#: src/journal/models.py:786
 msgid ""
 "An ISBN is relevant for non-serial collections such as conference proceedings"
 msgstr ""
 
-#: src/journal/models.py:676
+#: src/journal/models.py:827
 #: src/themes/OLH/templates/press/press_journals.html:71
 #: src/themes/clean/templates/press/press_journals.html:42
 #: src/themes/material/templates/press/press_journals.html:46
@@ -626,67 +643,83 @@ msgstr ""
 msgid "Current Issue"
 msgstr "Mot de passe"
 
-#: src/journal/models.py:734
+#: src/journal/models.py:885
 msgid "pages"
 msgstr ""
 
-#: src/journal/models.py:736
+#: src/journal/models.py:887
 msgid "page"
 msgstr ""
 
-#: src/journal/views.py:751
+#: src/journal/views.py:771
 #, fuzzy
 #| msgid "No files uploaded"
 msgid "No file uploaded"
 msgstr "Aucun fichier envoyé"
 
-#: src/journal/views.py:1009
+#: src/journal/views.py:1097
 msgid "Issue not in this journal’s issue list."
 msgstr ""
 
-#: src/journal/views.py:1129
+#: src/journal/views.py:1143
+msgid ""
+"Publication date set to { article.date_published.strftime(\"%Y-%m-%d %H:%M "
+"%Z\") } "
+msgstr ""
+
+#: src/journal/views.py:1150
+#, fuzzy
+#| msgid "Publication Fees"
+msgid "Publication date unset"
+msgstr "Frais de publication"
+
+#: src/journal/views.py:1156
+msgid "Something went wrong when trying to save the form. "
+msgstr ""
+
+#: src/journal/views.py:1241
 #, fuzzy
 #| msgid "Article Information"
 msgid "Article set for publication."
 msgstr "Renseignements sur l'article"
 
-#: src/journal/views.py:1401
+#: src/journal/views.py:1516
 msgid "You cannot move the first section up the order list"
 msgstr ""
 
-#: src/journal/views.py:1433
+#: src/journal/views.py:1548
 msgid "You cannot move the last section down the order list"
 msgstr ""
 
-#: src/journal/views.py:1440
+#: src/journal/views.py:1555
 msgid "This page accepts post requests only."
 msgstr ""
 
-#: src/journal/views.py:1511
+#: src/journal/views.py:1626
 msgid "User is already a guest editor."
 msgstr ""
 
-#: src/journal/views.py:1517
+#: src/journal/views.py:1632
 msgid "This user is not a member of this journal."
 msgstr ""
 
-#: src/journal/views.py:1570
+#: src/journal/views.py:1685
 msgid "Editor removed from Issue."
 msgstr ""
 
-#: src/journal/views.py:1576
+#: src/journal/views.py:1691
 msgid "Issue Editor not found."
 msgstr ""
 
-#: src/journal/views.py:1582
+#: src/journal/views.py:1697
 msgid "No Issue Editor ID supplied."
 msgstr ""
 
-#: src/journal/views.py:1729
+#: src/journal/views.py:1851
 msgid "Uploaded file is not UTF-8 encoded"
 msgstr ""
 
-#: src/journal/views.py:1823
+#: src/journal/views.py:1945
 msgid ""
 "You must login before you can become a reviewer. Click the button below to "
 "login."
@@ -694,7 +727,7 @@ msgstr ""
 "Vous devez vous connecter avant de devenir un réviseur. Cliquez sur le "
 "bouton ci-dessous pour vous connecter"
 
-#: src/journal/views.py:1828
+#: src/journal/views.py:1950
 msgid ""
 "You are not yet a reviewer for this journal. Click the button below to "
 "become a reviewer."
@@ -702,51 +735,86 @@ msgstr ""
 "Vous n'êtes pas encore critique pour ce journal. Cliquez sur le bouton ci-"
 "dessous pour devenir réviseur"
 
-#: src/journal/views.py:1833
+#: src/journal/views.py:1955
 msgid "You are already a reviewer."
 msgstr "Vous êtes déjà un relecteur"
 
-#: src/journal/views.py:1840
+#: src/journal/views.py:1962
 msgid "You are now a reviewer"
 msgstr "Vous êtes maintenant un réviseur"
 
-#: src/journal/views.py:1879
+#: src/journal/views.py:2001
 #, fuzzy
 #| msgid "Your message"
 msgid "Your message has been sent."
 msgstr "Votre message"
 
-#: src/journal/views.py:2313 src/journal/views.py:2330
-#: src/journal/views.py:2340
+#: src/journal/views.py:2478
+#, fuzzy
+#| msgid "No files uploaded"
+msgid "Manuscript file uploaded."
+msgstr "Aucun fichier envoyé"
+
+#: src/journal/views.py:2495
+#, fuzzy
+#| msgid "No files uploaded"
+msgid "Data/figure file uploaded."
+msgstr "Aucun fichier envoyé"
+
+#: src/journal/views.py:2506
 #, fuzzy
 #| msgid "No files uploaded"
 msgid "Production file uploaded."
 msgstr "Aucun fichier envoyé"
 
-#: src/journal/views.py:2350
+#: src/journal/views.py:2516
+#, fuzzy
+#| msgid "No files uploaded"
+msgid "Galley file uploaded."
+msgstr "Aucun fichier envoyé"
+
+#: src/journal/views.py:2552
 #, fuzzy
 #| msgid "No files uploaded"
 msgid "Proofing file uploaded."
 msgstr "Aucun fichier envoyé"
 
-#: src/journal/views.py:2603
+#: src/journal/views.py:2558
+#, fuzzy
+#| msgid "Upload"
+msgid "Saved file."
+msgstr "Télécharger"
+
+#: src/journal/views.py:2568
+#, fuzzy
+#| msgid "Filter"
+msgid "Supplementary file uploaded."
+msgstr "Filtre"
+
+#: src/journal/views.py:2578
+#, fuzzy
+#| msgid "No files uploaded"
+msgid "Typesetting source file uploaded."
+msgstr "Aucun fichier envoyé"
+
+#: src/journal/views.py:2849
 #, fuzzy
 #| msgid "Published on"
 msgid "Published after"
 msgstr "Publié le"
 
-#: src/journal/views.py:2607
+#: src/journal/views.py:2853
 #, fuzzy
 #| msgid "Published on"
 msgid "Published before"
 msgstr "Publié le"
 
-#: src/journal/views.py:2612
-#: src/templates/admin/submission/submit_review.html:70
+#: src/journal/views.py:2858
+#: src/templates/admin/submission/submit_review.html:75
 msgid "Section"
 msgstr "Section"
 
-#: src/journal/views.py:2631 src/themes/OLH/templates/repository/list.html:77
+#: src/journal/views.py:2870 src/themes/OLH/templates/repository/list.html:77
 #: src/themes/material/templates/preprints/list.html:80
 #: src/themes/material/templates/repository/list.html:61
 #, fuzzy
@@ -754,70 +822,25 @@ msgstr "Section"
 msgid "Author Name"
 msgstr "Auteur"
 
-#: src/journal/views.py:2632
+#: src/journal/views.py:2871
 msgid "Volume"
 msgstr "Tome"
 
-#: src/plugins_bak/typesetting/forms.py:16
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to create a typesetting assignment?"
-msgstr ""
-"Entrez votre adresse e-mail pour commencer le processus de réinitialisation"
-
-#: src/plugins_bak/typesetting/forms.py:90
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to create a proofreading assignment?"
-msgstr ""
-"Entrez votre adresse e-mail pour commencer le processus de réinitialisation"
-
-#: src/plugins_bak/typesetting/forms.py:160
-msgid "Text to show as the download link on the article page"
-msgstr ""
-
-#: src/plugins_bak/typesetting/forms.py:199
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to complete the proofreading task?"
-msgstr ""
-"Entrez votre adresse e-mail pour commencer le processus de réinitialisation"
-
-#: src/plugins_bak/typesetting/forms.py:224
-msgid "You have not proofed some galleys:"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:164
-msgid "Article has no typeset files"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:165
-msgid "One or more typeset files are missing images"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:167
-msgid "One or more typesetting or proofing tasks haven't been completed"
-msgstr ""
-
-#: src/plugins_bak/typesetting/templates/typesetting/typesetting_proofreading_assignment.html:116
-msgid "Mark Task as Complete"
-msgstr ""
-
-#: src/press/views.py:406
+#: src/press/views.py:405
 #, fuzzy
 #| msgid "Description"
 msgid "Description deleted."
 msgstr "La description"
 
-#: src/press/views.py:419
+#: src/press/views.py:418
 #, fuzzy
 #| msgid "Description"
 msgid "Description saved."
 msgstr "La description"
 
-#: src/repository/forms.py:44 src/submission/forms.py:75
+#: src/repository/forms.py:42 src/submission/forms.py:87
 #: src/templates/admin/core/manager/sections/section_articles.html:30
-#: src/templates/admin/submission/submit_review.html:46
+#: src/templates/admin/submission/submit_review.html:51
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:21
 #: src/themes/OLH/templates/repository/list.html:75
 #: src/themes/clean/templates/journal/articles.html:65
@@ -827,7 +850,7 @@ msgstr "La description"
 msgid "Title"
 msgstr "Titre"
 
-#: src/repository/forms.py:47 src/submission/forms.py:79
+#: src/repository/forms.py:45
 msgid "Enter your article's abstract here"
 msgstr "Entrez l'abrégé de votre article ici"
 
@@ -847,96 +870,89 @@ msgid ""
 "files."
 msgstr ""
 
-#: src/repository/models.py:350
+#: src/repository/models.py:375
 msgid ""
 "If this field is to be output as a dc metadata field you can addthe type "
 "here."
 msgstr ""
 
-#: src/repository/models.py:396 src/repository/models.py:983
-#: src/repository/models.py:1140 src/submission/models.py:632
+#: src/repository/models.py:421 src/repository/models.py:993
+#: src/repository/models.py:1144 src/submission/models.py:622
 #, fuzzy
 #| msgid "Article Files"
 msgid "Your article title"
 msgstr "Fichiers d'article"
 
-#: src/repository/models.py:403 src/submission/models.py:645
-msgid "Copying and pasting from word processors is supported."
-msgstr ""
-
-#: src/repository/models.py:949
-#: src/templates/admin/submission/submit_review.html:101
+#: src/repository/models.py:959
+#: src/templates/admin/submission/submit_review.html:117
 msgid "ORCID"
 msgstr ""
 
-#: src/repository/models.py:990 src/repository/models.py:1146
-msgid ""
-"Please avoid pasting content from word processors as they can add unwanted "
-"styling to the abstract. You can retype the abstract here or copy and paste "
-"it into notepad/a plain text editor before pasting here."
-msgstr ""
-
-#: src/repository/models.py:1209
+#: src/repository/models.py:1206
 msgid "Approved"
 msgstr ""
 
-#: src/repository/models.py:1211
+#: src/repository/models.py:1208
 #, fuzzy
 #| msgid "Peer Reviewed"
 msgid "Under Review"
 msgstr "Examen par les pairs"
 
-#: src/repository/models.py:1213 src/templates/admin/review/view_review.html:64
+#: src/repository/models.py:1210 src/templates/admin/review/view_review.html:64
 msgid "Declined"
 msgstr ""
 
-#: src/repository/views.py:1076
+#: src/repository/views.py:1097
 #, fuzzy
 #| msgid "Author Information"
 msgid "Author information saved"
 msgstr "Informations de l'auteur"
 
-#: src/review/forms.py:237
+#: src/review/forms.py:242
 msgid "Are you sure you want to request revisions?"
 msgstr ""
 
-#: src/review/forms.py:281
+#: src/review/forms.py:292
 #, fuzzy
 #| msgid "Enter your new password twice to complete the reset process"
 msgid "Are you sure you want to complete the revision request?"
 msgstr ""
 "Entrez votre adresse e-mail pour commencer le processus de réinitialisation"
 
-#: src/review/forms.py:406
+#: src/review/forms.py:415
 msgid "Author can access this review"
 msgstr ""
 
-#: src/review/forms.py:407
+#: src/review/forms.py:416
 msgid "Author can access review file"
 msgstr ""
 
-#: src/review/forms.py:427
+#: src/review/forms.py:436
 #, python-format
 msgid "Author can see ‘%(name)s’"
 msgstr ""
 
-#: src/review/models.py:195
+#: src/review/models.py:198
 msgid "Anonymity"
 msgstr ""
 
-#: src/review/models.py:331
+#: src/review/models.py:334
 msgid "available for the author to access"
 msgstr ""
 
-#: src/review/models.py:332
+#: src/review/models.py:335
 msgid "not available for the author to access"
 msgstr ""
 
-#: src/review/views.py:1605
+#: src/review/views.py:1664
 #, fuzzy
 #| msgid "This article is a preprints"
 msgid "This article has already been accepted or declined."
 msgstr "Cet article est une preprints"
+
+#: src/security/templatetags/securitytags.py:102
+msgid "[Anonymised data]"
+msgstr ""
 
 #: src/submission/decorators.py:22
 msgid "This page can only be accessed on Journals."
@@ -946,100 +962,104 @@ msgstr ""
 msgid "Submission is disabled for this journal."
 msgstr ""
 
-#: src/submission/forms.py:76
-#: src/templates/admin/submission/submit_review.html:48
+#: src/submission/forms.py:88
+#: src/templates/admin/submission/submit_review.html:53
 msgid "Subtitle"
 msgstr "Sous-titre"
 
-#: src/submission/forms.py:274
+#: src/submission/forms.py:289
 msgid "Enter biography here"
 msgstr ""
 
-#: src/submission/forms.py:277
+#: src/submission/forms.py:292
 msgid "Twitter handle"
 msgstr ""
 
-#: src/submission/forms.py:278
+#: src/submission/forms.py:293
 msgid "LinkedIn profile"
 msgstr ""
 
-#: src/submission/forms.py:279
+#: src/submission/forms.py:294
 msgid "ImpactStory profile"
 msgstr ""
 
-#: src/submission/forms.py:280
+#: src/submission/forms.py:295
 msgid "ORCID ID"
 msgstr ""
 
-#: src/submission/forms.py:281
+#: src/submission/forms.py:296
 #, fuzzy
 #| msgid "Your contact email address"
 msgid "Email address"
 msgstr "Votre adresse email de contact"
 
-#: src/submission/forms.py:338
+#: src/submission/forms.py:352
 #, python-format
 msgid "Currently linked to %s, leave blank to use this address"
 msgstr ""
 
-#: src/submission/forms.py:343
+#: src/submission/forms.py:357
 #, python-format
 msgid "If left blank, the account ORCiD will be used (%s)"
 msgstr ""
 
-#: src/submission/logic.py:98
+#: src/submission/logic.py:99
 msgid "You must upload a file that is either a Doc, Docx, RTF or ODT."
 msgstr ""
 
-#: src/submission/models.py:639
+#: src/submission/models.py:347
+msgid "Additional information regarding this funding entry"
+msgstr ""
+
+#: src/submission/models.py:629
 msgid "Do not use--deprecated in version 1.4.1 and later."
 msgstr ""
 
-#: src/submission/models.py:654
+#: src/submission/models.py:644
 msgid "The primary language of the article"
 msgstr ""
 
-#: src/submission/models.py:715
+#: src/submission/models.py:719
 msgid "Custom page range. e.g.: 'I-VII' or 1-3,4-8"
 msgstr ""
 
-#: src/submission/models.py:738
+#: src/submission/models.py:742
 msgid "Add any comments you'd like the editor to consider here."
 msgstr ""
 
-#: src/submission/models.py:761
+#: src/submission/models.py:765
 msgid ""
 "Custom 'how to cite' text. To be used only if the block generated by Janeway "
 "is not suitable."
 msgstr ""
 
-#: src/submission/models.py:767 src/submission/models.py:774
+#: src/submission/models.py:771 src/submission/models.py:778
 msgid ""
 "Name of the publisher who published this article Only relevant to migrated "
 "articles from a different publisher"
 msgstr ""
 
-#: src/submission/models.py:780
+#: src/submission/models.py:784
 msgid ""
 "Original ISSN of this article's journal when published Only relevant for "
 "back content published under a different title"
 msgstr ""
 
-#: src/submission/models.py:1898
+#: src/submission/models.py:1948
 msgid "Optional name prefix (e.g: Prof or Dr)"
 msgstr ""
 
-#: src/submission/models.py:1903
+#: src/submission/models.py:1954
 msgid "Optional name suffix (e.g.: Jr or III)"
 msgstr ""
 
-#: src/submission/models.py:1914
+#: src/submission/models.py:1985
 #, fuzzy
 #| msgid "Biography"
 msgid "Frozen Biography"
 msgstr "La Biographie"
 
-#: src/submission/models.py:1915
+#: src/submission/models.py:1986
 msgid ""
 "The author's biography at the time they published the linked article. For "
 "this article only, it overrides any main biography attached to the author's "
@@ -1047,110 +1067,110 @@ msgid ""
 "account will be populated instead."
 msgstr ""
 
-#: src/submission/models.py:1939
+#: src/submission/models.py:2009
 #, fuzzy
 #| msgid "Author"
 msgid "Author Email"
 msgstr "Auteur"
 
-#: src/submission/models.py:1944
+#: src/submission/models.py:2015
 msgid ""
 "ORCiD to be displayed when no account is associated with this author. It "
 "should be introduced in code format (e.g: 0000-0000-0000-000X)"
 msgstr ""
 
-#: src/submission/models.py:1951
+#: src/submission/models.py:2022
 msgid ""
 "If checked, this authors email address link will be displayed on the article "
 "page."
 msgstr ""
 
-#: src/submission/models.py:2311
-#: src/templates/admin/submission/submit_files.html:69
+#: src/submission/models.py:2387
+#: src/templates/admin/submission/submit_files.html:75
 #, fuzzy
 #| msgid "Figure/Data"
 msgid "Figures and Data Files"
 msgstr "Figure/données"
 
-#: src/submission/models.py:2318
+#: src/submission/models.py:2394
 msgid "The default license applied when no option is presented"
 msgstr ""
 
-#: src/submission/models.py:2326
+#: src/submission/models.py:2402
 msgid "The default language of articles when lang is hidden"
 msgstr ""
 
-#: src/submission/models.py:2332
+#: src/submission/models.py:2408
 msgid "The default section of articles when no option is presented"
 msgstr ""
 
-#: src/submission/views.py:260 src/submission/views.py:295
-#: src/submission/views.py:320
+#: src/submission/views.py:284 src/submission/views.py:319
+#: src/submission/views.py:344
 #, python-brace-format
 msgid "{author_name} added to the article."
 msgstr ""
 
-#: src/submission/views.py:288
+#: src/submission/views.py:312
 msgid "Errors found in the new author form"
 msgstr ""
 
-#: src/submission/views.py:309
+#: src/submission/views.py:333
 msgid "An empty search is not allowed."
 msgstr ""
 
-#: src/submission/views.py:327
+#: src/submission/views.py:351
 msgid "No author found with those details."
 msgstr ""
 
-#: src/submission/views.py:337
+#: src/submission/views.py:361
 #, fuzzy
 #| msgid "Select main author"
 msgid "You must select a main author."
 msgstr "Sélectionner l'auteur principal"
 
-#: src/submission/views.py:447
+#: src/submission/views.py:569
 msgid "File deleted"
 msgstr ""
 
-#: src/submission/views.py:501
+#: src/submission/views.py:624
 msgid "You must upload a manuscript file."
 msgstr ""
 
-#: src/submission/views.py:564
+#: src/submission/views.py:692
 #, fuzzy, python-brace-format
 #| msgid "Article Files"
 msgid "Article {title} submitted"
 msgstr "Fichiers d'article"
 
-#: src/submission/views.py:661
+#: src/submission/views.py:791
 msgid "Metadata updated."
 msgstr ""
 
-#: src/submission/views.py:673
+#: src/submission/views.py:803
 msgid "Primary author set."
 msgstr ""
 
-#: src/submission/views.py:690
+#: src/submission/views.py:820
 #, python-brace-format
 msgid "Author {author_name} updated."
 msgstr ""
 
-#: src/submission/views.py:708
+#: src/submission/views.py:838
 msgid "Frozen Author deleted."
 msgstr ""
 
-#: src/submission/views.py:823
+#: src/submission/views.py:953
 #, fuzzy
 #| msgid "License"
 msgid "License saved."
 msgstr "Licence"
 
-#: src/submission/views.py:868
+#: src/submission/views.py:998
 #, python-brace-format
 msgid "License {license_name} deleted."
 msgstr ""
 
-#: src/submission/views.py:904
+#: src/submission/views.py:1034
 msgid "Configuration updated."
 msgstr ""
 
@@ -1183,6 +1203,389 @@ msgstr ""
 #: src/templates/admin/copyediting/author_review.html:92
 msgid "Complete Copyedit Task"
 msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:5
+#: src/templates/admin/core/accounts/activate_account.html:10
+#: src/templates/admin/core/accounts/activate_account.html:15
+#: src/templates/admin/core/accounts/activate_account.html:29
+#: src/themes/OLH/templates/core/accounts/activate_account.html:9
+#: src/themes/OLH/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:30
+#: src/themes/clean/templates/core/accounts/activate_account.html:9
+#: src/themes/clean/templates/core/accounts/activate_account.html:17
+#: src/themes/clean/templates/core/accounts/activate_account.html:21
+#: src/themes/hourglass/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:18
+#: src/themes/material/templates/core/accounts/activate_account.html:23
+msgid "Activate Account"
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:17
+msgid "No account to activate"
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:24
+msgid ""
+"\n"
+"      You can complete the activation process by clicking the button\n"
+"      below.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:32
+msgid ""
+"\n"
+"      Sorry, we could not find an account to activate, or your account is "
+"active\n"
+"      already. You can check if it is active by attempting to log in.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:38
+#: src/templates/admin/core/accounts/login.html:5
+#: src/templates/admin/core/accounts/login.html:13
+#: src/templates/admin/core/accounts/orcid_registration.html:38
+#: src/themes/OLH/templates/core/login.html:43
+#: src/themes/clean/templates/core/login.html:40
+msgid "Log in"
+msgstr "S'identifier"
+
+#: src/templates/admin/core/accounts/edit_profile.html:9
+#: src/templates/admin/core/accounts/edit_profile.html:17
+#: src/themes/OLH/templates/core/accounts/edit_profile.html:8
+#: src/themes/clean/templates/core/accounts/edit_profile.html:9
+#: src/themes/hourglass/templates/core/accounts/edit_profile.html:11
+#: src/themes/material/templates/core/accounts/edit_profile.html:8
+msgid "Edit Profile"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:26
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
+#, fuzzy
+#| msgid "Your contact email address"
+msgid "Change Your Email Address"
+msgstr "Votre adresse email de contact"
+
+#: src/templates/admin/core/accounts/edit_profile.html:28
+msgid ""
+"\n"
+"          <p>If you want to change your email address you may do so below,\n"
+"          however, you will be logged out and your\n"
+"          account will be marked as inactive until you follow the\n"
+"          instructions in the verification email. <strong>Note: </strong>\n"
+"          Changing your email address will also change your username as "
+"these\n"
+"          are one and the same.</p>\n"
+"        "
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:36
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
+#, fuzzy
+#| msgid "Your contact email address"
+msgid "Current Email Address"
+msgstr "Votre adresse email de contact"
+
+#: src/templates/admin/core/accounts/edit_profile.html:43
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
+#, fuzzy
+#| msgid "Your contact email address"
+msgid "New Email Address"
+msgstr "Votre adresse email de contact"
+
+#: src/templates/admin/core/accounts/edit_profile.html:50
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
+#, fuzzy
+#| msgid "Your contact email address"
+msgid "Update Email Address"
+msgstr "Votre adresse email de contact"
+
+#: src/templates/admin/core/accounts/edit_profile.html:58
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
+#, fuzzy
+#| msgid "Regsiter for"
+msgid "Register for Article Notifications"
+msgstr "S'inscrire à"
+
+#: src/templates/admin/core/accounts/edit_profile.html:61
+msgid ""
+"\n"
+"              Use the button below to register to receive notifications of "
+"new articles\n"
+"              published in this journal.\n"
+"            "
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:68
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
+msgid "Unsubscribe from Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:72
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
+msgid "Subscribe to Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:80
+#: src/templates/admin/core/accounts/edit_profile.html:115
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
+#, fuzzy
+#| msgid "Reset Password"
+msgid "Update Password"
+msgstr "Mot de passe"
+
+#: src/templates/admin/core/accounts/edit_profile.html:82
+msgid ""
+"\n"
+"          You can update your password by entering your existing\n"
+"          password plus your new password.\n"
+"        "
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:91
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
+#, fuzzy
+#| msgid "Reset Password"
+msgid "Current Password"
+msgstr "Mot de passe"
+
+#: src/templates/admin/core/accounts/edit_profile.html:98
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
+#, fuzzy
+#| msgid "Reset Password"
+msgid "New Password"
+msgstr "Mot de passe"
+
+#: src/templates/admin/core/accounts/edit_profile.html:105
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
+#, fuzzy
+#| msgid "Password 1"
+msgid "Enter Password Again"
+msgstr "Mot de passe"
+
+#: src/templates/admin/core/accounts/edit_profile.html:122
+msgid "Profile Details"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:132
+#: src/templates/admin/core/accounts/reset_password.html:31
+#: src/templates/admin/press/edit_press_journal_description.html:24
+#: src/templates/admin/review/view_review.html:168
+#: src/templates/admin/review/view_review.html:189
+msgid "Save"
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:5
+#: src/templates/admin/core/accounts/get_reset_token.html:10
+#: src/templates/admin/core/accounts/get_reset_token.html:14
+#, fuzzy
+#| msgid "Reset Password"
+msgid "Reset password"
+msgstr "Mot de passe"
+
+#: src/templates/admin/core/accounts/get_reset_token.html:20
+msgid ""
+"\n"
+"      Enter your email address and then follow the link sent to you by "
+"email.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:27
+#, fuzzy
+#| msgid "Request Token"
+msgid "Request link"
+msgstr "Token de demande"
+
+#: src/templates/admin/core/accounts/login.html:24
+#: src/themes/OLH/templates/core/login.html:28
+#: src/themes/clean/templates/core/login.html:16
+#: src/themes/material/templates/core/login.html:18
+msgid "Log in with ORCiD"
+msgstr "Connectez-vous avec ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:33
+#, fuzzy
+#| msgid "Log in with ORCiD"
+msgid "Log in with"
+msgstr "Connectez-vous avec ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:45
+#: src/themes/OLH/templates/core/login.html:27
+#: src/themes/OLH/templates/press/core/login.html:25
+#: src/themes/clean/templates/core/login.html:14
+msgid "Log in with your account"
+msgstr "Connectez-vous avec votre compte"
+
+#: src/templates/admin/core/accounts/login.html:50
+#: src/templates/admin/core/accounts/orcid_registration.html:43
+#: src/themes/OLH/templates/core/login.html:44
+#: src/themes/clean/templates/core/login.html:44
+msgid "Forgotten your password?"
+msgstr "Mot de passe oublié?"
+
+#: src/templates/admin/core/accounts/login.html:55
+#: src/templates/admin/core/accounts/orcid_registration.html:48
+#: src/themes/OLH/templates/core/login.html:45
+#: src/themes/clean/templates/core/login.html:48
+msgid "Register a new account"
+msgstr ""
+
+#: src/templates/admin/core/accounts/orcid_registration.html:5
+#: src/templates/admin/core/accounts/orcid_registration.html:10
+#: src/templates/admin/core/accounts/orcid_registration.html:14
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:9
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:23
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:8
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:13
+msgid "Unregistered ORCiD"
+msgstr ""
+
+#: src/templates/admin/core/accounts/orcid_registration.html:19
+msgid ""
+"\n"
+"    The ORCiD you logged in with is not currently linked with an\n"
+"    account in our system. You can either register a new account, or login "
+"with\n"
+"    an existing account to link your ORCiD for future use.\n"
+"  "
+msgstr ""
+
+#: src/templates/admin/core/accounts/password_guide.html:11
+#: src/themes/OLH/templates/core/accounts/register.html:110
+#: src/themes/OLH/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/register.html:54
+#: src/themes/clean/templates/core/accounts/reset_password.html:47
+#: src/themes/material/templates/core/accounts/register.html:53
+#: src/themes/material/templates/core/accounts/reset_password.html:43
+#, fuzzy
+#| msgid "Password 1"
+msgid "Password Guide"
+msgstr "Mot de passe"
+
+#: src/templates/admin/core/accounts/password_guide.html:15
+msgid ""
+"\n"
+"        When it comes to passwords, length is better than complexity.\n"
+"      "
+msgstr ""
+
+#: src/templates/admin/core/accounts/password_guide.html:18
+msgid ""
+"\n"
+"        Its a common myth that a short and complex password\n"
+"        (Jfjfy&65^87) is more secure than a long and uncomplicated password\n"
+"        (our awesome moon base rocks).\n"
+"      "
+msgstr ""
+
+#: src/templates/admin/core/accounts/password_guide.html:23
+msgid ""
+"\n"
+"        We recommend selecting a long, but easy to remember\n"
+"        password such as our awesome moon base rocks which would take an\n"
+"        estimated septillion years to crack as opposed to a complex one "
+"like\n"
+"        Jfjfy&65^87 which would take just over 600 years on a standard\n"
+"        computer.\n"
+"      "
+msgstr ""
+
+#: src/templates/admin/core/accounts/register.html:5
+#: src/templates/admin/core/accounts/register.html:10
+#: src/templates/admin/core/accounts/register.html:14
+#, fuzzy
+#| msgid "Regsiter for"
+msgid "Register for an account"
+msgstr "S'inscrire à"
+
+#: src/templates/admin/core/accounts/register.html:39
+#: src/templates/admin/core/accounts/reset_password.html:19
+#: src/themes/OLH/templates/core/accounts/register.html:31
+#: src/themes/OLH/templates/core/accounts/reset_password.html:31
+#: src/themes/clean/templates/core/accounts/register.html:22
+#: src/themes/clean/templates/core/accounts/reset_password.html:21
+#: src/themes/material/templates/core/accounts/register.html:24
+#: src/themes/material/templates/core/accounts/reset_password.html:21
+msgid "Password Rules"
+msgstr "Mot de passe"
+
+#: src/templates/admin/core/accounts/register.html:43
+#: src/templates/admin/core/accounts/reset_password.html:23
+msgid ""
+"\n"
+"    For more information read our <a href=\"#\"\n"
+"    data-open=\"password-modal\">password guide</a>.\n"
+"  "
+msgstr ""
+
+#: src/templates/admin/core/accounts/register.html:55
+#: src/themes/OLH/templates/core/accounts/register.html:91
+#: src/themes/clean/templates/core/accounts/register.html:31
+#: src/themes/hourglass/templates/custom/register.html:24
+#: src/themes/material/templates/core/accounts/register.html:37
+msgid "By registering an account you agree to our"
+msgstr ""
+
+#: src/templates/admin/core/accounts/register.html:63
+#: src/templates/admin/journal/submissions.html:35
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:52
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:54
+#: src/themes/OLH/templates/core/accounts/register.html:9
+#: src/themes/OLH/templates/core/accounts/register.html:100
+#: src/themes/OLH/templates/core/base.html:142
+#: src/themes/OLH/templates/core/nav.html:76
+#: src/themes/OLH/templates/journal/submissions.html:30
+#: src/themes/OLH/templates/press/nav.html:58
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:45
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:47
+#: src/themes/clean/templates/core/accounts/register.html:9
+#: src/themes/clean/templates/core/accounts/register.html:39
+#: src/themes/clean/templates/core/nav.html:104
+#: src/themes/clean/templates/journal/submissions.html:17
+#: src/themes/clean/templates/press/nav.html:79
+#: src/themes/hourglass/templates/core/accounts/register.html:11
+#: src/themes/material/templates/core/accounts/register.html:10
+#: src/themes/material/templates/core/accounts/register.html:44
+#: src/themes/material/templates/core/nav.html:79
+#: src/themes/material/templates/core/nav.html:134
+#: src/themes/material/templates/journal/submissions.html:33
+#: src/themes/material/templates/press/nav.html:67
+#: src/themes/material/templates/press/nav.html:115
+#: src/themes/material/templates/repository/nav.html:60
+msgid "Register"
+msgstr "Registre"
+
+#: src/templates/admin/core/accounts/reset_password.html:5
+#: src/templates/admin/core/accounts/reset_password.html:10
+#: src/templates/admin/core/accounts/reset_password.html:14
+#, fuzzy
+#| msgid "Reset Password"
+msgid "Enter your new password"
+msgstr "Mot de passe"
 
 #: src/templates/admin/core/manager/sections/manage_section.html:15
 #: src/templates/admin/core/manager/sections/manage_section.html:22
@@ -1323,6 +1726,28 @@ msgid ""
 "the section if you want to delete it."
 msgstr ""
 
+#: src/templates/admin/core/manager/users/list.html:16
+#, fuzzy
+#| msgid "Journal Representatives"
+msgid "Journal Users"
+msgstr "Représentants des revues"
+
+#: src/templates/admin/core/manager/users/list.html:18
+msgid "All Users"
+msgstr ""
+
+#: src/templates/admin/core/manager/users/list.html:40
+#, fuzzy
+#| msgid "Username"
+msgid "Users"
+msgstr "Nom d'utilisateur"
+
+#: src/templates/admin/core/manager/users/list.html:70
+#, fuzzy
+#| msgid "Article Files"
+msgid "No accounts to display."
+msgstr "Fichiers d'article"
+
 #: src/templates/admin/core/request_submission_access.html:14
 msgid "requires that you request permission to make a submission."
 msgstr ""
@@ -1338,46 +1763,66 @@ msgid "You have an active access request that was submitted on: "
 msgstr ""
 
 #: src/templates/admin/elements/accounts/user_form.html:4
-#: src/themes/OLH/templates/elements/accounts/user_form.html:5
-#: src/themes/clean/templates/elements/accounts/user_form.html:5
-#: src/themes/material/templates/elements/accounts/user_form.html:6
-#, fuzzy
-#| msgid "Figure/Data"
-msgid "Core Data"
-msgstr "Figure/données"
+#: src/templates/admin/repository/article.html:212
+#: src/templates/admin/repository/author_article.html:91
+#: src/templates/admin/repository/submit/authors.html:76
+#: src/templates/admin/submission/submit_authors.html:69
+#: src/templates/admin/submission/submit_funding.html:72
+#: src/templates/common/elements/funder_info_for_readers.html:4
+msgid "Name"
+msgstr "Nom"
 
-#: src/templates/admin/elements/accounts/user_form.html:61
+#: src/templates/admin/elements/accounts/user_form.html:13
+#, fuzzy
+#| msgid "Salutation"
+msgid "Affiliations"
+msgstr "Salutation"
+
+#: src/templates/admin/elements/accounts/user_form.html:20
+#: src/themes/OLH/templates/elements/accounts/user_form.html:41
+#: src/themes/clean/templates/elements/accounts/user_form.html:38
+#: src/themes/material/templates/elements/accounts/user_form.html:39
+msgid "Social Media and Accounts"
+msgstr ""
+
+#: src/templates/admin/elements/accounts/user_form.html:30
 #: src/themes/OLH/templates/elements/accounts/user_form.html:65
 #: src/themes/clean/templates/elements/accounts/user_form.html:62
 #: src/themes/material/templates/elements/accounts/user_form.html:63
 msgid "Biography and Signature"
 msgstr ""
 
-#: src/templates/admin/elements/accounts/user_form.html:70
+#: src/templates/admin/elements/accounts/user_form.html:40
+#: src/templates/admin/elements/accounts/user_form.html:43
 #: src/themes/OLH/templates/elements/accounts/user_form.html:74
 #: src/themes/clean/templates/elements/accounts/user_form.html:71
 #: src/themes/material/templates/elements/accounts/user_form.html:72
 msgid "Review Interests"
 msgstr ""
 
-#: src/templates/admin/elements/accounts/user_form.html:71
+#: src/templates/admin/elements/accounts/user_form.html:50
 #: src/themes/OLH/templates/elements/accounts/user_form.html:75
 #: src/themes/clean/templates/elements/accounts/user_form.html:72
 #: src/themes/material/templates/elements/accounts/user_form.html:73
 msgid "Hit Enter to add a new interest"
 msgstr ""
 
-#: src/templates/admin/elements/accounts/user_form.html:75
+#: src/templates/admin/elements/accounts/user_form.html:53
 #: src/themes/OLH/templates/elements/accounts/user_form.html:79
 #: src/themes/clean/templates/elements/accounts/user_form.html:76
 #: src/themes/material/templates/elements/accounts/user_form.html:77
 msgid "Profile Image"
 msgstr ""
 
-#: src/templates/admin/elements/accounts/user_form.html:91
+#: src/templates/admin/elements/accounts/user_form.html:69
+#: src/themes/OLH/templates/elements/accounts/user_form.html:95
+#: src/themes/OLH/templates/journal/article.html:107
+#: src/themes/OLH/templates/journal/article.html:108
+#: src/themes/clean/templates/elements/accounts/user_form.html:92
+#: src/themes/material/templates/elements/accounts/user_form.html:93
 #, fuzzy
 #| msgid "Section"
-msgid "Email Options"
+msgid "Options"
 msgstr "Section"
 
 #: src/templates/admin/elements/confirm_modal.html:7
@@ -1401,7 +1846,7 @@ msgstr ""
 msgid "No, go back"
 msgstr ""
 
-#: src/templates/admin/elements/forms/field.html:7
+#: src/templates/admin/elements/forms/field.html:13
 msgid "translatable"
 msgstr ""
 
@@ -1418,6 +1863,10 @@ msgstr ""
 msgid ""
 "If you don't want to display metrics you can disable them all, or you can "
 "disable the display of citation metrics below"
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_article.html:37
+msgid "Enable the display of the dates an article was submitted and accepted."
 msgstr ""
 
 #: src/templates/admin/elements/forms/group_journal.html:32
@@ -1450,7 +1899,7 @@ msgstr ""
 msgid "How should editors and staff members get help with Janeway?"
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_journal_images.html:10
+#: src/templates/admin/elements/forms/group_journal_images.html:11
 msgid ""
 "For details about where each image appears, see the Janeway documentation: "
 msgstr ""
@@ -1469,15 +1918,15 @@ msgstr ""
 msgid "Review Form manager"
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_review.html:29
+#: src/templates/admin/elements/forms/group_review.html:28
 msgid "Settings here determine the review form experience."
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_review.html:41
+#: src/templates/admin/elements/forms/group_review.html:40
 msgid "Settings here determine the review experience for editors."
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_review.html:49
+#: src/templates/admin/elements/forms/group_review.html:48
 msgid "Settings here determine the review experience for authors."
 msgstr ""
 
@@ -1491,15 +1940,29 @@ msgid ""
 "Agreement that authors accept."
 msgstr ""
 
-#: src/templates/admin/elements/fundref/fundref.html:24
+#: src/templates/admin/elements/forms/messages_in_callout.html:11
+msgid "Problems processing the form"
+msgstr ""
+
+#: src/templates/admin/elements/fundref/fundref.html:22
 msgid "Funder"
 msgstr ""
 
-#: src/templates/admin/elements/fundref/fundref.html:61
-#: src/templates/admin/elements/fundref/fundref.html:82
-#: src/templates/admin/elements/fundref/fundref.html:166
-#: src/templates/admin/submission/submit_funding.html:85
-#: src/templates/admin/submission/submit_funding.html:108
+#: src/templates/admin/elements/fundref/fundref.html:23
+#: src/templates/admin/submission/submit_funding.html:73
+#: src/templates/common/elements/funder_info_for_readers.html:5
+msgid "FundRef ID"
+msgstr ""
+
+#: src/templates/admin/elements/fundref/fundref.html:24
+#, fuzzy
+#| msgid "Add Author"
+msgid "Add Funder"
+msgstr "Ajouter un auteur"
+
+#: src/templates/admin/elements/fundref/fundref.html:39
+#: src/templates/admin/submission/submit_funding.html:121
+#: src/templates/admin/submission/submit_funding.html:128
 #, fuzzy
 #| msgid "Add Author"
 msgid "Add funder"
@@ -1521,6 +1984,34 @@ msgstr ""
 #| msgid "Article Files"
 msgid "Sort Articles"
 msgstr "Fichiers d'article"
+
+#: src/templates/admin/elements/list_filters.html:7
+#, fuzzy
+#| msgid "Search"
+msgid "Search and filter"
+msgstr "Chercher"
+
+#: src/templates/admin/elements/list_filters.html:28
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
+msgid "Apply"
+msgstr ""
+
+#: src/templates/admin/elements/list_filters.html:32
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:10
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:11
+#: src/themes/material/templates/elements/journal/article_list_filters.html:15
+#, fuzzy
+#| msgid "Filter"
+msgid "Clear all"
+msgstr "Filtre"
+
+#: src/templates/admin/elements/metadata.html:143
+#: src/templates/admin/submission/edit/metadata.html:244
+#: src/templates/admin/submission/submit_funding.html:75
+#: src/templates/common/elements/funder_info_for_readers.html:7
+msgid "Funding Statement"
+msgstr ""
 
 #: src/templates/admin/elements/move_to_next_modal.html:7
 msgid "Workflow Info"
@@ -1565,7 +2056,7 @@ msgid "Save Publisher Note"
 msgstr "Publié le"
 
 #: src/templates/admin/elements/repository/metadata_form.html:39
-#: src/templates/admin/repository/submit/start.html:73 src/utils/forms.py:55
+#: src/templates/admin/repository/submit/start.html:71 src/utils/forms.py:60
 msgid "Hit Enter to add a new keyword."
 msgstr ""
 
@@ -1575,10 +2066,10 @@ msgid "Additional Fields"
 msgstr ""
 
 #: src/templates/admin/elements/submit/author.html:8
-#: src/templates/admin/repository/submit/authors.html:65
-#: src/templates/admin/repository/submit/authors.html:116
-#: src/templates/admin/repository/submit/authors.html:123
-#: src/templates/admin/submission/submit_authors.html:49
+#: src/templates/admin/repository/submit/authors.html:62
+#: src/templates/admin/repository/submit/authors.html:113
+#: src/templates/admin/repository/submit/authors.html:120
+#: src/templates/admin/submission/submit_authors.html:54
 #: src/themes/OLH/templates/elements/submit/author.html:8
 msgid "Add New Author"
 msgstr "Ajouter un nouvel auteur"
@@ -1588,14 +2079,13 @@ msgstr "Ajouter un nouvel auteur"
 msgid "Add Author"
 msgstr "Ajouter un auteur"
 
-#: src/templates/admin/elements/submit/file.html:7
+#: src/templates/admin/elements/submit/file.html:9
 #: src/themes/OLH/templates/elements/submit/file.html:6
 #: src/themes/OLH/templates/elements/submit/preprint_file.html:6
 msgid "Add New File"
 msgstr "Ajouter un nouveau fichier"
 
-#: src/templates/admin/elements/submit/file.html:35
-#: src/templates/admin/elements/submit/file.html:51
+#: src/templates/admin/elements/submit/file.html:33
 #: src/themes/OLH/templates/elements/submit/file.html:25
 #: src/themes/OLH/templates/elements/submit/preprint_file.html:25
 msgid "Add File"
@@ -1651,6 +2141,7 @@ msgstr "Renseignements sur l'article"
 #: src/themes/clean/templates/journal/contact.html:5
 #: src/themes/clean/templates/journal/contact.html:21
 #: src/themes/clean/templates/press/nav.html:53
+#: src/themes/hourglass/templates/press/contact.html:4
 #: src/themes/material/templates/core/nav.html:42
 #: src/themes/material/templates/core/nav.html:103
 #: src/themes/material/templates/journal/contact.html:5
@@ -1660,14 +2151,6 @@ msgstr "Renseignements sur l'article"
 msgid "Contact"
 msgstr "Contacter"
 
-#: src/core/models.py:1492
-#: src/templates/admin/journal/contact.html:38
-#: src/themes/OLH/templates/journal/contact.html:30
-#: src/themes/OLH/templates/press/journal/contact.html:22
-#: src/themes/clean/templates/journal/contact.html:27
-msgid "Who would you like to contact?"
-msgstr "Qui souhaitez-vous contacter?"
-
 #: src/templates/admin/journal/contact.html:52
 #: src/themes/OLH/templates/journal/contact.html:39
 #: src/themes/OLH/templates/press/journal/contact.html:30
@@ -1676,37 +2159,37 @@ msgstr "Qui souhaitez-vous contacter?"
 msgid "Send Message"
 msgstr "Envoyer le message"
 
-#: src/templates/admin/journal/manage/archive_article.html:24
+#: src/templates/admin/journal/manage/archive_article.html:25
 #, fuzzy
 #| msgid "Article"
 msgid "Edit Article Images"
 msgstr "Article"
 
-#: src/templates/admin/journal/manage/archive_article.html:26
+#: src/templates/admin/journal/manage/archive_article.html:27
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Edit Publication Info"
 msgstr "Frais de publication"
 
-#: src/templates/admin/journal/manage/archive_article.html:28
+#: src/templates/admin/journal/manage/archive_article.html:29
 #, fuzzy
 #| msgid "Latest Articles"
 msgid "Remote Article View"
 msgstr "Derniers articles"
 
-#: src/templates/admin/journal/manage/archive_article.html:178
+#: src/templates/admin/journal/manage/archive_article.html:179
 msgid "Undo Article Rejection"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:182
+#: src/templates/admin/journal/manage/archive_article.html:183
 msgid "Review"
 msgstr "La revue"
 
-#: src/templates/admin/journal/manage/archive_article.html:184
+#: src/templates/admin/journal/manage/archive_article.html:185
 msgid "Unassigned"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:186
+#: src/templates/admin/journal/manage/archive_article.html:187
 #, python-format
 msgid ""
 "You will have the opportunity to send an email to the author, and then the "
@@ -1729,52 +2212,26 @@ msgid ""
 "                 "
 msgstr ""
 
-#: src/templates/admin/journal/submissions.html:35
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:48
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:50
-#: src/themes/OLH/templates/core/accounts/register.html:5
-#: src/themes/OLH/templates/core/accounts/register.html:96
-#: src/themes/OLH/templates/core/base.html:141
-#: src/themes/OLH/templates/core/nav.html:77
-#: src/themes/OLH/templates/journal/submissions.html:30
-#: src/themes/OLH/templates/press/nav.html:58
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:41
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:43
-#: src/themes/clean/templates/core/accounts/register.html:5
-#: src/themes/clean/templates/core/accounts/register.html:39
-#: src/themes/clean/templates/core/nav.html:104
-#: src/themes/clean/templates/journal/submissions.html:17
-#: src/themes/clean/templates/press/nav.html:79
-#: src/themes/material/templates/core/accounts/register.html:6
-#: src/themes/material/templates/core/accounts/register.html:44
-#: src/themes/material/templates/core/nav.html:79
-#: src/themes/material/templates/core/nav.html:134
-#: src/themes/material/templates/journal/submissions.html:33
-#: src/themes/material/templates/press/nav.html:67
-#: src/themes/material/templates/press/nav.html:115
-#: src/themes/material/templates/repository/nav.html:60
-msgid "Register"
-msgstr "Registre"
-
 #: src/templates/admin/journal/submissions.html:36
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:28
-#: src/themes/OLH/templates/core/base.html:141
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/themes/OLH/templates/core/base.html:142
 #: src/themes/OLH/templates/core/login.html:6
-#: src/themes/OLH/templates/core/nav.html:76
+#: src/themes/OLH/templates/core/nav.html:75
 #: src/themes/OLH/templates/elements/journal_footer.html:30
 #: src/themes/OLH/templates/journal/become_reviewer.html:16
 #: src/themes/OLH/templates/journal/submissions.html:31
 #: src/themes/OLH/templates/press/core/login.html:5
 #: src/themes/OLH/templates/press/elements/press_footer.html:15
 #: src/themes/OLH/templates/press/nav.html:57
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:19
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:23
 #: src/themes/clean/templates/core/login.html:5
 #: src/themes/clean/templates/core/nav.html:103
-#: src/themes/clean/templates/elements/journal_footer.html:41
+#: src/themes/clean/templates/elements/journal_footer.html:43
 #: src/themes/clean/templates/elements/press_footer.html:19
 #: src/themes/clean/templates/journal/become_reviewer.html:13
 #: src/themes/clean/templates/journal/submissions.html:18
 #: src/themes/clean/templates/press/nav.html:77
+#: src/themes/hourglass/templates/core/accounts/login.html:11
 #: src/themes/material/templates/core/login.html:5
 #: src/themes/material/templates/core/login.html:42
 #: src/themes/material/templates/core/nav.html:78
@@ -1788,7 +2245,7 @@ msgid "Login"
 msgstr "S'identifier"
 
 #: src/templates/admin/journal/submissions.html:38
-#: src/templates/admin/submission/start.html:72
+#: src/templates/admin/submission/start.html:77
 #: src/themes/OLH/templates/core/nav.html:43
 #: src/themes/OLH/templates/journal/submissions.html:32
 #: src/themes/clean/templates/core/nav.html:71
@@ -1811,10 +2268,11 @@ msgid "Licences"
 msgstr "Licence"
 
 #: src/templates/admin/journal/submissions.html:48
+#: src/templates/admin/submission/submit_info.html:109
 #: src/themes/OLH/templates/journal/submissions.html:40
 #: src/themes/clean/templates/journal/submissions.html:27
 #: src/themes/material/templates/journal/submissions.html:46
-msgid "allows the following licences for submission"
+msgid "The following licences are allowed:"
 msgstr ""
 
 #: src/templates/admin/press/edit_press_journal_description.html:5
@@ -1825,8 +2283,9 @@ msgstr ""
 #: src/templates/admin/press/edit_press_journal_description.html:11
 #: src/templates/admin/press/edit_press_journal_description.html:17
 #: src/templates/admin/repository/article.html:215
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 #: src/templates/admin/review/view_review.html:112
+#: src/templates/admin/submission/submit_funding.html:76
 #: src/themes/OLH/templates/elements/edit_author.html:4
 msgid "Edit"
 msgstr ""
@@ -1843,12 +2302,6 @@ msgid ""
 "description is used."
 msgstr ""
 
-#: src/templates/admin/press/edit_press_journal_description.html:24
-#: src/templates/admin/review/view_review.html:168
-#: src/templates/admin/review/view_review.html:189
-msgid "Save"
-msgstr ""
-
 #: src/templates/admin/press/edit_press_journal_description.html:25
 #, fuzzy
 #| msgid "Description"
@@ -1863,33 +2316,26 @@ msgstr ""
 msgid "proofreaders"
 msgstr ""
 
-#: src/templates/admin/repository/article.html:212
-#: src/templates/admin/repository/author_article.html:91
-#: src/templates/admin/repository/submit/authors.html:79
-#: src/templates/admin/submission/submit_authors.html:64
-#: src/templates/admin/submission/submit_funding.html:49
-msgid "Name"
-msgstr "Nom"
-
 #: src/templates/admin/repository/article.html:214
 #: src/templates/admin/repository/author_article.html:93
-#: src/templates/admin/repository/submit/authors.html:81
-#: src/templates/admin/submission/submit_review.html:102
-#: src/themes/OLH/templates/core/accounts/public_profile.html:14
-#: src/themes/clean/templates/core/accounts/public_profile.html:14
-#: src/themes/material/templates/core/accounts/public_profile.html:14
+#: src/templates/admin/repository/submit/authors.html:78
+#: src/templates/admin/submission/submit_review.html:118
+#: src/themes/OLH/templates/core/accounts/public_profile.html:42
+#: src/themes/clean/templates/core/accounts/public_profile.html:18
+#: src/themes/material/templates/core/accounts/public_profile.html:18
 #, fuzzy
 #| msgid "Salutation"
 msgid "Affiliation"
 msgstr "Salutation"
 
 #: src/templates/admin/repository/article.html:216
-#: src/templates/admin/repository/submit/authors.html:82
+#: src/templates/admin/repository/submit/authors.html:79
+#: src/templates/admin/submission/submit_funding.html:77
 msgid "Delete"
 msgstr ""
 
 #: src/templates/admin/repository/article.html:239
-#: src/templates/admin/repository/submit/authors.html:97
+#: src/templates/admin/repository/submit/authors.html:94
 #, fuzzy
 #| msgid "No files uploaded"
 msgid "No authors added."
@@ -1911,39 +2357,39 @@ msgstr ""
 msgid "Add Authors to"
 msgstr "Ajouter un auteur"
 
-#: src/templates/admin/repository/submit/authors.html:23
-#: src/themes/clean/templates/journal/article.html:217
+#: src/templates/admin/repository/submit/authors.html:20
+#: src/themes/clean/templates/journal/article.html:219
 #, fuzzy
 #| msgid "Author Information"
 msgid "Information"
 msgstr "Informations de l'auteur"
 
-#: src/templates/admin/repository/submit/authors.html:27
+#: src/templates/admin/repository/submit/authors.html:24
 msgid ""
 "You can add yourself as an author using the button below. This will copy "
 "metadata from your profile to create a"
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:27
+#: src/templates/admin/repository/submit/authors.html:24
 msgid "author record."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:28
+#: src/templates/admin/repository/submit/authors.html:25
 msgid ""
 "You can search the database of existing authors and add them as authors."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:29
+#: src/templates/admin/repository/submit/authors.html:26
 msgid "You can create a new record for an author using the form below."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:34
-#: src/templates/admin/submission/submit_authors.html:46
+#: src/templates/admin/repository/submit/authors.html:31
+#: src/templates/admin/submission/submit_authors.html:51
 msgid "Add Self as Author"
 msgstr "Ajouter l'auteur comme auteur"
 
-#: src/templates/admin/repository/submit/authors.html:37
-#: src/templates/admin/submission/submit_authors.html:44
+#: src/templates/admin/repository/submit/authors.html:34
+#: src/templates/admin/submission/submit_authors.html:49
 msgid ""
 "By default, your account is the owner of this submission, but is not an "
 "Author on record. You can add yourself using the button below."
@@ -1952,26 +2398,26 @@ msgstr ""
 "pas un auteur enregistré.Vous pouvez vous ajouter en utilisant le bouton ci-"
 "dessous"
 
-#: src/templates/admin/repository/submit/authors.html:45
+#: src/templates/admin/repository/submit/authors.html:42
 #, fuzzy
 #| msgid "Search for Existing Authors"
 msgid "Search for an Author"
 msgstr "Recherche d'auteurs existants"
 
-#: src/templates/admin/repository/submit/authors.html:48
+#: src/templates/admin/repository/submit/authors.html:45
 msgid ""
 "You can search by email or ORCiD. eg. person@example.com or "
 "0000-0003-2126-266X."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/repository/submit/authors.html:58
 #, fuzzy
 #| msgid "Add Author"
 msgid "Add an Author"
 msgstr "Ajouter un auteur"
 
-#: src/templates/admin/repository/submit/authors.html:64
-#: src/templates/admin/submission/submit_authors.html:48
+#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/submission/submit_authors.html:53
 msgid ""
 "If you cannot find the author record by searching, and you are not the only "
 "author, you can add one by clicking the button below. This will open a popup "
@@ -1982,40 +2428,40 @@ msgstr ""
 "en cliquant sur le bouton ci-dessous. Cela ouvrira un mode popup pour "
 "quevous puissiez compléter leurs détails."
 
-#: src/templates/admin/repository/submit/authors.html:70
+#: src/templates/admin/repository/submit/authors.html:67
 #: src/themes/OLH/templates/journal/article.html:27
 #: src/themes/OLH/templates/journal/article.html:63
-#: src/themes/OLH/templates/journal/article.html:158
-#: src/themes/OLH/templates/journal/article.html:332
+#: src/themes/OLH/templates/journal/article.html:161
+#: src/themes/OLH/templates/journal/article.html:313
 #: src/themes/OLH/templates/journal/authors.html:4
 #: src/themes/OLH/templates/journal/authors.html:5
 #: src/themes/OLH/templates/journal/authors.html:11
 #: src/themes/OLH/templates/journal/print.html:15
 #: src/themes/OLH/templates/repository/preprint.html:33
 #: src/themes/clean/templates/journal/article.html:37
-#: src/themes/clean/templates/journal/article.html:167
+#: src/themes/clean/templates/journal/article.html:153
 #: src/themes/clean/templates/journal/authors.html:9
 #: src/themes/clean/templates/journal/print.html:15
-#: src/themes/material/templates/journal/article.html:269
+#: src/themes/material/templates/journal/article.html:250
 #: src/themes/material/templates/journal/authors.html:5
 #: src/themes/material/templates/journal/authors.html:6
 #: src/themes/material/templates/journal/authors.html:10
 #: src/themes/material/templates/preprints/article.html:28
-#: src/themes/material/templates/repository/preprint.html:149
+#: src/themes/material/templates/repository/preprint.html:147
 msgid "Authors"
 msgstr "Auteurs"
 
-#: src/templates/admin/repository/submit/authors.html:73
+#: src/templates/admin/repository/submit/authors.html:70
 msgid ""
 "You can reorder the authors by dragging and dropping rows in the table below."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:103
+#: src/templates/admin/repository/submit/authors.html:100
 msgid "Once you have added all of your authors you can complete this stage."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:106
-msgid "Complete Step 2 of 3"
+#: src/templates/admin/repository/submit/authors.html:103
+msgid "Complete Step 2 of 4"
 msgstr ""
 
 #: src/templates/admin/repository/submit/files.html:8
@@ -2024,65 +2470,59 @@ msgstr ""
 msgid "Upload Files for"
 msgstr "Télécharger"
 
-#: src/templates/admin/repository/submit/files.html:29
+#: src/templates/admin/repository/submit/files.html:25
 msgid "You can use the form below to select and upload your manuscript file."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:43
 #, fuzzy
 #| msgid "Filter"
 msgid "Supplementary files"
 msgstr "Filtre"
 
-#: src/templates/admin/repository/submit/files.html:50
+#: src/templates/admin/repository/submit/files.html:46
 msgid "Optional links to externaly hosted supplementary files."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:51
-#: src/templates/admin/repository/submit/files.html:101
-#: src/templates/admin/repository/submit/files.html:108
+#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:97
+#: src/templates/admin/repository/submit/files.html:104
 #: src/templates/admin/repository/supp_files_body.html:53
 #, fuzzy
 #| msgid "Filter"
 msgid "Add New Supplementary File"
 msgstr "Filtre"
 
-#: src/templates/admin/repository/submit/files.html:60
+#: src/templates/admin/repository/submit/files.html:56
 msgid ""
 "If you want to change this file you can upload a new one and it will be "
 "overwritten."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:93
-msgid "Complete Step 3 of 3"
+#: src/templates/admin/repository/submit/files.html:89
+msgid "Complete Step 3 of 4"
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:120
+#: src/templates/admin/repository/submit/files.html:116
 #, fuzzy
 #| msgid "Author Information"
 msgid "Submission Information"
 msgstr "Informations de l'auteur"
 
-#: src/templates/admin/repository/submit/review.html:8
-#, fuzzy
-#| msgid "Submission Checklist"
-msgid "Submission Complete"
-msgstr "Liste de vérification de la soumission"
-
-#: src/templates/admin/repository/submit/start.html:26
+#: src/templates/admin/repository/submit/start.html:24
 #, fuzzy
 #| msgid "Submission Started"
 msgid "Submission Agreement"
 msgstr "Début de la soumission"
 
-#: src/templates/admin/repository/submit/start.html:38
+#: src/templates/admin/repository/submit/start.html:36
 #: src/themes/OLH/templates/repository/preprint.html:122
 #: src/themes/material/templates/preprints/article.html:121
 msgid "Metadata"
 msgstr ""
 
-#: src/templates/admin/repository/submit/start.html:94
-msgid "Complete Step 1 of 3"
+#: src/templates/admin/repository/submit/start.html:92
+msgid "Complete Step 1 of 4"
 msgstr ""
 
 #: src/templates/admin/repository/version_queue.html:19
@@ -2094,17 +2534,25 @@ msgstr ""
 #: src/templates/admin/review/add_review_assignment.html:27
 msgid ""
 "\n"
-"                        You can select a reviewer using the radio buttons in "
-"the first column and complete the section under \"Set Options\".\n"
-"                        If you cannot find the reviewer you want in this "
-"list you can use \"Enroll Existing User\" to search the database and give "
-"users the Reviewer role, or \"Add New Reviewer\" to create a new account for "
-"a reviewer (this process is silent, they will not receive an account "
-"creation email).\n"
-"                        "
+"                                You can select a reviewer using the radio\n"
+"                                buttons in the first column and complete "
+"the\n"
+"                                section under 'Set Options'.\n"
+"                                If you cannot find the reviewer you want in\n"
+"                                this list you can use 'Enroll Existing User' "
+"to\n"
+"                                search the database and give users the "
+"Reviewer\n"
+"                                role, or 'Add New Reviewer' to create a new\n"
+"                                account for a reviewer (this process is "
+"silent,\n"
+"                                so they will not receive an account "
+"creation\n"
+"                                email).\n"
+"                            "
 msgstr ""
 
-#: src/templates/admin/review/decision.html:44
+#: src/templates/admin/review/decision.html:57
 msgid ""
 "Note: This article has completed reviews that have not been made available "
 "to the author:"
@@ -2121,33 +2569,33 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:25
+#: src/templates/admin/review/in_review.html:23
 #, fuzzy
 #| msgid "This article is a preprints"
 msgid "This article is not yet in the review stage"
 msgstr "Cet article est une preprints"
 
-#: src/templates/admin/review/in_review.html:27
+#: src/templates/admin/review/in_review.html:25
 msgid "Before you can move this paper into review you need to"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:28
+#: src/templates/admin/review/in_review.html:26
 msgid "assign an editor"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
 msgid ""
 "This paper has not had an automatic plagiarism check. If you wish to do so "
 "you can run a"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
 msgid "Similarity Check via iThenticate"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:68
+#: src/templates/admin/review/in_review.html:66
 #, python-format
 msgid ""
 "\n"
@@ -2156,7 +2604,7 @@ msgid ""
 "                                            "
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:217
+#: src/templates/admin/review/in_review.html:215
 msgid ""
 "\n"
 "                                The latest manuscript and figure files for "
@@ -2165,19 +2613,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:287
+#: src/templates/admin/review/in_review.html:285
 msgid "Move to Next Stage"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:20
+#: src/templates/admin/review/projected_issue.html:27
 msgid "Save Projected Issue"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:30
+#: src/templates/admin/review/projected_issue.html:37
 msgid "What is this for?"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:31
+#: src/templates/admin/review/projected_issue.html:38
 msgid ""
 "The projected issue field can be used internally to keep track of plans and "
 "communicate with typesetters, without affecting issue assignment or "
@@ -2185,31 +2633,31 @@ msgid ""
 "to issues on a rolling basis and publish them individually."
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:32
+#: src/templates/admin/review/projected_issue.html:39
 msgid ""
 "You can assign articles directly to issues in the prepublication stage or "
 "through "
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:32
+#: src/templates/admin/review/projected_issue.html:39
 msgid "issue management"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:33
+#: src/templates/admin/review/projected_issue.html:40
 msgid "How does it work?"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:34
+#: src/templates/admin/review/projected_issue.html:41
 msgid ""
 "Select an issue from the drop down on the left and press save. This "
 "article's projected issue will now be set."
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:35
+#: src/templates/admin/review/projected_issue.html:42
 msgid "Can I unset a projected issue?"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:36
+#: src/templates/admin/review/projected_issue.html:43
 msgid "Yes, you can select the blank option (-------) from the dropdown."
 msgstr ""
 
@@ -2221,23 +2669,23 @@ msgid ""
 "revisions once you click 'Submit Revisions'"
 msgstr ""
 
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 msgid "Assign"
 msgstr ""
 
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 msgid "Projected Issue"
 msgstr ""
 
-#: src/templates/admin/review/unassigned_article.html:122
+#: src/templates/admin/review/unassigned_article.html:125
 msgid "This article is projected to be published as part of"
 msgstr ""
 
-#: src/templates/admin/review/unassigned_article.html:124
+#: src/templates/admin/review/unassigned_article.html:127
 msgid "This article is not projected to be published as part of any issue."
 msgstr ""
 
-#: src/templates/admin/review/unassigned_article.html:137
+#: src/templates/admin/review/unassigned_article.html:140
 msgid ""
 "To check an article for possible plagiarism, you can send an article for an "
 "automated Similarity Check via iThenticate by clicking Send below. The "
@@ -2322,7 +2770,6 @@ msgid "Withdrawn"
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:63
-#: src/themes/material/templates/journal/article.html:394
 msgid "Accepted"
 msgstr ""
 
@@ -2402,7 +2849,7 @@ msgstr ""
 msgid "Suggested Reviewers"
 msgstr "Examen par les pairs"
 
-#: src/templates/admin/submission/edit/metadata.html:178
+#: src/templates/admin/submission/edit/metadata.html:195
 msgid ""
 "\n"
 "                            You can search the <a href=\"https://www."
@@ -2412,15 +2859,15 @@ msgid ""
 "                        "
 msgstr ""
 
-#: src/templates/admin/submission/manager/delete_license.html:26
+#: src/templates/admin/submission/manager/delete_license.html:25
 msgid ""
 "This license is currently used by the following articles. If you delete it "
 "these articles will no longer have a license listed."
 msgstr ""
 
-#: src/templates/admin/submission/manager/delete_license.html:27
+#: src/templates/admin/submission/manager/delete_license.html:26
 msgid ""
-"You should only delete this license if you are absolutley sure you want to "
+"You should only delete this license if you are absolutely sure you want to "
 "remove it."
 msgstr ""
 
@@ -2439,43 +2886,43 @@ msgstr ""
 "Veuillez lire attentivement les instructions ci-dessous avant de vérifier "
 "les éléments"
 
-#: src/templates/admin/submission/start.html:24
+#: src/templates/admin/submission/start.html:29
 msgid ""
 "All authors must agree to the below statements in order to submit an article "
 "to"
 msgstr ""
 
-#: src/templates/admin/submission/start.html:24
+#: src/templates/admin/submission/start.html:29
 msgid ""
 "If you do not agree with these terms you will be unable to proceed with your "
 "submission."
 msgstr ""
 
-#: src/templates/admin/submission/start.html:29
+#: src/templates/admin/submission/start.html:34
 msgid "Publication Fees"
 msgstr "Frais de publication"
 
-#: src/templates/admin/submission/start.html:36
+#: src/templates/admin/submission/start.html:41
 msgid "Author(s) agrees to the above statement"
 msgstr "Auteur(s) accepte la déclaration ci-dessus"
 
-#: src/templates/admin/submission/start.html:42
+#: src/templates/admin/submission/start.html:47
 msgid "Submission Checklist"
 msgstr "Liste de vérification de la soumission"
 
-#: src/templates/admin/submission/start.html:48
+#: src/templates/admin/submission/start.html:53
 msgid "Author(s) confirms that this article adheres to the above requirements"
 msgstr ""
 "L'auteur(s) confirme que cet article est conforme aux exigences ci-dessus"
 
-#: src/templates/admin/submission/start.html:54
+#: src/templates/admin/submission/start.html:59
 msgid "Copyright Notice"
 msgstr "Copyright"
 
-#: src/templates/admin/submission/start.html:66
-#: src/themes/OLH/templates/journal/article.html:428
-#: src/themes/clean/templates/journal/article.html:255
-#: src/themes/material/templates/journal/article.html:424
+#: src/templates/admin/submission/start.html:71
+#: src/themes/OLH/templates/journal/article.html:419
+#: src/themes/clean/templates/journal/article.html:265
+#: src/themes/material/templates/journal/article.html:400
 msgid "Competing Interests"
 msgstr ""
 
@@ -2485,11 +2932,11 @@ msgstr ""
 msgid "Author Information"
 msgstr "Informations de l'auteur"
 
-#: src/templates/admin/submission/submit_authors.html:18
+#: src/templates/admin/submission/submit_authors.html:23
 msgid "Search for Existing Authors"
 msgstr "Recherche d'auteurs existants"
 
-#: src/templates/admin/submission/submit_authors.html:25
+#: src/templates/admin/submission/submit_authors.html:30
 msgid ""
 "Search for a user using email address or ORCiD. If a user is matched, they "
 "will be automatically added as an author. This search only returns exact "
@@ -2499,12 +2946,12 @@ msgstr ""
 "utilisateur est apparié, il seraautomatiquement ajouté comme auteur. Cette "
 "recherche ne renvoie que les correspondances exactes."
 
-#: src/templates/admin/submission/submit_authors.html:31
+#: src/templates/admin/submission/submit_authors.html:36
 msgid "Search by email address or ORCiD"
 msgstr "Recherche par adresse e-mail ou ORCiD"
 
-#: src/templates/admin/submission/submit_authors.html:35
-#: src/themes/OLH/templates/core/base.html:153
+#: src/templates/admin/submission/submit_authors.html:40
+#: src/themes/OLH/templates/core/base.html:154
 #: src/themes/OLH/templates/journal/full-text-search.html:8
 #: src/themes/OLH/templates/journal/full-text-search.html:10
 #: src/themes/OLH/templates/journal/full-text-search.html:70
@@ -2527,25 +2974,25 @@ msgstr "Recherche par adresse e-mail ou ORCiD"
 msgid "Search"
 msgstr "Chercher"
 
-#: src/templates/admin/submission/submit_authors.html:40
+#: src/templates/admin/submission/submit_authors.html:45
 #, fuzzy
 #| msgid "Add Author"
 msgid "Add Authors"
 msgstr "Ajouter un auteur"
 
-#: src/templates/admin/submission/submit_authors.html:55
+#: src/templates/admin/submission/submit_authors.html:60
 msgid "Current Authors"
 msgstr "Auteurs actuels"
 
-#: src/templates/admin/submission/submit_authors.html:57
+#: src/templates/admin/submission/submit_authors.html:62
 msgid "Drag and drop an author to re-order them."
 msgstr ""
 
-#: src/templates/admin/submission/submit_authors.html:81
+#: src/templates/admin/submission/submit_authors.html:86
 msgid "No authors yet, add one!"
 msgstr "Pas encore d'auteurs, ajoutez un!"
 
-#: src/templates/admin/submission/submit_authors.html:88
+#: src/templates/admin/submission/submit_authors.html:93
 msgid ""
 "You are required to select a main author, this author will receive the "
 "communications regarding your articles process through our systems. This "
@@ -2555,14 +3002,14 @@ msgstr ""
 "communications relatives à votre processus d'articles via nos systèmes. Ce "
 "n'est pas forcément vous."
 
-#: src/templates/admin/submission/submit_authors.html:89
+#: src/templates/admin/submission/submit_authors.html:94
 msgid "Select main author"
 msgstr "Sélectionner l'auteur principal"
 
-#: src/templates/admin/submission/submit_authors.html:99
-#: src/templates/admin/submission/submit_files.html:112
-#: src/templates/admin/submission/submit_funding.html:75
-#: src/templates/admin/submission/submit_info.html:83
+#: src/templates/admin/submission/submit_authors.html:104
+#: src/templates/admin/submission/submit_files.html:118
+#: src/templates/admin/submission/submit_funding.html:111
+#: src/templates/admin/submission/submit_info.html:93
 msgid "Save and Continue"
 msgstr "Sauvegarder et continuer"
 
@@ -2572,87 +3019,100 @@ msgstr "Sauvegarder et continuer"
 msgid "Upload files"
 msgstr "Télécharger"
 
-#: src/templates/admin/submission/submit_files.html:33
-#: src/templates/admin/submission/submit_files.html:74
+#: src/templates/admin/submission/submit_files.html:39
+#: src/templates/admin/submission/submit_files.html:80
 msgid "Upload"
 msgstr "Télécharger"
 
-#: src/templates/admin/submission/submit_files.html:41
-#: src/templates/admin/submission/submit_files.html:81
-#: src/templates/admin/submission/submit_review.html:121
+#: src/templates/admin/submission/submit_files.html:47
+#: src/templates/admin/submission/submit_files.html:87
+#: src/templates/admin/submission/submit_review.html:137
 msgid "File Name"
 msgstr "Nom de fichier"
 
-#: src/templates/admin/submission/submit_files.html:59
-#: src/templates/admin/submission/submit_files.html:97
+#: src/templates/admin/submission/submit_files.html:65
+#: src/templates/admin/submission/submit_files.html:103
 msgid "No files uploaded"
 msgstr "Aucun fichier envoyé"
 
 #: src/templates/admin/submission/submit_funding.html:7
-#: src/templates/admin/submission/submit_info.html:6
-#: src/templates/admin/submission/submit_review.html:43
-msgid "Article Info"
+#, fuzzy
+#| msgid "Article Information"
+msgid "Funding Information"
 msgstr "Renseignements sur l'article"
 
-#: src/templates/admin/submission/submit_funding.html:16
+#: src/templates/admin/submission/submit_funding.html:25
 #: src/templates/admin/submission/timeline.html:36
 #: src/templates/admin/submission/timeline.html:37
-#: src/themes/OLH/templates/journal/article.html:229
-#: src/themes/clean/templates/journal/article.html:123
-#: src/themes/material/templates/journal/article.html:151
+#: src/templates/common/elements/funder_info_for_readers.html:3
 msgid "Funding"
 msgstr ""
 
-#: src/templates/admin/submission/submit_funding.html:20
+#: src/templates/admin/submission/submit_funding.html:30
+msgid ""
+"\n"
+"                         Here you can search the FundRef database to add "
+"grant IDs to your article's metadata. If you can't find a specific funder, "
+"you can manually enter the details. You can also edit or delete entries as "
+"necessary.\n"
+"                    "
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:36
 msgid "Add Funding Source"
 msgstr ""
 
-#: src/templates/admin/submission/submit_funding.html:27
+#: src/templates/admin/submission/submit_funding.html:47
 #, fuzzy
 #| msgid "Featured Articles"
 msgid "Search for funder"
 msgstr "Article vedette"
 
-#: src/templates/admin/submission/submit_funding.html:31
+#: src/templates/admin/submission/submit_funding.html:53
 msgid "Add funder manually"
 msgstr ""
 
-#: src/templates/admin/submission/submit_funding.html:41
+#: src/templates/admin/submission/submit_funding.html:64
 #, fuzzy
 #| msgid "Current Authors"
 msgid "Current Funders"
 msgstr "Auteurs actuels"
 
-#: src/templates/admin/submission/submit_funding.html:50
+#: src/templates/admin/submission/submit_funding.html:74
 msgid "Grant Number"
 msgstr ""
 
-#: src/templates/admin/submission/submit_funding.html:65
+#: src/templates/admin/submission/submit_funding.html:100
 #, fuzzy
 #| msgid "No files uploaded"
 msgid "No funders added."
 msgstr "Aucun fichier envoyé"
 
-#: src/templates/admin/submission/submit_info.html:16
+#: src/templates/admin/submission/submit_info.html:6
+#: src/templates/admin/submission/submit_review.html:48
+msgid "Article Info"
+msgstr "Renseignements sur l'article"
+
+#: src/templates/admin/submission/submit_info.html:26
 #, fuzzy
 #| msgid "This article is a preprints"
 msgid "This article is a preprint"
 msgstr "Cet article est une preprints"
 
-#: src/templates/admin/submission/submit_info.html:21
+#: src/templates/admin/submission/submit_info.html:31
 #, fuzzy
 #| msgid "Author Information"
 msgid "Basic Information"
 msgstr "Informations de l'auteur"
 
-#: src/templates/admin/submission/submit_info.html:58
+#: src/templates/admin/submission/submit_info.html:68
 #, fuzzy
 #| msgid "Article Information"
 msgid "View license information"
 msgstr "Renseignements sur l'article"
 
-#: src/templates/admin/submission/submit_info.html:67
-#: src/themes/OLH/templates/journal/article.html:178
+#: src/templates/admin/submission/submit_info.html:77
+#: src/themes/OLH/templates/journal/article.html:181
 #: src/themes/OLH/templates/journal/keywords.html:6
 #: src/themes/OLH/templates/journal/keywords.html:12
 #: src/themes/OLH/templates/journal/print.html:33
@@ -2672,19 +3132,15 @@ msgstr "Renseignements sur l'article"
 #: src/themes/material/templates/journal/search.html:50
 #: src/themes/material/templates/preprints/list.html:79
 #: src/themes/material/templates/repository/list.html:60
-#: src/themes/material/templates/repository/preprint.html:172
+#: src/themes/material/templates/repository/preprint.html:170
 msgid "Keywords"
 msgstr "Mots clés"
 
-#: src/templates/admin/submission/submit_info.html:96
+#: src/templates/admin/submission/submit_info.html:106
 #, fuzzy
 #| msgid "Article Information"
 msgid "License Information"
 msgstr "Renseignements sur l'article"
-
-#: src/templates/admin/submission/submit_info.html:99
-msgid "allows the following licenses for submission"
-msgstr ""
 
 #: src/templates/admin/submission/submit_review.html:7
 #: src/templates/admin/submission/timeline.html:43
@@ -2696,7 +3152,7 @@ msgstr ""
 msgid "Review your submission"
 msgstr "Commencer la soumission"
 
-#: src/templates/admin/submission/submit_review.html:21
+#: src/templates/admin/submission/submit_review.html:26
 msgid ""
 "Please review your submission use the details below. If you need to make "
 "changes use the links above to move back along the submission steps. You "
@@ -2705,118 +3161,118 @@ msgid ""
 "receipt email. "
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:25
+#: src/templates/admin/submission/submit_review.html:30
 #, fuzzy
 #| msgid "Author Agreement"
 msgid "Agreements"
 msgstr "Contrat d'auteur"
 
-#: src/templates/admin/submission/submit_review.html:29
+#: src/templates/admin/submission/submit_review.html:34
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Agreed to Publication Fees statement"
 msgstr "Frais de publication"
 
-#: src/templates/admin/submission/submit_review.html:33
+#: src/templates/admin/submission/submit_review.html:38
 #, fuzzy
 #| msgid "Submission Checklist"
 msgid "Agreed to Submission Checklist"
 msgstr "Liste de vérification de la soumission"
 
-#: src/templates/admin/submission/submit_review.html:37
+#: src/templates/admin/submission/submit_review.html:42
 msgid "Agreed to Copyright statement"
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:59
-#: src/themes/OLH/templates/journal/article.html:175
+#: src/templates/admin/submission/submit_review.html:64
+#: src/themes/OLH/templates/journal/article.html:178
 #: src/themes/OLH/templates/journal/print.html:30
 #: src/themes/OLH/templates/repository/preprint.html:45
 #: src/themes/clean/templates/journal/article.html:78
 #: src/themes/clean/templates/journal/print.html:30
 #: src/themes/material/templates/journal/article.html:73
 #: src/themes/material/templates/preprints/article.html:43
-#: src/themes/material/templates/repository/preprint.html:157
+#: src/themes/material/templates/repository/preprint.html:155
 msgid "Abstract"
 msgstr "Abstrait"
 
-#: src/templates/admin/submission/submit_review.html:68
+#: src/templates/admin/submission/submit_review.html:73
 msgid "Language"
 msgstr "La langue"
 
-#: src/templates/admin/submission/submit_review.html:72
-#: src/themes/material/templates/journal/article.html:413
+#: src/templates/admin/submission/submit_review.html:77
+#: src/themes/material/templates/journal/article.html:389
 msgid "Licence"
 msgstr "Licence"
 
-#: src/templates/admin/submission/submit_review.html:94
+#: src/templates/admin/submission/submit_review.html:110
 msgid "Author Info"
 msgstr "Informations de l'auteur"
 
-#: src/templates/admin/submission/submit_review.html:97
+#: src/templates/admin/submission/submit_review.html:113
 #, fuzzy
 #| msgid "First name"
 msgid "First Name"
 msgstr "Prénom"
 
-#: src/templates/admin/submission/submit_review.html:98
+#: src/templates/admin/submission/submit_review.html:114
 #, fuzzy
 #| msgid "Middle name"
 msgid "Middle Name"
 msgstr "Deuxième nom"
 
-#: src/templates/admin/submission/submit_review.html:99
+#: src/templates/admin/submission/submit_review.html:115
 #, fuzzy
 #| msgid "Last name"
 msgid "Last Name"
 msgstr "Nom de famille"
 
-#: src/templates/admin/submission/submit_review.html:100
+#: src/templates/admin/submission/submit_review.html:116
 #, fuzzy
 #| msgid "Your contact email address"
 msgid "Email Address"
 msgstr "Votre adresse email de contact"
 
-#: src/templates/admin/submission/submit_review.html:110
+#: src/templates/admin/submission/submit_review.html:126
 msgid "No ORCID supplied"
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:117
+#: src/templates/admin/submission/submit_review.html:133
 #: src/templates/admin/submission/timeline.html:28
 #: src/templates/admin/submission/timeline.html:29
 msgid "Article Files"
 msgstr "Fichiers d'article"
 
-#: src/templates/admin/submission/submit_review.html:122
+#: src/templates/admin/submission/submit_review.html:138
 #, fuzzy
 #| msgid "File Name"
 msgid "File Type"
 msgstr "Nom de fichier"
 
-#: src/templates/admin/submission/submit_review.html:128
+#: src/templates/admin/submission/submit_review.html:144
 #, fuzzy
 #| msgid "Manuscript File"
 msgid "Manuscript"
 msgstr "Fichier manuscrit"
 
-#: src/templates/admin/submission/submit_review.html:136
+#: src/templates/admin/submission/submit_review.html:152
 msgid "Figure/Data"
 msgstr "Figure/données"
 
-#: src/templates/admin/submission/submit_review.html:146
+#: src/templates/admin/submission/submit_review.html:162
 msgid "Comments to the Editor"
 msgstr "Commentaires au rédacteur"
 
-#: src/templates/admin/submission/submit_review.html:149
+#: src/templates/admin/submission/submit_review.html:165
 msgid ""
 "Before submitting you have the option to add additional comments for the "
 "editor using the field below. Only the editor will see anything you add here."
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:155
+#: src/templates/admin/submission/submit_review.html:171
 msgid "Complete"
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:155
+#: src/templates/admin/submission/submit_review.html:171
 #: src/themes/OLH/templates/core/nav.html:40
 #: src/themes/clean/templates/core/nav.html:47
 #: src/themes/material/templates/core/nav.html:39
@@ -2835,15 +3291,36 @@ msgstr "Début de la soumission"
 msgid "Article Information"
 msgstr "Renseignements sur l'article"
 
+#: src/templates/common/accounts/register_privacy_policy.html:3
+#: src/templates/common/accounts/register_privacy_policy.html:7
+#: src/templates/common/accounts/register_privacy_policy.html:11
+#: src/themes/OLH/templates/elements/journal_footer.html:25
+#: src/themes/OLH/templates/elements/journal_footer.html:27
+#: src/themes/OLH/templates/press/elements/press_footer.html:9
+#: src/themes/OLH/templates/press/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/journal_footer.html:33
+#: src/themes/clean/templates/elements/journal_footer.html:37
+#: src/themes/clean/templates/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/press_footer.html:14
+#: src/themes/hourglass/templates/custom/register.html:29
+#: src/themes/hourglass/templates/custom/register.html:35
+#: src/themes/material/templates/elements/journal_footer.html:28
+msgid "Privacy Policy"
+msgstr "Politique de confidentialité"
+
+#: src/templates/common/elements/funder_info_for_readers.html:6
+msgid "Funding ID"
+msgstr ""
+
 #: src/templates/common/elements/journal/article_issue_list.html:4
 #: src/themes/OLH/templates/core/nav.html:25
+#: src/themes/OLH/templates/journal/issues.html:5
 #: src/themes/OLH/templates/journal/issues.html:7
-#: src/themes/OLH/templates/journal/issues.html:9
 #: src/themes/clean/templates/core/nav.html:24
 #: src/themes/clean/templates/journal/issues.html:6
 #: src/themes/material/templates/core/nav.html:33
 #: src/themes/material/templates/core/nav.html:94
-#: src/themes/material/templates/journal/issues.html:6
+#: src/themes/material/templates/journal/issues.html:5
 #, fuzzy
 #| msgid "Issue"
 msgid "Issues"
@@ -2867,6 +3344,30 @@ msgstr ""
 #| msgid "This article is a preprints"
 msgid "This article is not a part of any issues"
 msgstr "Cet article est une preprints"
+
+#: src/templates/common/elements/orcid_registration.html:16
+#, fuzzy
+#| msgid "Log in with ORCiD"
+msgid "Register with ORCiD"
+msgstr "Connectez-vous avec ORCiD"
+
+#: src/templates/common/elements/password_rules.html:2
+#, python-format
+msgid "Your password should be %(password_length)s characters long."
+msgstr ""
+
+#: src/templates/common/elements/password_rules.html:6
+msgid "Your password should contain at least one upper case letter."
+msgstr ""
+
+#: src/templates/common/elements/password_rules.html:11
+msgid "Your password should contain at least one number."
+msgstr ""
+
+#: src/templates/common/elements/skip_to_main_content.html:3
+#: src/themes/clean/templates/500.html:21
+msgid "Skip to main content"
+msgstr ""
 
 #: src/templates/common/elements/sorting.html:7
 #: src/themes/clean/templates/elements/sorting.html:7
@@ -2914,113 +3415,93 @@ msgstr ""
 msgid "A server error has occurred"
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:5
-#: src/themes/OLH/templates/core/accounts/activate_account.html:22
-#: src/themes/OLH/templates/core/accounts/activate_account.html:26
-#: src/themes/clean/templates/core/accounts/activate_account.html:5
-#: src/themes/clean/templates/core/accounts/activate_account.html:13
-#: src/themes/clean/templates/core/accounts/activate_account.html:17
-#: src/themes/material/templates/core/accounts/activate_account.html:5
-#: src/themes/material/templates/core/accounts/activate_account.html:14
-#: src/themes/material/templates/core/accounts/activate_account.html:19
-msgid "Activate Account"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/activate_account.html:25
-#: src/themes/clean/templates/core/accounts/activate_account.html:16
-#: src/themes/material/templates/core/accounts/activate_account.html:17
-msgid "You can complete the activation process by clicking the button below."
+#: src/themes/OLH/templates/cms/page.html:22
+#: src/themes/clean/templates/cms/page.html:19
+#: src/themes/clean/templates/journal/article.html:340
+#: src/themes/material/templates/cms/page.html:25
+#: src/themes/material/templates/journal/article.html:484
+#: src/themes/material/templates/journal/submissions.html:72
+msgid "Table of Contents"
 msgstr ""
 
 #: src/themes/OLH/templates/core/accounts/activate_account.html:29
 #: src/themes/clean/templates/core/accounts/activate_account.html:20
-#: src/themes/material/templates/core/accounts/activate_account.html:23
+#: src/themes/material/templates/core/accounts/activate_account.html:21
+msgid "You can complete the activation process by clicking the button below."
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/activate_account.html:33
+#: src/themes/clean/templates/core/accounts/activate_account.html:24
+#: src/themes/material/templates/core/accounts/activate_account.html:27
 msgid "Error"
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:31
+#: src/themes/OLH/templates/core/accounts/activate_account.html:35
 msgid ""
 "There was no inactive account with this activation code found. It is "
 "possible that your account is already active, you can check by attempting to"
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:32
-#: src/themes/clean/templates/core/accounts/activate_account.html:22
-#: src/themes/material/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:36
+#: src/themes/clean/templates/core/accounts/activate_account.html:26
+#: src/themes/material/templates/core/accounts/activate_account.html:30
 #, fuzzy
 #| msgid "Login"
 msgid "login"
 msgstr "S'identifier"
 
-#: src/themes/OLH/templates/core/accounts/edit_profile.html:4
-#: src/themes/clean/templates/core/accounts/edit_profile.html:5
-#: src/themes/material/templates/core/accounts/edit_profile.html:4
-msgid "Edit Profile"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:5
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:9
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:86
 #: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:105
 #: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:100
 msgid "Update"
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:25
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:15
-#: src/themes/material/templates/core/accounts/get_reset_token.html:14
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:20
+#: src/themes/material/templates/core/accounts/get_reset_token.html:20
 msgid "Enter your email address to begin the reset process"
 msgstr ""
 "Entrez votre adresse e-mail pour commencer le processus de réinitialisation"
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:27
-msgid "somebody"
-msgstr "personne"
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:21
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:31
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:24
+#: src/themes/material/templates/core/accounts/get_reset_token.html:25
 msgid "Request Token"
 msgstr "Token de demande"
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:5
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:19
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:4
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:9
-msgid "Unregistered ORCiD"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:20
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:24
 msgid ""
 "The ORCiD you logged in with is not currently linked with an account in our "
 "system. You can either register a new account, or login with an existing "
 "account to link your ORCiD for future use."
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:40
 #: src/themes/OLH/templates/press/core/login.html:36
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:29
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:33
 #, fuzzy
 #| msgid "Log in"
 msgid "Log In"
 msgstr "S'identifier"
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:37
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:41
 #: src/themes/OLH/templates/press/core/login.html:37
 #, fuzzy
 #| msgid "Forgotten your password?"
 msgid "Forgot your password?"
 msgstr "Mot de passe oublié?"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:5
-#: src/themes/OLH/templates/core/nav.html:73
+#: src/themes/OLH/templates/core/accounts/public_profile.html:9
+#: src/themes/OLH/templates/core/nav.html:72
 #: src/themes/OLH/templates/elements/right_hand_menu.html:38
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:12
 #: src/themes/OLH/templates/press/nav.html:54
 #: src/themes/OLH/templates/repository/elements/right_hand_menu.html:10
-#: src/themes/clean/templates/core/accounts/public_profile.html:4
+#: src/themes/clean/templates/core/accounts/public_profile.html:8
 #: src/themes/clean/templates/core/nav.html:98
 #: src/themes/clean/templates/press/nav.html:71
-#: src/themes/material/templates/core/accounts/public_profile.html:5
+#: src/themes/material/templates/core/accounts/public_profile.html:9
 #: src/themes/material/templates/core/nav.html:165
 #: src/themes/material/templates/core/nav.html:200
 #: src/themes/material/templates/press/nav.html:135
@@ -3028,130 +3509,62 @@ msgstr "Mot de passe oublié?"
 msgid "Profile"
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:13
-#: src/themes/clean/templates/core/accounts/public_profile.html:13
-#: src/themes/material/templates/core/accounts/public_profile.html:13
+#: src/themes/OLH/templates/core/accounts/public_profile.html:19
+#: src/themes/clean/templates/core/accounts/public_profile.html:17
+#: src/themes/material/templates/core/accounts/public_profile.html:17
 msgid "Roles"
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:25
-#: src/themes/clean/templates/core/accounts/public_profile.html:25
-#: src/themes/material/templates/core/accounts/public_profile.html:25
+#: src/themes/OLH/templates/core/accounts/public_profile.html:27
+msgid "Editorial groups"
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:35
+msgid "Staff roles"
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:56
+#: src/themes/clean/templates/core/accounts/public_profile.html:29
+#: src/themes/material/templates/core/accounts/public_profile.html:29
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Publications"
 msgstr "Frais de publication"
 
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
+#: src/themes/OLH/templates/core/accounts/register.html:29
+#: src/themes/clean/templates/core/accounts/register.html:21
+#: src/themes/material/templates/core/accounts/register.html:19
 #, fuzzy
 #| msgid "Regsiter for"
 msgid "Register for an account with"
 msgstr "S'inscrire à"
 
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
-msgid "account"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:26
-#: src/themes/OLH/templates/core/accounts/reset_password.html:27
-#: src/themes/clean/templates/core/accounts/register.html:18
-#: src/themes/clean/templates/core/accounts/reset_password.html:17
-#: src/themes/material/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/reset_password.html:17
-msgid "Password Rules"
-msgstr "Mot de passe"
-
-#: src/themes/OLH/templates/core/accounts/register.html:28
-#: src/themes/clean/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/register.html:22
-#: src/themes/material/templates/core/accounts/reset_password.html:19
-#, python-format
-msgid "Your password should be %(password_length)s characters long."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:29
-#: src/themes/OLH/templates/core/accounts/reset_password.html:30
-#: src/themes/clean/templates/core/accounts/register.html:21
-#: src/themes/clean/templates/core/accounts/reset_password.html:20
-#: src/themes/material/templates/core/accounts/register.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:20
-msgid "Your password should contain at least one upper case letter.\""
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:30
-#: src/themes/OLH/templates/core/accounts/reset_password.html:31
-#: src/themes/clean/templates/core/accounts/register.html:22
-#: src/themes/clean/templates/core/accounts/reset_password.html:21
-#: src/themes/material/templates/core/accounts/register.html:24
-#: src/themes/material/templates/core/accounts/reset_password.html:21
-#, python-format
-msgid "Your password should contain at least one number.\" %%}"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:32
+#: src/themes/OLH/templates/core/accounts/register.html:35
+#: src/themes/OLH/templates/core/accounts/reset_password.html:36
 msgid ""
-"For more information read our <a href=\"#\" data-open=\"password-modal"
-"\">password guide</a>."
+"For more information read our <a href=\"#\" data-open=\"password-"
+"modal\">password guide</a>."
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/register.html:83
-#: src/themes/clean/templates/core/accounts/register.html:27
-#: src/themes/material/templates/core/accounts/register.html:33
-msgid "By registering an account you agree to our"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:85
-#: src/themes/OLH/templates/core/accounts/register.html:87
-#: src/themes/OLH/templates/elements/journal_footer.html:25
-#: src/themes/OLH/templates/elements/journal_footer.html:27
-#: src/themes/OLH/templates/press/elements/press_footer.html:9
-#: src/themes/OLH/templates/press/elements/press_footer.html:11
-#: src/themes/clean/templates/core/accounts/register.html:29
-#: src/themes/clean/templates/core/accounts/register.html:31
-#: src/themes/clean/templates/elements/journal_footer.html:33
-#: src/themes/clean/templates/elements/journal_footer.html:37
-#: src/themes/clean/templates/elements/press_footer.html:11
-#: src/themes/clean/templates/elements/press_footer.html:14
-#: src/themes/material/templates/core/accounts/register.html:35
-#: src/themes/material/templates/core/accounts/register.html:37
-#: src/themes/material/templates/elements/journal_footer.html:28
-msgid "Privacy Policy"
-msgstr "Politique de confidentialité"
-
-#: src/themes/OLH/templates/core/accounts/register.html:106
-#: src/themes/OLH/templates/core/accounts/reset_password.html:48
-#: src/themes/clean/templates/core/accounts/register.html:54
-#: src/themes/clean/templates/core/accounts/reset_password.html:43
-#: src/themes/material/templates/core/accounts/register.html:53
-#: src/themes/material/templates/core/accounts/reset_password.html:41
-#, fuzzy
-#| msgid "Password 1"
-msgid "Password Guide"
-msgstr "Mot de passe"
-
-#: src/themes/OLH/templates/core/accounts/register.html:107
-#: src/themes/OLH/templates/core/accounts/reset_password.html:49
-#: src/themes/clean/templates/core/accounts/reset_password.html:49
+#: src/themes/OLH/templates/core/accounts/register.html:111
+#: src/themes/OLH/templates/core/accounts/reset_password.html:53
+#: src/themes/clean/templates/core/accounts/reset_password.html:53
 #: src/themes/material/templates/core/accounts/register.html:54
-#: src/themes/material/templates/core/accounts/reset_password.html:42
+#: src/themes/material/templates/core/accounts/reset_password.html:44
 msgid "When it comes to passwords, length is better than complexity."
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/register.html:108
-#: src/themes/OLH/templates/core/accounts/reset_password.html:50
+#: src/themes/OLH/templates/core/accounts/register.html:112
+#: src/themes/OLH/templates/core/accounts/reset_password.html:54
 #: src/themes/material/templates/core/accounts/register.html:55
-#: src/themes/material/templates/core/accounts/reset_password.html:43
+#: src/themes/material/templates/core/accounts/reset_password.html:45
 msgid ""
 "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
 "secure than a long and uncomplicated password (our awesome moon base rocks)."
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/register.html:109
-#: src/themes/OLH/templates/core/accounts/reset_password.html:51
+#: src/themes/OLH/templates/core/accounts/register.html:113
+#: src/themes/OLH/templates/core/accounts/reset_password.html:55
 msgid ""
 "We recommend selecting a long, but easy to remember password such as our "
 "awesome moon base rocks which would take an estimated septillion years to "
@@ -3159,41 +3572,27 @@ msgid ""
 "over 600 years on a standard computer."
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:6
-#: src/themes/OLH/templates/core/accounts/reset_password.html:38
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:4
-#: src/themes/clean/templates/core/accounts/reset_password.html:5
-#: src/themes/clean/templates/core/accounts/reset_password.html:29
-#: src/themes/material/templates/core/accounts/get_reset_token.html:4
-#: src/themes/material/templates/core/accounts/reset_password.html:5
-#: src/themes/material/templates/core/accounts/reset_password.html:29
+#: src/themes/OLH/templates/core/accounts/reset_password.html:10
+#: src/themes/OLH/templates/core/accounts/reset_password.html:42
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:8
+#: src/themes/clean/templates/core/accounts/reset_password.html:9
+#: src/themes/clean/templates/core/accounts/reset_password.html:33
+#: src/themes/hourglass/templates/core/accounts/get_reset_token.html:9
+#: src/themes/hourglass/templates/core/accounts/reset_password.html:10
+#: src/themes/material/templates/core/accounts/get_reset_token.html:8
+#: src/themes/material/templates/core/accounts/reset_password.html:9
+#: src/themes/material/templates/core/accounts/reset_password.html:31
 msgid "Reset Password"
 msgstr "Mot de passe"
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:26
-#: src/themes/clean/templates/core/accounts/reset_password.html:16
-#: src/themes/material/templates/core/accounts/reset_password.html:16
+#: src/themes/OLH/templates/core/accounts/reset_password.html:30
+#: src/themes/clean/templates/core/accounts/reset_password.html:20
+#: src/themes/material/templates/core/accounts/reset_password.html:20
 msgid "Enter your new password twice to complete the reset process"
 msgstr ""
 "Entrez votre adresse e-mail pour commencer le processus de réinitialisation"
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:29
-#: src/themes/clean/templates/core/accounts/reset_password.html:19
-#, python-format
-msgid ""
-"Your password should be %(request.press.password_length)s characters long."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/reset_password.html:33
-#: src/themes/material/templates/core/accounts/register.html:26
-msgid ""
-"For more information read our\n"
-"                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-"\">password guide</a>\n"
-"                        ."
-msgstr ""
-
-#: src/themes/OLH/templates/core/base.html:60
+#: src/themes/OLH/templates/core/base.html:61
 #: src/themes/OLH/templates/core/nav.html:7
 #: src/themes/OLH/templates/press/nav.html:6
 #: src/themes/OLH/templates/press/press_index.html:5
@@ -3209,18 +3608,6 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/themes/OLH/templates/core/login.html:27
-#: src/themes/OLH/templates/press/core/login.html:25
-#: src/themes/clean/templates/core/login.html:14
-msgid "Log in with your account"
-msgstr "Connectez-vous avec votre compte"
-
-#: src/themes/OLH/templates/core/login.html:28
-#: src/themes/clean/templates/core/login.html:16
-#: src/themes/material/templates/core/login.html:18
-msgid "Log in with ORCiD"
-msgstr "Connectez-vous avec ORCiD"
-
 #: src/themes/OLH/templates/core/login.html:31
 #: src/themes/OLH/templates/press/core/login.html:28
 #: src/themes/clean/templates/core/login.html:20
@@ -3229,38 +3616,6 @@ msgstr "Connectez-vous avec ORCiD"
 #| msgid "Log in with ORCiD"
 msgid "Login with"
 msgstr "Connectez-vous avec ORCiD"
-
-#: src/themes/OLH/templates/core/login.html:43
-#: src/themes/clean/templates/core/login.html:40
-msgid "Log in"
-msgstr "S'identifier"
-
-#: src/themes/OLH/templates/core/login.html:44
-#: src/themes/clean/templates/core/login.html:44
-msgid "Forgotten your password?"
-msgstr "Mot de passe oublié?"
-
-#: src/themes/OLH/templates/core/login.html:45
-#: src/themes/clean/templates/core/login.html:48
-msgid "Register a new account"
-msgstr ""
-
-#: src/themes/OLH/templates/core/nav.html:29
-#: src/themes/OLH/templates/core/nav.html:37
-#: src/themes/OLH/templates/journal/editorial_team.html:10
-#: src/themes/OLH/templates/journal/editorial_team.html:20
-#: src/themes/OLH/templates/press/nav.html:39
-#: src/themes/clean/templates/core/nav.html:32
-#: src/themes/clean/templates/core/nav.html:41
-#: src/themes/clean/templates/journal/editorial_team.html:4
-#: src/themes/clean/templates/journal/editorial_team.html:9
-#: src/themes/material/templates/core/nav.html:36
-#: src/themes/material/templates/core/nav.html:97
-#: src/themes/material/templates/journal/editorial_team.html:11
-#: src/themes/material/templates/preprints/editors.html:5
-#: src/themes/material/templates/preprints/editors.html:6
-msgid "Editorial Team"
-msgstr ""
 
 #: src/themes/OLH/templates/core/nav.html:44
 #: src/themes/OLH/templates/journal/become_reviewer.html:5
@@ -3345,13 +3700,13 @@ msgstr "Article"
 msgid "Edit Issue"
 msgstr "Publication"
 
-#: src/themes/OLH/templates/core/nav.html:66
+#: src/themes/OLH/templates/core/nav.html:65
 #: src/themes/OLH/templates/elements/right_hand_menu.html:31
 #: src/themes/material/templates/core/nav.html:194
 msgid "Edit News Item"
 msgstr ""
 
-#: src/themes/OLH/templates/core/nav.html:70
+#: src/themes/OLH/templates/core/nav.html:69
 #: src/themes/OLH/templates/elements/right_hand_menu.html:35
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:8
 #: src/themes/OLH/templates/press/nav.html:51
@@ -3367,7 +3722,7 @@ msgstr ""
 msgid "Admin"
 msgstr ""
 
-#: src/themes/OLH/templates/core/nav.html:74
+#: src/themes/OLH/templates/core/nav.html:73
 #: src/themes/OLH/templates/elements/right_hand_menu.html:39
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:13
 #: src/themes/OLH/templates/press/nav.html:55
@@ -3383,70 +3738,63 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: src/themes/OLH/templates/core/news/index.html:11
-#: src/themes/material/templates/core/news/index.html:11
+#: src/themes/OLH/templates/core/news/index.html:12
+#: src/themes/material/templates/core/news/index.html:12
 #: src/themes/material/templates/press/core/news/index.html:11
 #, fuzzy
 #| msgid "Filter"
 msgid "Filtering tag"
 msgstr "Filtre"
 
-#: src/themes/OLH/templates/core/news/index.html:24
-#: src/themes/OLH/templates/core/news/item.html:24
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:27
-#: src/themes/OLH/templates/press/core/news/index.html:22
-#: src/themes/OLH/templates/press/core/news/item.html:24
-#: src/themes/OLH/templates/press/core/news/item.html:33
-#: src/themes/material/templates/core/news/index.html:30
-#: src/themes/material/templates/core/news/item.html:30
+#: src/themes/OLH/templates/core/news/index.html:25
+#: src/themes/OLH/templates/core/news/item.html:25
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:28
+#: src/themes/OLH/templates/press/core/news/index.html:23
+#: src/themes/OLH/templates/press/core/news/item.html:25
+#: src/themes/OLH/templates/press/core/news/item.html:34
+#: src/themes/hourglass/templates/custom/news-item.html:16
+#: src/themes/material/templates/core/news/index.html:31
+#: src/themes/material/templates/core/news/item.html:31
 #: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
+#: src/themes/material/templates/press/core/news/item.html:18
 msgid "on"
 msgstr ""
 
-#: src/themes/OLH/templates/core/news/index.html:26
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:29
-#: src/themes/OLH/templates/press/core/news/index.html:24
+#: src/themes/OLH/templates/core/news/index.html:27
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:30
+#: src/themes/OLH/templates/press/core/news/index.html:25
 #: src/themes/clean/templates/core/news/index.html:17
 #: src/themes/clean/templates/press/core/news/index.html:17
-#: src/themes/material/templates/core/news/index.html:34
-#: src/themes/material/templates/journal/homepage_elements/news.html:36
+#: src/themes/material/templates/core/news/index.html:35
+#: src/themes/material/templates/journal/homepage_elements/news.html:37
 #: src/themes/material/templates/press/core/news/index.html:25
 msgid "Read More"
 msgstr "Lire la suite"
 
-#: src/themes/OLH/templates/core/news/index.html:33
+#: src/themes/OLH/templates/core/news/index.html:34
 #: src/themes/material/templates/press/core/news/index.html:30
 #, fuzzy
 #| msgid "This journal currently has no news items to display"
 msgid "This journal currently has no news items to display."
 msgstr "Cette revue n'a actuellement aucune nouvelle à afficher"
 
-#: src/themes/OLH/templates/core/news/item.html:40
+#: src/themes/OLH/templates/core/news/item.html:41
 #: src/themes/clean/templates/core/news/item.html:20
 #: src/themes/clean/templates/press/core/news/item.html:16
 msgid "Tags "
 msgstr ""
 
-#: src/themes/OLH/templates/core/news/item.html:47
+#: src/themes/OLH/templates/core/news/item.html:48
 #: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
+#: src/themes/material/templates/core/news/item.html:44
 msgid "Back to"
 msgstr ""
 
-#: src/themes/OLH/templates/core/news/item.html:47
+#: src/themes/OLH/templates/core/news/item.html:48
 #: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
+#: src/themes/material/templates/core/news/item.html:44
 msgid "List"
 msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
-#, fuzzy
-#| msgid "Your contact email address"
-msgid "Change Your Email Address"
-msgstr "Votre adresse email de contact"
 
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:8
 msgid ""
@@ -3460,66 +3808,12 @@ msgid ""
 "                "
 msgstr ""
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
-#, fuzzy
-#| msgid "Your contact email address"
-msgid "Current Email Address"
-msgstr "Votre adresse email de contact"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
-#, fuzzy
-#| msgid "Your contact email address"
-msgid "New Email Address"
-msgstr "Votre adresse email de contact"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
-#, fuzzy
-#| msgid "Your contact email address"
-msgid "Update Email Address"
-msgstr "Votre adresse email de contact"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
-#, fuzzy
-#| msgid "Regsiter for"
-msgid "Register for Article Notifications"
-msgstr "S'inscrire à"
-
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:31
 #: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:43
 msgid ""
 "Use the button below to register to receive notifications of new articles\n"
 "                            published in this journal "
 msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
-msgid "Unsubscribe from Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
-msgid "Subscribe to Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
-#, fuzzy
-#| msgid "Reset Password"
-msgid "Update Password"
-msgstr "Mot de passe"
 
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:53
 #: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:66
@@ -3528,42 +3822,13 @@ msgid ""
 "new password."
 msgstr ""
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
+#: src/themes/OLH/templates/elements/accounts/user_form.html:5
+#: src/themes/clean/templates/elements/accounts/user_form.html:5
+#: src/themes/material/templates/elements/accounts/user_form.html:6
 #, fuzzy
-#| msgid "Reset Password"
-msgid "Current Password"
-msgstr "Mot de passe"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
-#, fuzzy
-#| msgid "Reset Password"
-msgid "New Password"
-msgstr "Mot de passe"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
-#, fuzzy
-#| msgid "Password 1"
-msgid "Enter Password Again"
-msgstr "Mot de passe"
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:41
-#: src/themes/clean/templates/elements/accounts/user_form.html:38
-#: src/themes/material/templates/elements/accounts/user_form.html:39
-msgid "Social Media and Accounts"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:95
-#: src/themes/OLH/templates/journal/article.html:108
-#: src/themes/clean/templates/elements/accounts/user_form.html:92
-#: src/themes/material/templates/elements/accounts/user_form.html:93
-#, fuzzy
-#| msgid "Section"
-msgid "Options"
-msgstr "Section"
+#| msgid "Figure/Data"
+msgid "Core Data"
+msgstr "Figure/données"
 
 #: src/themes/OLH/templates/elements/edit_author.html:5
 msgid "NB."
@@ -3609,13 +3874,13 @@ msgid "Date"
 msgstr "la Date"
 
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:26
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:34
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:35
 #: src/themes/OLH/templates/elements/journal/article_list_filters.html:6
 #: src/themes/OLH/templates/elements/journal/search_form.html:19
 #: src/themes/OLH/templates/press/press_journals.html:93
 #: src/themes/OLH/templates/press/press_journals.html:94
 #: src/themes/clean/templates/elements/journal/article_list_filters.html:7
-#: src/themes/clean/templates/journal/articles.html:81
+#: src/themes/clean/templates/journal/articles.html:82
 #: src/themes/clean/templates/journal/full-text-search.html:54
 #: src/themes/clean/templates/press/press_journals.html:56
 #: src/themes/material/templates/journal/articles.html:95
@@ -3625,20 +3890,16 @@ msgstr "la Date"
 msgid "Filter"
 msgstr "Filtre"
 
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:36
-#: src/themes/clean/templates/journal/articles.html:84
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:37
+#: src/themes/clean/templates/journal/articles.html:85
 #: src/themes/material/templates/journal/articles.html:109
 #, fuzzy
 #| msgid "Filter"
 msgid "Clear Filters"
 msgstr "Filtre"
 
-#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
-#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
-msgid "Apply"
-msgstr ""
-
 #: src/themes/OLH/templates/elements/journal/authors_block.html:4
+#: src/themes/clean/templates/elements/article_listing.html:27
 #: src/themes/clean/templates/elements/journal/authors_block.html:4
 #: src/themes/material/templates/elements/article_listing.html:25
 msgid "and"
@@ -3652,7 +3913,7 @@ msgstr ""
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:5
 #: src/themes/clean/templates/elements/journal/citation_modals.html:6
-#: src/themes/clean/templates/journal/article.html:294
+#: src/themes/clean/templates/journal/article.html:304
 msgid "Harvard-style Citation"
 msgstr ""
 
@@ -3667,13 +3928,13 @@ msgid "Preprints"
 msgstr "Fichier manuscrit"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:19
-#: src/themes/OLH/templates/journal/article.html:135
+#: src/themes/OLH/templates/journal/article.html:137
 msgid "Vancouver Citation Style"
 msgstr ""
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:19
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:40
-#: src/themes/OLH/templates/journal/article.html:136
+#: src/themes/OLH/templates/journal/article.html:138
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "APA Citation Style"
@@ -3681,19 +3942,19 @@ msgstr "Frais de publication"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:27
 #: src/themes/clean/templates/elements/journal/citation_modals.html:28
-#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/clean/templates/journal/article.html:305
 msgid "Vancouver-style Citation"
 msgstr ""
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:40
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:63
-#: src/themes/OLH/templates/journal/article.html:134
+#: src/themes/OLH/templates/journal/article.html:136
 msgid "Harvard Citation Style"
 msgstr ""
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:49
 #: src/themes/clean/templates/elements/journal/citation_modals.html:49
-#: src/themes/clean/templates/journal/article.html:296
+#: src/themes/clean/templates/journal/article.html:306
 #, fuzzy
 #| msgid "Salutation"
 msgid "APA-style Citation"
@@ -3701,7 +3962,7 @@ msgstr "Salutation"
 
 #: src/themes/OLH/templates/elements/journal/editorial_social_content.html:4
 #: src/themes/clean/templates/elements/journal/editorial_social_content.html:4
-#: src/themes/clean/templates/journal/article.html:283
+#: src/themes/clean/templates/journal/article.html:293
 msgid "Twitter"
 msgstr ""
 
@@ -3720,17 +3981,45 @@ msgstr ""
 msgid "Linkedin"
 msgstr ""
 
+#: src/themes/OLH/templates/elements/journal/issue_list.html:16
+#: src/themes/clean/templates/elements/journal/issue_list.html:5
+#: src/themes/clean/templates/journal/issues.html:14
+#: src/themes/material/templates/elements/journal/issue_list.html:16
+#: src/themes/material/templates/elements/journal/issue_list.html:20
+msgid "items"
+msgstr "articles"
+
+#: src/themes/OLH/templates/elements/journal/issue_list.html:24
+msgid "There are no issues published in this journal yet."
+msgstr ""
+
+#: src/themes/OLH/templates/elements/journal/issue_list_by_decade.html:3
+#: src/themes/material/templates/elements/journal/issue_list_by_decade.html:3
+msgid ""
+"\n"
+"            Issues are grouped by decade. Select a decade to view the "
+"issues\n"
+"            published during that decade.\n"
+"        "
+msgstr ""
+
 #: src/themes/OLH/templates/elements/journal/issue_sidebar.html:7
-#: src/themes/OLH/templates/journal/article.html:208
-#: src/themes/OLH/templates/journal/article.html:263
+#: src/themes/OLH/templates/journal/article.html:210
+#: src/themes/OLH/templates/journal/article.html:246
+#: src/themes/OLH/templates/journal/article.html:334
 #: src/themes/OLH/templates/repository/preprint.html:114
+#: src/themes/OLH/templates/repository/preprint.html:152
 #: src/themes/clean/templates/elements/journal/issue_sidebar.html:6
-#: src/themes/clean/templates/journal/article.html:102
-#: src/themes/clean/templates/journal/article.html:281
+#: src/themes/clean/templates/journal/article.html:101
+#: src/themes/clean/templates/journal/article.html:184
+#: src/themes/clean/templates/journal/article.html:291
 #: src/themes/material/templates/elements/journal/issue_sidebar.html:5
-#: src/themes/material/templates/journal/article.html:188
+#: src/themes/material/templates/journal/article.html:123
+#: src/themes/material/templates/journal/article.html:169
+#: src/themes/material/templates/journal/article.html:273
 #: src/themes/material/templates/preprints/article.html:133
-#: src/themes/material/templates/repository/preprint.html:132
+#: src/themes/material/templates/repository/preprint.html:130
+#: src/themes/material/templates/repository/preprint.html:203
 msgid "Downloads"
 msgstr "Téléchargements"
 
@@ -3791,11 +4080,11 @@ msgid "Sort articles by"
 msgstr "Fichiers d'article"
 
 #: src/themes/OLH/templates/elements/journal/summary_modal.html:3
-#: src/themes/OLH/templates/journal/article.html:437
+#: src/themes/OLH/templates/journal/article.html:428
 #: src/themes/clean/templates/elements/journal/summary_modal.html:6
-#: src/themes/clean/templates/journal/article.html:250
+#: src/themes/clean/templates/journal/article.html:260
 #: src/themes/material/templates/elements/summary_modal.html:5
-#: src/themes/material/templates/journal/article.html:380
+#: src/themes/material/templates/journal/article.html:382
 msgid "Non Specialist Summary"
 msgstr ""
 
@@ -3866,9 +4155,9 @@ msgid "Public Submissions"
 msgstr "Soumissions"
 
 #: src/themes/OLH/templates/elements/section_block.html:12
-#: src/themes/OLH/templates/journal/article.html:298
+#: src/themes/OLH/templates/journal/article.html:279
 #: src/themes/clean/templates/elements/sections_block.html:9
-#: src/themes/clean/templates/journal/article.html:242
+#: src/themes/clean/templates/journal/article.html:252
 #: src/themes/material/templates/elements/sections_display.html:11
 msgid "Peer Reviewed"
 msgstr "Examen par les pairs"
@@ -3965,7 +4254,7 @@ msgstr "Article"
 
 #: src/themes/OLH/templates/journal/article.html:28
 #: src/themes/OLH/templates/journal/article.html:64
-#: src/themes/OLH/templates/journal/article.html:159
+#: src/themes/OLH/templates/journal/article.html:162
 #: src/themes/OLH/templates/journal/print.html:15
 #: src/themes/clean/templates/journal/article.html:38
 #: src/themes/clean/templates/journal/print.html:15
@@ -3973,41 +4262,84 @@ msgid "Author"
 msgstr "Auteur"
 
 #: src/themes/OLH/templates/journal/article.html:115
-#: src/themes/material/templates/journal/article.html:250
+#: src/themes/clean/templates/journal/article.html:172
+#: src/themes/material/templates/journal/article.html:231
 msgid "Share"
 msgstr "Partager"
 
+#: src/themes/OLH/templates/journal/article.html:116
+#: src/themes/clean/templates/journal/article.html:176
+#: src/themes/material/templates/journal/article.html:236
+msgid "Share on Facebook"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:118
+#: src/themes/clean/templates/journal/article.html:179
+#: src/themes/material/templates/journal/article.html:239
+#, fuzzy
+#| msgid "Share"
+msgid "Share on X"
+msgstr "Partager"
+
+#: src/themes/OLH/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:182
+#: src/themes/material/templates/journal/article.html:242
+msgid "Share on LinkedIn"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:128
+#, fuzzy
+#| msgid "Article"
+msgid "print article"
+msgstr "Article"
+
+#: src/themes/OLH/templates/journal/article.html:129
+msgid "decrease text size"
+msgstr ""
+
 #: src/themes/OLH/templates/journal/article.html:130
+msgid "increase text size"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:132
+#, fuzzy
+#| msgid "Dyslexia"
+msgid "Dyslexia mode"
+msgstr "Dyslexie"
+
+#: src/themes/OLH/templates/journal/article.html:132
 msgid "Dyslexia"
 msgstr "Dyslexie"
 
-#: src/themes/OLH/templates/journal/article.html:137
-#: src/themes/OLH/templates/journal/article.html:210
-#: src/themes/OLH/templates/journal/article.html:353
-#: src/themes/OLH/templates/journal/article.html:357
+#: src/themes/OLH/templates/journal/article.html:134
+#, fuzzy
+#| msgid "Article"
+msgid "Cite article"
+msgstr "Article"
+
+#: src/themes/OLH/templates/journal/article.html:139
+#: src/themes/OLH/templates/journal/article.html:213
+#: src/themes/OLH/templates/journal/article.html:339
 #: src/themes/clean/templates/journal/article.html:104
-#: src/themes/clean/templates/journal/article.html:186
-#: src/themes/clean/templates/journal/article.html:191
-#: src/themes/clean/templates/journal/article.html:298
-#: src/themes/clean/templates/journal/article.html:301
+#: src/themes/clean/templates/journal/article.html:190
+#: src/themes/clean/templates/journal/article.html:308
+#: src/themes/clean/templates/journal/article.html:311
 #: src/themes/material/templates/elements/journal/issue_sidebar.html:8
-#: src/themes/material/templates/journal/article.html:124
 #: src/themes/material/templates/journal/article.html:127
-#: src/themes/material/templates/journal/article.html:293
-#: src/themes/material/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:279
 #: src/themes/material/templates/preprints/article.html:113
 #: src/themes/material/templates/preprints/article.html:117
 #: src/themes/material/templates/preprints/article.html:139
 msgid "Download"
 msgstr "Télécharger"
 
-#: src/themes/OLH/templates/journal/article.html:138
+#: src/themes/OLH/templates/journal/article.html:140
 #, fuzzy
 #| msgid "Download"
 msgid " Download"
 msgstr "Télécharger"
 
-#: src/themes/OLH/templates/journal/article.html:183
+#: src/themes/OLH/templates/journal/article.html:186
 #: src/themes/OLH/templates/journal/print.html:35
 #: src/themes/clean/templates/journal/article.html:89
 #: src/themes/clean/templates/journal/print.html:35
@@ -4015,145 +4347,164 @@ msgstr "Télécharger"
 msgid "How to Cite"
 msgstr "Comment citer"
 
-#: src/themes/OLH/templates/journal/article.html:190
+#: src/themes/OLH/templates/journal/article.html:193
 #: src/themes/clean/templates/journal/article.html:95
 #: src/themes/material/templates/journal/article.html:101
 msgid "Rights"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:195
-#: src/themes/clean/templates/journal/article.html:143
+#: src/themes/OLH/templates/journal/article.html:198
+#: src/themes/clean/templates/journal/article.html:129
 #: src/themes/material/templates/journal/article.html:110
 #, fuzzy
 #| msgid "Published on"
 msgid "Publisher Notes"
 msgstr "Publié le"
 
-#: src/themes/OLH/templates/journal/article.html:213
-#: src/themes/OLH/templates/journal/article.html:361
+#: src/themes/OLH/templates/journal/article.html:216
+#: src/themes/OLH/templates/journal/article.html:343
 #, fuzzy
 #| msgid "View"
 msgid "View PDF"
 msgstr "Vue"
 
-#: src/themes/OLH/templates/journal/article.html:239
-#, python-format
-msgid ""
-"\n"
-"                                                        (grant %(id)s)\n"
-"                                                    "
+#: src/themes/OLH/templates/journal/article.html:227
+#: src/themes/OLH/templates/journal/article.html:356
+#: src/themes/clean/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:207
+#: src/themes/material/templates/journal/article.html:143
+#: src/themes/material/templates/journal/article.html:298
+msgid "Downloads are not available for this article."
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:257
-#: src/themes/clean/templates/journal/article.html:280
-#: src/themes/material/templates/journal/article.html:182
+#: src/themes/OLH/templates/journal/article.html:240
+#: src/themes/OLH/templates/repository/preprint.html:151
+#: src/themes/clean/templates/journal/article.html:290
+#: src/themes/material/templates/journal/article.html:163
 #: src/themes/material/templates/preprints/article.html:132
+#: src/themes/material/templates/repository/preprint.html:202
 msgid "Views"
 msgstr "Vues"
 
-#: src/themes/OLH/templates/journal/article.html:269
-#: src/themes/clean/templates/journal/article.html:289
-#: src/themes/material/templates/journal/article.html:220
+#: src/themes/OLH/templates/journal/article.html:253
+#: src/themes/clean/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:201
 #, fuzzy
 #| msgid "Salutation"
 msgid "Citations"
 msgstr "Salutation"
 
-#: src/themes/OLH/templates/journal/article.html:283
-#: src/themes/clean/templates/journal/article.html:221
+#: src/themes/OLH/templates/journal/article.html:267
+#: src/themes/clean/templates/journal/article.html:233
+#: src/themes/material/templates/journal/article.html:354
 #: src/themes/material/templates/preprints/article.html:123
 msgid "Published on"
 msgstr "Publié le"
 
 #: src/themes/OLH/templates/journal/article.html:287
-#: src/themes/clean/templates/journal/article.html:224
-msgid "Accepted on"
-msgstr ""
-
-#: src/themes/OLH/templates/journal/article.html:306
-#: src/themes/OLH/templates/repository/preprint.html:126
-#: src/themes/clean/templates/journal/article.html:245
+#: src/themes/OLH/templates/repository/preprint.html:127
+#: src/themes/clean/templates/journal/article.html:255
 #: src/themes/material/templates/preprints/article.html:124
-#: src/themes/material/templates/repository/preprint.html:190
+#: src/themes/material/templates/repository/preprint.html:189
 msgid "License"
 msgstr "Licence"
 
-#: src/themes/OLH/templates/journal/article.html:374
+#: src/themes/OLH/templates/journal/article.html:359
 msgid "Downloads are not available until this article is published "
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:383
-#: src/themes/material/templates/journal/article.html:434
+#: src/themes/OLH/templates/journal/article.html:368
+#: src/themes/material/templates/journal/article.html:410
 msgid "Identifiers"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:393
-#: src/themes/material/templates/journal/article.html:326
+#: src/themes/OLH/templates/journal/article.html:378
+#: src/themes/material/templates/journal/article.html:308
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Publication details"
 msgstr "Frais de publication"
 
-#: src/themes/OLH/templates/journal/article.html:396
-#: src/themes/clean/templates/journal/article.html:227
-#: src/themes/material/templates/journal/article.html:330
+#: src/themes/OLH/templates/journal/article.html:381
+#: src/themes/clean/templates/journal/article.html:237
+#: src/themes/material/templates/journal/article.html:312
 msgid "Pages"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:399
-#: src/themes/clean/templates/journal/article.html:230
+#: src/themes/OLH/templates/journal/article.html:384
+#: src/themes/clean/templates/journal/article.html:240
 #, fuzzy
 #| msgid "Article Files"
 msgid "Article Number"
 msgstr "Fichiers d'article"
 
-#: src/themes/OLH/templates/journal/article.html:402
-#: src/themes/clean/templates/journal/article.html:233
-#: src/themes/material/templates/journal/article.html:342
+#: src/themes/OLH/templates/journal/article.html:387
+#: src/themes/clean/templates/journal/article.html:243
+#: src/themes/material/templates/journal/article.html:324
 #, fuzzy
 #| msgid "Published on"
 msgid "Publisher"
 msgstr "Publié le"
 
-#: src/themes/OLH/templates/journal/article.html:405
-#: src/themes/clean/templates/journal/article.html:236
+#: src/themes/OLH/templates/journal/article.html:390
+#: src/themes/clean/templates/journal/article.html:246
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Original Publication"
 msgstr "Frais de publication"
 
-#: src/themes/OLH/templates/journal/article.html:408
-#: src/themes/clean/templates/journal/article.html:239
-#: src/themes/material/templates/journal/article.html:354
+#: src/themes/OLH/templates/journal/article.html:393
+#: src/themes/clean/templates/journal/article.html:249
+#: src/themes/material/templates/journal/article.html:336
 msgid "Original ISSN"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:416
-#: src/themes/clean/templates/journal/article.html:209
-#: src/themes/material/templates/journal/article.html:366
-#: src/themes/material/templates/repository/preprint.html:140
+#: src/themes/OLH/templates/journal/article.html:396
+#: src/themes/clean/templates/journal/article.html:223
+#: src/themes/material/templates/journal/article.html:342
+#, fuzzy
+#| msgid "Start Submission"
+msgid "Submitted on"
+msgstr "Soumission"
+
+#: src/themes/OLH/templates/journal/article.html:399
+#: src/themes/clean/templates/journal/article.html:228
+#: src/themes/material/templates/journal/article.html:348
+msgid "Accepted on"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:407
+#: src/themes/clean/templates/journal/article.html:211
+#: src/themes/material/templates/journal/article.html:368
+#: src/themes/material/templates/repository/preprint.html:138
 #, fuzzy
 #| msgid "Filter"
 msgid "Supplementary Files"
 msgstr "Filtre"
 
-#: src/themes/OLH/templates/journal/article.html:439
-#: src/themes/material/templates/journal/article.html:381
+#: src/themes/OLH/templates/journal/article.html:430
+#: src/themes/material/templates/journal/article.html:383
 msgid "View Summary"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:446
+#: src/themes/OLH/templates/journal/article.html:437
 msgid "Jump to"
 msgstr "Sauter à"
 
-#: src/themes/OLH/templates/journal/article.html:472
-#: src/themes/clean/templates/journal/article.html:305
-#: src/themes/material/templates/journal/article.html:478
+#: src/themes/OLH/templates/journal/article.html:463
+#: src/themes/clean/templates/journal/article.html:324
+#: src/themes/material/templates/journal/article.html:464
 msgid "File Checksums"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:485
-#: src/themes/material/templates/journal/article.html:446
+#: src/themes/OLH/templates/journal/article.html:473
+#: src/themes/clean/templates/journal/article.html:334
+#: src/themes/material/templates/journal/article.html:475
+msgid "File Checksums are not available for this article."
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:480
+#: src/themes/material/templates/journal/article.html:422
 #, fuzzy
 #| msgid "Peer Reviewed"
 msgid "Peer Review"
@@ -4197,7 +4548,6 @@ msgstr "Collections"
 
 #: src/themes/OLH/templates/journal/collections.html:29
 #: src/themes/OLH/templates/repository/preprint.html:124
-#: src/themes/material/templates/journal/article.html:400
 #, fuzzy
 #| msgid "Published on"
 msgid "Published"
@@ -4236,21 +4586,21 @@ msgstr "Article vedette"
 msgid "Unnamed Journal"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
 #: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
 #, fuzzy
 #| msgid "Date"
 msgid "Latest"
 msgstr "la Date"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
 #: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
 msgid "Posts"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:35
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:36
 #: src/themes/clean/templates/press/core/news/index.html:21
 msgid "This journal currently has no news items to display"
 msgstr "Cette revue n'a actuellement aucune nouvelle à afficher"
@@ -4269,18 +4619,6 @@ msgstr "Article vedette"
 #| msgid "Featured Articles"
 msgid "Featured Preprints"
 msgstr "Article vedette"
-
-#: src/themes/OLH/templates/journal/issues.html:31
-#: src/themes/clean/templates/journal/issues.html:19
-#: src/themes/clean/templates/journal/issues.html:28
-#: src/themes/material/templates/journal/issues.html:29
-#: src/themes/material/templates/journal/issues.html:31
-msgid "items"
-msgstr "articles"
-
-#: src/themes/OLH/templates/journal/issues.html:39
-msgid "There are no issues published in this journal yet."
-msgstr ""
 
 #: src/themes/OLH/templates/journal/keyword.html:6
 #: src/themes/OLH/templates/journal/keyword.html:12
@@ -4332,39 +4670,40 @@ msgstr "Soumissions"
 msgid "Login with ORCiD"
 msgstr "Connectez-vous avec ORCiD"
 
-#: src/themes/OLH/templates/press/core/news/index.html:5
-#: src/themes/OLH/templates/press/core/news/index.html:10
-#: src/themes/OLH/templates/press/core/news/item.html:5
+#: src/themes/OLH/templates/press/core/news/index.html:6
+#: src/themes/OLH/templates/press/core/news/index.html:11
+#: src/themes/OLH/templates/press/core/news/item.html:6
 #: src/themes/clean/templates/press/core/news/index.html:9
 #: src/themes/clean/templates/press/nav.html:16
+#: src/themes/hourglass/templates/press/news/index.html:4
 #: src/themes/material/templates/core/nav.html:88
 #: src/themes/material/templates/press/core/news/index.html:5
 #: src/themes/material/templates/press/core/news/index.html:10
-#: src/themes/material/templates/press/core/news/item.html:5
+#: src/themes/material/templates/press/core/news/item.html:6
 msgid "News"
 msgstr "Nouvelles"
 
-#: src/themes/OLH/templates/press/core/news/index.html:31
+#: src/themes/OLH/templates/press/core/news/index.html:32
 #, fuzzy
 #| msgid "This journal currently has no news items to display"
 msgid "This press currently has no news items to display."
 msgstr "Cette revue n'a actuellement aucune nouvelle à afficher"
 
-#: src/themes/OLH/templates/press/core/news/item.html:33
+#: src/themes/OLH/templates/press/core/news/item.html:34
 #: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
+#: src/themes/material/templates/press/core/news/item.html:18
 msgid "Posted by"
 msgstr "Posté par"
 
-#: src/themes/OLH/templates/press/core/news/item.html:40
-#: src/themes/material/templates/core/news/item.html:35
-#: src/themes/material/templates/press/core/news/item.html:22
+#: src/themes/OLH/templates/press/core/news/item.html:41
+#: src/themes/material/templates/core/news/item.html:36
+#: src/themes/material/templates/press/core/news/item.html:23
 msgid "Tags"
 msgstr ""
 
-#: src/themes/OLH/templates/press/core/news/item.html:45
+#: src/themes/OLH/templates/press/core/news/item.html:46
 #: src/themes/clean/templates/press/core/news/item.html:18
-#: src/themes/material/templates/press/core/news/item.html:30
+#: src/themes/material/templates/press/core/news/item.html:31
 msgid "Back to News List"
 msgstr ""
 
@@ -4377,6 +4716,7 @@ msgstr "Plan du site"
 #: src/themes/OLH/templates/press/press_journals.html:5
 #: src/themes/clean/templates/press/nav.html:37
 #: src/themes/clean/templates/press/press_journals.html:10
+#: src/themes/hourglass/templates/press/press_journals.html:9
 #: src/themes/material/templates/press/press_journals.html:9
 msgid "Journals"
 msgstr ""
@@ -4392,16 +4732,22 @@ msgstr ""
 msgid "Repositories"
 msgstr ""
 
+#: src/themes/OLH/templates/press/nav.html:39
+#: src/themes/material/templates/preprints/editors.html:5
+#: src/themes/material/templates/preprints/editors.html:6
+msgid "Editorial Team"
+msgstr ""
+
 #: src/themes/OLH/templates/press/press_journals.html:48
 msgid "Disciplines"
 msgstr ""
 
 #: src/themes/OLH/templates/press/press_journals.html:61
 #: src/themes/OLH/templates/press/press_journals.html:68
-#: src/themes/clean/templates/journal/article.html:195
+#: src/themes/clean/templates/journal/article.html:194
 #: src/themes/clean/templates/press/press_journals.html:32
 #: src/themes/clean/templates/press/press_journals.html:39
-#: src/themes/material/templates/journal/article.html:303
+#: src/themes/material/templates/journal/article.html:283
 #: src/themes/material/templates/press/press_journals.html:36
 #: src/themes/material/templates/press/press_journals.html:43
 msgid "View"
@@ -4467,7 +4813,7 @@ msgstr "Salutation"
 #: src/themes/OLH/templates/repository/nav.html:6
 #: src/themes/material/templates/repository/nav.html:21
 #: src/themes/material/templates/repository/nav.html:45
-#: src/themes/material/templates/repository/preprint.html:168
+#: src/themes/material/templates/repository/preprint.html:166
 #, fuzzy
 #| msgid "Subject"
 msgid "Subjects"
@@ -4482,7 +4828,7 @@ msgstr "Fichier manuscrit"
 
 #: src/themes/OLH/templates/repository/preprint.html:60
 #: src/themes/material/templates/preprints/article.html:63
-#: src/themes/material/templates/repository/preprint.html:87
+#: src/themes/material/templates/repository/preprint.html:85
 #, fuzzy
 #| msgid "Comments to Editor"
 msgid "Comments"
@@ -4506,18 +4852,27 @@ msgstr ""
 msgid "Last Updated"
 msgstr "Nom de famille"
 
-#: src/themes/OLH/templates/repository/preprint.html:134
+#: src/themes/OLH/templates/repository/preprint.html:138
 #: src/themes/material/templates/preprints/article.html:135
 #, fuzzy
 #| msgid "Section"
 msgid "Versions"
 msgstr "Section"
 
-#: src/themes/OLH/templates/repository/preprint.html:139
+#: src/themes/OLH/templates/repository/preprint.html:143
 msgid "This is the only version of the preprint."
 msgstr ""
 
-#: src/themes/OLH/templates/repository/preprint.html:143
+#: src/themes/OLH/templates/repository/preprint.html:149
+#: src/themes/clean/templates/journal/article.html:288
+#: src/themes/material/templates/preprints/article.html:130
+#: src/themes/material/templates/repository/preprint.html:201
+#, fuzzy
+#| msgid "Altmetrics"
+msgid "Metrics"
+msgstr "Altmetrics"
+
+#: src/themes/OLH/templates/repository/preprint.html:156
 #: src/themes/material/templates/preprints/article.html:152
 #: src/themes/material/templates/preprints/list.html:6
 #: src/themes/material/templates/preprints/list.html:14
@@ -4528,16 +4883,11 @@ msgstr ""
 msgid "You do not have permission to view this page"
 msgstr ""
 
-#: src/themes/clean/templates/500.html:21
-#: src/themes/clean/templates/core/base.html:37
-msgid "Skip to main content"
-msgstr ""
-
 #: src/themes/clean/templates/500.html:27
 msgid "A server error has occurred."
 msgstr ""
 
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:10
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:14
 msgid ""
 "The ORCiD you logged in with is not currently linked with an account in our "
 "system. You can either\n"
@@ -4545,17 +4895,14 @@ msgid ""
 "link your ORCiD for future use."
 msgstr ""
 
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:34
 #, fuzzy
 #| msgid "Forgotten your password?"
 msgid "Forgot your password"
 msgstr "Mot de passe oublié?"
 
-#: src/themes/clean/templates/core/accounts/public_profile.html:10
-msgid "profile photo"
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/register.html:24
+#: src/themes/clean/templates/core/accounts/register.html:26
+#: src/themes/clean/templates/core/accounts/reset_password.html:26
 msgid ""
 "For more information read our <a href=\"#\" data-toggle=\"modal\" data-"
 "target=\"#passwordmodal\">password guide</a>."
@@ -4579,23 +4926,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: src/themes/clean/templates/core/accounts/reset_password.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:23
-msgid ""
-"For more information read our\n"
-"                                    <a href=\"#passwordmodal\" class=\"modal-"
-"trigger\">password guide</a>\n"
-"                                    ."
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/reset_password.html:50
+#: src/themes/clean/templates/core/accounts/reset_password.html:54
 msgid ""
 "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
 "secure than a long and\n"
 "                        uncomplicated password (our awesome moon base rocks)."
 msgstr ""
 
-#: src/themes/clean/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/reset_password.html:56
 msgid ""
 "We recommend selecting a long, but easy to remember password such as <em>our "
 "awesome moon base\n"
@@ -4652,10 +4990,24 @@ msgstr "Mot de passe"
 msgid "Enter New Password Again"
 msgstr "Mot de passe"
 
+#: src/themes/clean/templates/elements/journal/issue_list.html:8
+#, fuzzy
+#| msgid "This article is a preprints"
+msgid "This journal has no issues"
+msgstr "Cet article est une preprints"
+
+#: src/themes/clean/templates/elements/journal/issue_list_by_decade.html:2
+msgid ""
+"\n"
+"        Issues are grouped by decade. Select a decade to view the issues\n"
+"        published during that decade.\n"
+"    "
+msgstr ""
+
 #: src/themes/clean/templates/elements/journal/table_modal.html:12
 #: src/themes/clean/templates/elements/public_reviews.html:35
 #: src/themes/material/templates/core/accounts/register.html:61
-#: src/themes/material/templates/core/accounts/reset_password.html:49
+#: src/themes/material/templates/core/accounts/reset_password.html:51
 #: src/themes/material/templates/elements/summary_modal.html:13
 msgid "Close"
 msgstr ""
@@ -4683,51 +5035,30 @@ msgstr ""
 msgid "Sections submission information"
 msgstr ""
 
-#: src/themes/clean/templates/journal/article.html:133
-#, python-format
-msgid ""
-"\n"
-"                                        (grant %(id)s)\n"
-"                                    "
-msgstr ""
-
-#: src/themes/clean/templates/journal/article.html:268
+#: src/themes/clean/templates/journal/article.html:278
 #, fuzzy
 #| msgid "Peer Reviewed"
 msgid "Open Peer Reviews"
 msgstr "Examen par les pairs"
 
-#: src/themes/clean/templates/journal/article.html:278
-#: src/themes/material/templates/preprints/article.html:130
-#, fuzzy
-#| msgid "Altmetrics"
-msgid "Metrics"
-msgstr "Altmetrics"
-
-#: src/themes/clean/templates/journal/article.html:285
-#: src/themes/material/templates/journal/article.html:203
+#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/material/templates/journal/article.html:184
 msgid "Wikipedia"
 msgstr ""
 
-#: src/themes/clean/templates/journal/article.html:287
-#: src/themes/material/templates/journal/article.html:211
+#: src/themes/clean/templates/journal/article.html:297
+#: src/themes/material/templates/journal/article.html:192
 msgid "Reddit"
 msgstr ""
 
-#: src/themes/clean/templates/journal/article.html:292
+#: src/themes/clean/templates/journal/article.html:302
 #: src/themes/material/templates/preprints/article.html:145
 #, fuzzy
 #| msgid "Salutation"
 msgid "Citation"
 msgstr "Salutation"
 
-#: src/themes/clean/templates/journal/article.html:317
-#: src/themes/material/templates/journal/article.html:494
-#: src/themes/material/templates/journal/submissions.html:72
-msgid "Table of Contents"
-msgstr ""
-
-#: src/themes/clean/templates/journal/article.html:343
+#: src/themes/clean/templates/journal/article.html:366
 msgid "View Larger Table"
 msgstr ""
 
@@ -4743,7 +5074,7 @@ msgstr "Section"
 
 #: src/themes/clean/templates/journal/authors.html:26
 #: src/themes/material/templates/journal/authors.html:31
-#: src/themes/material/templates/journal/editorial_team.html:36
+#: src/themes/material/templates/journal/editorial_team.html:34
 msgid "View Profile"
 msgstr ""
 
@@ -4779,15 +5110,9 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: src/themes/clean/templates/journal/issues.html:16
+#: src/themes/clean/templates/journal/issues.html:14
 msgid "The current issue is"
 msgstr ""
-
-#: src/themes/clean/templates/journal/issues.html:30
-#, fuzzy
-#| msgid "This article is a preprints"
-msgid "This journal has no issues"
-msgstr "Cet article est une preprints"
 
 #: src/themes/clean/templates/press/press_journals.html:52
 #, fuzzy
@@ -4800,14 +5125,69 @@ msgstr "Cet article est une preprints"
 msgid "Start typing to filter."
 msgstr ""
 
-#: src/themes/material/templates/core/accounts/activate_account.html:25
+#: src/themes/hourglass/templates/core/accounts/orcid_registration.html:10
+msgid "Unregistered ORCID"
+msgstr ""
+
+#: src/themes/hourglass/templates/custom/get-reset-token.html:27
+#, fuzzy
+#| msgid "Enter your email address to begin the reset process"
+msgid ""
+"\n"
+"                  Enter your email address to begin the reset process\n"
+"                "
+msgstr ""
+"Entrez votre adresse e-mail pour commencer le processus de réinitialisation"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:19
+msgid ""
+"\n"
+"          <p>The ORCiD you logged in with is not currently linked with\n"
+"          an account in our system. You can either register a new account, "
+"or\n"
+"          login with an existing account to link your ORCiD for future use.</"
+"p>\n"
+"        "
+msgstr ""
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:43
+#, fuzzy
+#| msgid "Regsiter for"
+msgid "Register an account"
+msgstr "S'inscrire à"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:46
+#, fuzzy
+#| msgid "Reset Password"
+msgid "Reset your password"
+msgstr "Mot de passe"
+
+#: src/themes/hourglass/templates/custom/profile.html:40
+msgid ""
+"\n"
+"                    Please note: If you update your email,\n"
+"                    You will be logged out, and you won't be\n"
+"                    able to log in again until you follow\n"
+"                    the verification link in an email\n"
+"                    sent to your new email address.\n"
+"                  "
+msgstr ""
+
+#: src/themes/material/templates/core/accounts/activate_account.html:29
 msgid ""
 "There was no inactive account with this activation code found. It is "
 "possible that your account is already active, you can check by attempting to "
 msgstr ""
 
+#: src/themes/material/templates/core/accounts/register.html:29
+#: src/themes/material/templates/core/accounts/reset_password.html:26
+msgid ""
+"For more information read our <a href=\"#\" data-target=\"passwordmodal\" "
+"class=\"modal-trigger\">password guide</a>."
+msgstr ""
+
 #: src/themes/material/templates/core/accounts/register.html:56
-#: src/themes/material/templates/core/accounts/reset_password.html:44
+#: src/themes/material/templates/core/accounts/reset_password.html:46
 msgid ""
 "We recommend selecting a long, but easy to remember password such as <i>our "
 "awesome moon base\n"
@@ -4835,7 +5215,7 @@ msgstr "S'inscrire à"
 msgid "Reset Your Password"
 msgstr "Mot de passe"
 
-#: src/themes/material/templates/core/news/index.html:39
+#: src/themes/material/templates/core/news/index.html:40
 #, fuzzy
 #| msgid "This journal currently has no news items to display"
 msgid "This journal currently has no items to display."
@@ -4876,43 +5256,39 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
+#: src/themes/material/templates/elements/journal/issue_list.html:26
+msgid "close"
+msgstr ""
+
+#: src/themes/material/templates/elements/journal/issue_list.html:30
+#, fuzzy
+#| msgid "Issue"
+msgid "View Issue"
+msgstr "Publication"
+
 #: src/themes/material/templates/elements/license_block.html:4
 #, fuzzy
 #| msgid "Author Information"
 msgid "More Information "
 msgstr "Informations de l'auteur"
 
-#: src/themes/material/templates/journal/article.html:161
-#, python-format
-msgid ""
-"\n"
-"                                                (grant %(id)s)\n"
-"                                            "
-msgstr ""
-
-#: src/themes/material/templates/journal/article.html:195
+#: src/themes/material/templates/journal/article.html:176
 msgid "Tweets"
 msgstr ""
 
-#: src/themes/material/templates/journal/article.html:336
+#: src/themes/material/templates/journal/article.html:318
 #, fuzzy
 #| msgid "Article Info"
 msgid "Article No."
 msgstr "Renseignements sur l'article"
 
-#: src/themes/material/templates/journal/article.html:348
+#: src/themes/material/templates/journal/article.html:330
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Publication"
 msgstr "Frais de publication"
 
-#: src/themes/material/templates/journal/article.html:389
-#, fuzzy
-#| msgid "Date"
-msgid "Dates"
-msgstr "la Date"
-
-#: src/themes/material/templates/journal/article.html:450
+#: src/themes/material/templates/journal/article.html:426
 #, fuzzy
 #| msgid "This article is a preprints"
 msgid "This article has been peer reviewed."
@@ -4923,16 +5299,6 @@ msgstr "Cet article est une preprints"
 #| msgid "Collections"
 msgid "View Collection"
 msgstr "Collections"
-
-#: src/themes/material/templates/journal/issues.html:35
-msgid "close"
-msgstr ""
-
-#: src/themes/material/templates/journal/issues.html:39
-#, fuzzy
-#| msgid "Issue"
-msgid "View Issue"
-msgstr "Publication"
 
 #: src/themes/material/templates/journal/new_search.html:26
 #: src/themes/material/templates/journal/search.html:28
@@ -5003,28 +5369,77 @@ msgstr "Institution"
 msgid "Start New Submission"
 msgstr "Commencer la soumission"
 
-#: src/themes/material/templates/repository/preprint.html:70
+#: src/themes/material/templates/repository/preprint.html:68
 #, fuzzy
 #| msgid "Comments to Editor"
 msgid "Add a Comment"
 msgstr "Commentaires au rédacteur"
 
-#: src/utils/forms.py:102
+#: src/utils/forms.py:107
 #, python-format
 msgid "What is %(num1)i %(operator)s %(num2)i? "
 msgstr "Qu'est-ce que %(num1)i %(operator)s %(num2)i?"
 
-#: src/utils/forms.py:103
+#: src/utils/forms.py:108
 msgid "Answer this question: "
 msgstr "Répond a cette question: "
 
-#: src/utils/transactional_emails.py:370
+#: src/utils/forms.py:153
+msgid "HTML is not allowed in this field"
+msgstr ""
+
+#: src/utils/transactional_emails.py:385
 msgid "accepted"
 msgstr ""
 
-#: src/utils/transactional_emails.py:380
+#: src/utils/transactional_emails.py:395
 msgid "declined"
 msgstr ""
+
+#~ msgid "Password 1"
+#~ msgstr "Mot de passe"
+
+#~ msgid "Password 2"
+#~ msgstr "Répéter le mot de passe"
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to create a typesetting assignment?"
+#~ msgstr ""
+#~ "Entrez votre adresse e-mail pour commencer le processus de "
+#~ "réinitialisation"
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to create a proofreading assignment?"
+#~ msgstr ""
+#~ "Entrez votre adresse e-mail pour commencer le processus de "
+#~ "réinitialisation"
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to complete the proofreading task?"
+#~ msgstr ""
+#~ "Entrez votre adresse e-mail pour commencer le processus de "
+#~ "réinitialisation"
+
+#, fuzzy
+#~| msgid "Section"
+#~ msgid "Email Options"
+#~ msgstr "Section"
+
+#, fuzzy
+#~| msgid "Submission Checklist"
+#~ msgid "Submission Complete"
+#~ msgstr "Liste de vérification de la soumission"
+
+#~ msgid "somebody"
+#~ msgstr "personne"
+
+#, fuzzy
+#~| msgid "Date"
+#~ msgid "Dates"
+#~ msgstr "la Date"
 
 #, fuzzy
 #~| msgid "Current Authors"
@@ -5129,16 +5544,16 @@ msgstr ""
 #~| "Your password should be at minimum 12 characters long. It does not need "
 #~| "to contain specific\n"
 #~| "                        characters but you should make it as long as "
-#~| "possible. For more information read our <a href=\"#\" data-open="
-#~| "\"password-modal\">password guide</a>"
+#~| "possible. For more information read our <a href=\"#\" data-"
+#~| "open=\"password-modal\">password guide</a>"
 #~ msgid ""
 #~ "Your password should be at minimum 12 characters long. It does not need "
 #~ "to\n"
 #~ "                            contain specific\n"
 #~ "                            characters but you should make it as long as "
 #~ "possible. For more information read our\n"
-#~ "                            <a href=\"#\" data-open=\"password-modal"
-#~ "\">password guide</a>"
+#~ "                            <a href=\"#\" data-open=\"password-"
+#~ "modal\">password guide</a>"
 #~ msgstr ""
 #~ "Votre mot de passe doit comporter au moins 12 caractères. Il n'a pas "
 #~ "besoin de contenir des caractères spécifiques, mais vous devriez le faire "
@@ -5175,8 +5590,8 @@ msgstr ""
 #~| "Your password should be at minimum 12 characters long. It does not need "
 #~| "to contain specific\n"
 #~| "                        characters but you should make it as long as "
-#~| "possible. For more information read our <a href=\"#\" data-open="
-#~| "\"password-modal\">password guide</a>"
+#~| "possible. For more information read our <a href=\"#\" data-"
+#~| "open=\"password-modal\">password guide</a>"
 #~ msgid ""
 #~ "Your password should be at minimum 12 characters long. It does not\n"
 #~ "                                    need to contain specific\n"
@@ -5196,8 +5611,8 @@ msgstr ""
 #~| "Your password should be at minimum 12 characters long. It does not need "
 #~| "to contain specific\n"
 #~| "                        characters but you should make it as long as "
-#~| "possible. For more information read our <a href=\"#\" data-open="
-#~| "\"password-modal\">password guide</a>"
+#~| "possible. For more information read our <a href=\"#\" data-"
+#~| "open=\"password-modal\">password guide</a>"
 #~ msgid ""
 #~ "Your password should be at minimum 12 characters long. It does not\n"
 #~ "                                    need to contain specific\n"
@@ -5228,8 +5643,8 @@ msgstr ""
 #~| msgid ""
 #~| "Your password should be at minimum 12 characters long. It does not need "
 #~| "to contain specific characters but you should make it as long as "
-#~| "possible. For more information read on <a href=\"#\" data-open="
-#~| "\"password-modal\">password guide</a>."
+#~| "possible. For more information read on <a href=\"#\" data-"
+#~| "open=\"password-modal\">password guide</a>."
 #~ msgid ""
 #~ "Your password should be at minimum 12 characters long. It does not need "
 #~ "to\n"
@@ -5247,8 +5662,8 @@ msgstr ""
 #~| msgid ""
 #~| "Your password should be at minimum 12 characters long. It does not need "
 #~| "to contain specific characters but you should make it as long as "
-#~| "possible. For more information read on <a href=\"#\" data-open="
-#~| "\"password-modal\">password guide</a>."
+#~| "possible. For more information read on <a href=\"#\" data-"
+#~| "open=\"password-modal\">password guide</a>."
 #~ msgid ""
 #~ "Your password should be at minimum 12 characters long. It does not need\n"
 #~ "                                to contain specific characters but you "
@@ -5267,15 +5682,15 @@ msgstr ""
 #~| msgid ""
 #~| "Your password should be at minimum 12 characters long. It does not need "
 #~| "to contain specific characters but you should make it as long as "
-#~| "possible. For more information read on <a href=\"#\" data-open="
-#~| "\"password-modal\">password guide</a>."
+#~| "possible. For more information read on <a href=\"#\" data-"
+#~| "open=\"password-modal\">password guide</a>."
 #~ msgid ""
 #~ "Your password should be at minimum 12 characters long. It does not need\n"
 #~ "                        to contain specific characters but you should "
 #~ "make it as long as possible. For more\n"
 #~ "                        information read on\n"
-#~ "                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-#~ "\"> password guide</a>\n"
+#~ "                        <a href=\"#passwordmodal\" class=\"modal-"
+#~ "trigger\"> password guide</a>\n"
 #~ "                        ."
 #~ msgstr ""
 #~ "Votre mot de passe doit comporter au moins 12 caractères. Il n'a pas "

--- a/src/core/locales/it/LC_MESSAGES/django.po
+++ b/src/core/locales/it/LC_MESSAGES/django.po
@@ -2,72 +2,79 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Janeway\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-12 16:34+0000\n"
+"POT-Creation-Date: 2024-12-05 10:48+0000\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: src/comms/models.py:94
+#: src/comms/models.py:119
 #, fuzzy, python-brace-format
 #| msgid "Posted by"
 msgid "Posted by {byline}"
 msgstr "Pubblicato da"
 
-#: src/comms/models.py:95
+#: src/comms/models.py:120
 #, fuzzy, python-brace-format
 #| msgid "Posted by"
 msgid "Posted by  {byline}"
 msgstr "Pubblicato da"
 
-#: src/copyediting/forms.py:16
+#: src/copyediting/forms.py:17
 msgid "Are you sure you want to create a copyediting assignment?"
 msgstr ""
 
-#: src/copyediting/forms.py:99
+#: src/copyediting/forms.py:104
 msgid "Are you sure you want to ask the author to review copyedits?"
 msgstr ""
 
-#: src/copyediting/forms.py:146
+#: src/copyediting/forms.py:151
 msgid "Are you sure you want to complete the copyedit task?"
 msgstr ""
 
-#: src/core/forms/forms.py:110
-msgid "Password 1"
-msgstr "Password 1"
-
-#: src/core/forms/forms.py:111
-msgid "Password 2"
-msgstr "Password 2"
-
-#: src/core/forms/forms.py:129
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/core/forms/forms.py:114 src/core/forms/forms.py:162
+#: src/templates/admin/core/accounts/orcid_registration.html:29
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
 #: src/themes/OLH/templates/press/core/login.html:33
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:24
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:28
 #: src/themes/clean/templates/core/login.html:34
+#: src/themes/hourglass/templates/custom/orcid-registration.html:32
 msgid "Password"
 msgstr "Password"
 
-#: src/core/forms/forms.py:130
+#: src/core/forms/forms.py:123 src/core/forms/forms.py:170
 msgid "Repeat Password"
 msgstr "Ripeti la password"
 
-#: src/core/forms/forms.py:133
+#: src/core/forms/forms.py:148 src/core/models.py:235
+#: src/templates/admin/core/accounts/orcid_registration.html:25
+#: src/templates/admin/repository/article.html:213
+#: src/templates/admin/repository/author_article.html:92
+#: src/templates/admin/repository/submit/authors.html:77
+#: src/templates/admin/submission/submit_authors.html:70
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:33
+#: src/themes/OLH/templates/press/core/login.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:25
+#: src/themes/hourglass/templates/custom/orcid-registration.html:28
+msgid "Email"
+msgstr "Email"
+
+#: src/core/forms/forms.py:179
 msgid ""
 "Check this box if you would like to receive notifications of new articles "
 "published in this journal"
 msgstr ""
 
-#: src/core/forms/forms.py:495
+#: src/core/forms/forms.py:578
 msgid "E-mail"
 msgstr "Email"
 
-#: src/core/forms/forms.py:694
+#: src/core/forms/forms.py:783
 msgid "Are you sure?"
 msgstr ""
 
-#: src/core/forms/forms.py:725
+#: src/core/forms/forms.py:814
 #, python-format
 msgid ""
 "The account belonging to %(email)s has not yet been activated, so the "
@@ -112,243 +119,233 @@ msgstr ""
 msgid "Issues and Collections"
 msgstr "Visualizza raccolta"
 
-#: src/core/janeway_global_settings.py:252
+#: src/core/janeway_global_settings.py:254
 #, fuzzy
 #| msgid "English"
 msgid "English"
 msgstr "inglese"
 
-#: src/core/janeway_global_settings.py:253
+#: src/core/janeway_global_settings.py:255
 #, fuzzy
 #| msgid "English"
 msgid "English (US)"
 msgstr "inglese"
 
-#: src/core/janeway_global_settings.py:254
+#: src/core/janeway_global_settings.py:256
 msgid "French"
 msgstr "francese"
 
-#: src/core/janeway_global_settings.py:255
+#: src/core/janeway_global_settings.py:257
 msgid "German"
 msgstr "tedesco"
 
-#: src/core/janeway_global_settings.py:256
+#: src/core/janeway_global_settings.py:258
 msgid "Dutch"
 msgstr ""
 
-#: src/core/janeway_global_settings.py:257
+#: src/core/janeway_global_settings.py:259
 msgid "Welsh"
 msgstr "Gallese"
 
-#: src/core/logic.py:810
+#: src/core/logic.py:833
 msgid "Your password must be {} characters long"
 msgstr ""
 
-#: src/core/logic.py:814
+#: src/core/logic.py:837
 msgid "An uppercase character is required"
 msgstr ""
 
-#: src/core/logic.py:817
+#: src/core/logic.py:840
 msgid "A number is required"
 msgstr ""
 
-#: src/core/models.py:69
+#: src/core/models.py:77
 msgid "Miss"
 msgstr ""
 
-#: src/core/models.py:70
+#: src/core/models.py:78
 msgid "Ms"
 msgstr ""
 
-#: src/core/models.py:71
+#: src/core/models.py:79
 #, fuzzy
 #| msgid "Metrics"
 msgid "Mrs"
 msgstr "Metrica"
 
-#: src/core/models.py:72
+#: src/core/models.py:80
 msgid "Mr"
 msgstr ""
 
-#: src/core/models.py:73
+#: src/core/models.py:81
 msgid "Mx"
 msgstr ""
 
-#: src/core/models.py:74
+#: src/core/models.py:82
 msgid "Dr"
 msgstr ""
 
-#: src/core/models.py:75
+#: src/core/models.py:83
 #, fuzzy
 #| msgid "Profile"
 msgid "Prof."
 msgstr "Profilo"
 
-#: src/core/models.py:208 src/templates/admin/repository/article.html:213
-#: src/templates/admin/repository/author_article.html:92
-#: src/templates/admin/repository/submit/authors.html:80
-#: src/templates/admin/submission/submit_authors.html:65
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:26
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:29
-#: src/themes/OLH/templates/press/core/login.html:30
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:16
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:18
-msgid "Email"
-msgstr "Email"
-
-#: src/core/models.py:209
+#: src/core/models.py:236
 msgid "Username"
 msgstr "Nome utente"
 
-#: src/core/models.py:211
+#: src/core/models.py:242
 msgid "First name"
 msgstr "Nome"
 
-#: src/core/models.py:212 src/submission/forms.py:271
+#: src/core/models.py:248 src/submission/forms.py:286
 msgid "Middle name"
 msgstr "Secondo nome"
 
-#: src/core/models.py:213 src/submission/forms.py:272
+#: src/core/models.py:254 src/submission/forms.py:287
 msgid "Last name"
 msgstr "Cognome"
 
-#: src/core/models.py:217
+#: src/core/models.py:263
 msgid "Salutation"
 msgstr "Titolo"
 
-#: src/core/models.py:222
+#: src/core/models.py:269
 msgid "Name suffix"
 msgstr ""
 
-#: src/core/models.py:224
-#: src/themes/OLH/templates/core/accounts/public_profile.html:19
-#: src/themes/clean/templates/core/accounts/public_profile.html:19
-#: src/themes/material/templates/core/accounts/public_profile.html:19
+#: src/core/models.py:274
+#: src/themes/OLH/templates/core/accounts/public_profile.html:50
+#: src/themes/clean/templates/core/accounts/public_profile.html:23
+#: src/themes/material/templates/core/accounts/public_profile.html:23
 msgid "Biography"
 msgstr "Biografia"
 
-#: src/core/models.py:225 src/submission/models.py:1943
+#: src/core/models.py:276 src/submission/models.py:2014
 msgid "ORCiD"
 msgstr "ORCID"
 
-#: src/core/models.py:226 src/submission/forms.py:275
+#: src/core/models.py:280 src/submission/forms.py:290
 msgid "Institution"
 msgstr "Istituzione"
 
-#: src/core/models.py:227 src/submission/forms.py:276
+#: src/core/models.py:286 src/submission/forms.py:291
 msgid "Department"
 msgstr "Dipartimento"
 
-#: src/core/models.py:228
+#: src/core/models.py:289
 #, fuzzy
 #| msgid "Twitter"
 msgid "Twitter Handle"
 msgstr "Twitter"
 
-#: src/core/models.py:229
+#: src/core/models.py:290
 #, fuzzy
 #| msgid "Facebook"
 msgid "Facebook Handle"
 msgstr "Facebook"
 
-#: src/core/models.py:230
+#: src/core/models.py:291
 #, fuzzy
 #| msgid "Edit Profile"
 msgid "Linkedin Profile"
 msgstr "Modifica il profilo"
 
-#: src/core/models.py:231
+#: src/core/models.py:292
 #: src/themes/OLH/templates/elements/journal/editorial_social_content.html:3
 #: src/themes/clean/templates/elements/journal/editorial_social_content.html:3
 msgid "Website"
 msgstr "Sito web"
 
-#: src/core/models.py:232
+#: src/core/models.py:293
 #, fuzzy
 #| msgid "Username"
 msgid "Github Username"
 msgstr "Nome utente"
 
-#: src/core/models.py:236
+#: src/core/models.py:297
 #, fuzzy
 #| msgid "Information"
 msgid "Confirmation Code"
 msgstr "Informazioni"
 
-#: src/core/models.py:237
+#: src/core/models.py:300
 msgid "Signature"
 msgstr ""
 
-#: src/core/models.py:243
-#: src/themes/OLH/templates/core/accounts/public_profile.html:15
-#: src/themes/clean/templates/core/accounts/public_profile.html:15
-#: src/themes/material/templates/core/accounts/public_profile.html:15
+#: src/core/models.py:307
+#: src/themes/OLH/templates/core/accounts/public_profile.html:45
+#: src/themes/clean/templates/core/accounts/public_profile.html:19
+#: src/themes/material/templates/core/accounts/public_profile.html:19
 msgid "Country"
 msgstr "Nazione"
 
-#: src/core/models.py:246
+#: src/core/models.py:314
 msgid "Preferred Timezone"
 msgstr ""
 
-#: src/core/models.py:254
+#: src/core/models.py:323
 msgid "Enable Digest"
 msgstr ""
 
-#: src/core/models.py:259
+#: src/core/models.py:328
 msgid "If enabled, your basic profile will be available to the public."
 msgstr ""
 
-#: src/core/models.py:261
+#: src/core/models.py:330
 msgid "Enable public profile"
 msgstr ""
 
-#: src/core/models.py:566 src/core/models.py:578
+#: src/core/models.py:639 src/core/models.py:651
 msgid "Expires on"
 msgstr ""
 
-#: src/core/models.py:840 src/core/models.py:1118
+#: src/core/models.py:915 src/core/models.py:1193
 #, fuzzy
 #| msgid "Article"
 msgid "Article PK"
 msgstr "Articolo"
 
-#: src/core/models.py:845 src/core/models.py:1123 src/repository/models.py:838
-#: src/templates/admin/elements/submit/file.html:24
-#: src/templates/admin/submission/submit_files.html:40
-#: src/templates/admin/submission/submit_files.html:80
-#: src/templates/admin/submission/submit_review.html:120
+#: src/core/models.py:920 src/core/models.py:1198 src/repository/models.py:848
+#: src/templates/admin/submission/submit_files.html:46
+#: src/templates/admin/submission/submit_files.html:86
+#: src/templates/admin/submission/submit_review.html:136
 msgid "Label"
 msgstr "Etichetta"
 
-#: src/core/models.py:846 src/core/models.py:1124
-#: src/templates/admin/elements/submit/file.html:31
+#: src/core/models.py:921 src/core/models.py:1199
 msgid "Description"
 msgstr "Descrizione"
 
-#: src/core/models.py:857
+#: src/core/models.py:932
 msgid "Remote URL of file"
 msgstr ""
 
-#: src/core/models.py:1150
+#: src/core/models.py:1225
 msgid "Other"
 msgstr ""
 
-#: src/core/models.py:1151
+#: src/core/models.py:1226
 msgid "Image"
 msgstr ""
 
-#: src/core/models.py:1492
+#: src/core/models.py:1594 src/templates/admin/journal/contact.html:38
+#: src/themes/OLH/templates/journal/contact.html:30
+#: src/themes/OLH/templates/press/journal/contact.html:22
+#: src/themes/clean/templates/journal/contact.html:27
+msgid "Who would you like to contact?"
+msgstr "Chi vorresti contattare?"
 
-#: src/core/models.py:1493
+#: src/core/models.py:1595
 msgid "Your contact email address"
 msgstr "Il tuo indirizzo email"
 
-#: src/core/models.py:1494
+#: src/core/models.py:1596
 msgid "Subject"
 msgstr "Argomento"
 
-#: src/core/models.py:1495
+#: src/core/models.py:1597
 msgid "Your message"
 msgstr "Il tuo messaggio"
 
@@ -369,153 +366,165 @@ msgstr ""
 "Il tipo MIME {mimetype} non è valido. I tipi validi sono: {validator."
 "mimetypes}"
 
-#: src/core/views.py:78
+#: src/core/views.py:80
 msgid "You have been banned from logging in due to failed attempts."
 msgstr ""
 
-#: src/core/views.py:122
+#: src/core/views.py:124
 msgid ""
 "Password reset process has been initiated, please check your inbox for a "
 "reset request link."
 msgstr ""
 
-#: src/core/views.py:132
+#: src/core/views.py:134
 msgid ""
 "Wrong email/password combination or your email address has not been "
 "confirmed yet."
 msgstr ""
 
-#: src/core/views.py:219
+#: src/core/views.py:226
 msgid "You have been logged out."
 msgstr ""
 
-#: src/core/views.py:236
+#: src/core/views.py:249
 msgid "If your account was found, an email has been sent to you."
 msgstr ""
 
-#: src/core/views.py:355
+#: src/core/views.py:377
 msgid ""
 "Your account has been created. Please follow the instructions in the email "
 "that has been sent to you."
 msgstr ""
 
-#: src/core/views.py:400
+#: src/core/views.py:420
 #, fuzzy
 #| msgid "Account"
 msgid "Account activated"
 msgstr "Account"
 
-#: src/core/views.py:442
+#: src/core/views.py:469
 msgid "An account with that email address already exists."
 msgstr ""
 
-#: src/core/views.py:448
+#: src/core/views.py:475
 #, fuzzy
 #| msgid "Email Address"
 msgid "Email address is not valid."
 msgstr "Indirizzo email"
 
-#: src/core/views.py:463
+#: src/core/views.py:490
 #, fuzzy
 #| msgid "Password Guide"
 msgid "Password updated."
 msgstr "Guida password"
 
-#: src/core/views.py:467
+#: src/core/views.py:494
 msgid "Passwords do not match"
 msgstr ""
 
-#: src/core/views.py:470
+#: src/core/views.py:497
 msgid "Old password is not correct."
 msgstr ""
 
-#: src/core/views.py:480
+#: src/core/views.py:507
 #, fuzzy
 #| msgid "Register for"
 msgid "Successfully subscribed to article notifications."
 msgstr "Registrati per"
 
-#: src/core/views.py:491
+#: src/core/views.py:518
 msgid "Successfully unsubscribed from article notifications."
 msgstr ""
 
-#: src/core/views.py:1943
+#: src/core/views.py:2079
 msgid ""
 "You cannot remove a section that contains articles. Remove articles from the "
 "section if you want to delete it."
 msgstr ""
+
+#: src/core/views.py:2711 src/journal/forms.py:24 src/journal/views.py:2866
+msgid "Newest"
+msgstr ""
+
+#: src/core/views.py:2712 src/journal/forms.py:25 src/journal/views.py:2867
+msgid "Oldest"
+msgstr ""
+
+#: src/core/views.py:2713
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name A-Z"
+msgstr "Cognome"
+
+#: src/core/views.py:2714
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name Z-A"
+msgstr "Cognome"
 
 #: src/discussion/models.py:27
 msgid "Max. 300 characters."
 msgstr ""
 
 #. Translators: Search order options
-#: src/journal/forms.py:20
+#: src/journal/forms.py:21
 msgid "Relevance"
 msgstr ""
 
-#: src/journal/forms.py:21 src/journal/views.py:2629
+#: src/journal/forms.py:22 src/journal/views.py:2868
 #, fuzzy
 #| msgid "Title"
 msgid "Titles A-Z"
 msgstr "Titolo"
 
-#: src/journal/forms.py:22 src/journal/views.py:2630
+#: src/journal/forms.py:23 src/journal/views.py:2869
 #, fuzzy
 #| msgid "Title"
 msgid "Titles Z-A"
 msgstr "Titolo"
 
-#: src/journal/forms.py:23 src/journal/views.py:2627
-msgid "Newest"
-msgstr ""
-
-#: src/journal/forms.py:24 src/journal/views.py:2628
-msgid "Oldest"
-msgstr ""
-
-#: src/journal/forms.py:97
+#: src/journal/forms.py:98
 #: src/themes/clean/templates/core/homepage_elements/search_bar.html:20
 #, fuzzy
 #| msgid "Search"
 msgid "Search term"
 msgstr "Ricerca"
 
-#: src/journal/forms.py:98
+#: src/journal/forms.py:99
 #, fuzzy
 #| msgid "Search preprints"
 msgid "Search Titles"
 msgstr "Cerca preprints"
 
-#: src/journal/forms.py:99
+#: src/journal/forms.py:100
 #, fuzzy
 #| msgid "Abstract"
 msgid "Search Abstract"
 msgstr "Abstract"
 
-#: src/journal/forms.py:100
+#: src/journal/forms.py:101
 #, fuzzy
 #| msgid "Search for Existing Authors"
 msgid "Search Authors"
 msgstr "Cerca gli autori esistenti"
 
-#: src/journal/forms.py:101
+#: src/journal/forms.py:102
 #, fuzzy
 #| msgid "Keywords"
 msgid "Search Keywords"
 msgstr "Parole chiave"
 
-#: src/journal/forms.py:102
+#: src/journal/forms.py:103
 msgid "Search Full Text"
 msgstr ""
 
-#: src/journal/forms.py:103
+#: src/journal/forms.py:104
 #, fuzzy
 #| msgid "Search"
 msgid "Search ORCIDs"
 msgstr "Ricerca"
 
-#: src/journal/forms.py:104 src/templates/common/elements/sorting.html:16
+#: src/journal/forms.py:105 src/templates/common/elements/sorting.html:16
 #: src/themes/clean/templates/elements/sorting.html:17
 #: src/themes/material/templates/elements/sorting.html:31
 #, fuzzy
@@ -523,174 +532,196 @@ msgstr "Ricerca"
 msgid "Sort results by"
 msgstr "Il titolo dell'articolo"
 
-#: src/journal/logic.py:212
+#: src/journal/logic.py:216
 msgid "Articles without a section cannot be added to an issue."
 msgstr ""
 "Gli articoli senza una sezione non possono essere aggiunti ad una "
 "pubblicazione."
 
-#: src/journal/models.py:80
+#: src/journal/models.py:101
 msgid ""
 "Short acronym for the journal. Used as part of the journal URLin path mode "
 "and to uniquely identify the journal"
 msgstr ""
 
-#: src/journal/models.py:98
+#: src/journal/models.py:119
 msgid ""
 "The default thumbnail for articles, not to be confused with 'Default cover "
 "image'."
 msgstr ""
 
-#: src/journal/models.py:106
+#: src/journal/models.py:127
 msgid "Replaces the press logo in the footer."
 msgstr ""
 
-#: src/journal/models.py:113
+#: src/journal/models.py:134
 msgid ""
 "The default cover image for journal issues and for the journal's listing on "
 "the press-level website."
 msgstr ""
 
-#: src/journal/models.py:121
+#: src/journal/models.py:142
 #, fuzzy
 #| msgid "The default language of articles when lang is hidden"
 msgid "The default background image for article openers and carousel items."
 msgstr "La lingua predefinita degli articoli quando la lingua è nascosta"
 
-#: src/journal/models.py:129
+#: src/journal/models.py:150
 msgid ""
 "The logo-sized image at the top of all pages, typically used for journal "
 "logos."
 msgstr ""
 
-#: src/journal/models.py:137
+#: src/journal/models.py:158
 msgid ""
 "The tiny round or square image appearing in browser tabs before the webpage "
 "title"
 msgstr ""
 
-#: src/journal/models.py:148
+#: src/journal/models.py:166
+msgid ""
+"A default image displayed on the profile and editorial team pages when the "
+"user has no set profile image."
+msgstr ""
+
+#: src/journal/models.py:183
 #, fuzzy
 #| msgid "This article has been peer reviewed."
 msgid "This field has been deprecated in v1.4.3"
 msgstr "Questo articolo è stato soggetto a peer review."
 
-#: src/journal/models.py:158
+#: src/journal/models.py:193
 msgid "When enabled, the journal is marked as not hosted in Janeway."
 msgstr ""
 
-#: src/journal/models.py:169
+#: src/journal/models.py:204
 msgid "If the journal is remote you can link to its submission page."
 msgstr ""
 
-#: src/journal/models.py:174
+#: src/journal/models.py:209
 msgid "If the journal is remote you can link to its home page."
 msgstr ""
 
-#: src/journal/models.py:178
+#: src/journal/models.py:213
 msgid "Enables a \"View PDF\" link on article pages."
 msgstr ""
 
-#: src/journal/models.py:220
+#: src/journal/models.py:255
 msgid ""
 "Whether to display article numbers. Article numbers are distinct from "
 "article ID and can be set in Edit Metadata."
 msgstr ""
 
-#: src/journal/models.py:532
+#: src/journal/models.py:600
 msgid "Please add as much detail as you can."
 msgstr ""
 
-#: src/journal/models.py:573
+#: src/journal/models.py:724
 #, fuzzy
 #| msgid "Subtitle of the article display format; Title: Subtitle"
 msgid "Autogenerated cache of the display format of an issue title"
 msgstr ""
 "Sottotitoli del formato di visualizzazione dell'articolo; Titolo: sottotitolo"
 
-#: src/journal/models.py:588
+#: src/journal/models.py:739
 msgid "Image representing the cover of a printed issue or volume"
 msgstr ""
 
-#: src/journal/models.py:594
+#: src/journal/models.py:745
 msgid "landscape hero image used in the carousel and issue page"
 msgstr ""
 
-#: src/journal/models.py:613
+#: src/journal/models.py:764
 msgid ""
 "An optional alphanumeric code (Slug) used to generate a verbose  url for "
 "this issue. e.g: 'winter-special-issue'."
 msgstr ""
 
-#: src/journal/models.py:635
+#: src/journal/models.py:786
 msgid ""
 "An ISBN is relevant for non-serial collections such as conference proceedings"
 msgstr ""
 
-#: src/journal/models.py:676
+#: src/journal/models.py:827
 #: src/themes/OLH/templates/press/press_journals.html:71
 #: src/themes/clean/templates/press/press_journals.html:42
 #: src/themes/material/templates/press/press_journals.html:46
 msgid "Current Issue"
 msgstr "Pubblicazione corrente"
 
-#: src/journal/models.py:734
+#: src/journal/models.py:885
 msgid "pages"
 msgstr ""
 
-#: src/journal/models.py:736
+#: src/journal/models.py:887
 msgid "page"
 msgstr ""
 
-#: src/journal/views.py:751
+#: src/journal/views.py:771
 msgid "No file uploaded"
 msgstr "Nessun file caricato"
 
-#: src/journal/views.py:1009
+#: src/journal/views.py:1097
 msgid "Issue not in this journal’s issue list."
 msgstr ""
 
-#: src/journal/views.py:1129
+#: src/journal/views.py:1143
+msgid ""
+"Publication date set to { article.date_published.strftime(\"%Y-%m-%d %H:%M "
+"%Z\") } "
+msgstr ""
+
+#: src/journal/views.py:1150
+#, fuzzy
+#| msgid "Publication Fees"
+msgid "Publication date unset"
+msgstr "Tariffe di pubblicazione"
+
+#: src/journal/views.py:1156
+msgid "Something went wrong when trying to save the form. "
+msgstr ""
+
+#: src/journal/views.py:1241
 msgid "Article set for publication."
 msgstr "Articolo pronto per la pubblicazione."
 
-#: src/journal/views.py:1401
+#: src/journal/views.py:1516
 msgid "You cannot move the first section up the order list"
 msgstr "Non puoi spostare la prima sezione più in su nell'ordine"
 
-#: src/journal/views.py:1433
+#: src/journal/views.py:1548
 msgid "You cannot move the last section down the order list"
 msgstr "Non puoi spostare l'ultima sezione più in giù nell'ordine"
 
-#: src/journal/views.py:1440
+#: src/journal/views.py:1555
 msgid "This page accepts post requests only."
 msgstr "Questa pagina accetta solo richieste di post."
 
-#: src/journal/views.py:1511
+#: src/journal/views.py:1626
 msgid "User is already a guest editor."
 msgstr "L'utente è già un guest editor."
 
-#: src/journal/views.py:1517
+#: src/journal/views.py:1632
 msgid "This user is not a member of this journal."
 msgstr "L'utente non è un membro di questa rivista."
 
-#: src/journal/views.py:1570
+#: src/journal/views.py:1685
 msgid "Editor removed from Issue."
 msgstr "L'editore è stato rimosso da questa pubblicazione."
 
-#: src/journal/views.py:1576
+#: src/journal/views.py:1691
 msgid "Issue Editor not found."
 msgstr "Editore della pubblicazione non trovato."
 
-#: src/journal/views.py:1582
+#: src/journal/views.py:1697
 msgid "No Issue Editor ID supplied."
 msgstr "ID dell'editore della pubblicazione non fornito."
 
-#: src/journal/views.py:1729
+#: src/journal/views.py:1851
 msgid "Uploaded file is not UTF-8 encoded"
 msgstr "Il file caricato non è codificato in UTF-8"
 
-#: src/journal/views.py:1823
+#: src/journal/views.py:1945
 msgid ""
 "You must login before you can become a reviewer. Click the button below to "
 "login."
@@ -698,7 +729,7 @@ msgstr ""
 "È necessario accedere prima di poter diventare un revisore. Fai clic sul "
 "pulsante qui sotto per accedere."
 
-#: src/journal/views.py:1828
+#: src/journal/views.py:1950
 msgid ""
 "You are not yet a reviewer for this journal. Click the button below to "
 "become a reviewer."
@@ -706,117 +737,104 @@ msgstr ""
 "Non sei ancora un revisore per questa rivista. Fai clic sul pulsante qui "
 "sotto per diventare un revisore."
 
-#: src/journal/views.py:1833
+#: src/journal/views.py:1955
 msgid "You are already a reviewer."
 msgstr "Sei già un revisore."
 
-#: src/journal/views.py:1840
+#: src/journal/views.py:1962
 msgid "You are now a reviewer"
 msgstr "Ora sei un revisore"
 
-#: src/journal/views.py:1879
+#: src/journal/views.py:2001
 msgid "Your message has been sent."
 msgstr "Il tuo messaggio è stato inviato."
 
-#: src/journal/views.py:2313 src/journal/views.py:2330
-#: src/journal/views.py:2340
+#: src/journal/views.py:2478
+#, fuzzy
+#| msgid "Production file uploaded."
+msgid "Manuscript file uploaded."
+msgstr "File per la produzione caricato."
+
+#: src/journal/views.py:2495
+#, fuzzy
+#| msgid "Proofing file uploaded."
+msgid "Data/figure file uploaded."
+msgstr "File caricato per la correzione."
+
+#: src/journal/views.py:2506
 msgid "Production file uploaded."
 msgstr "File per la produzione caricato."
 
-#: src/journal/views.py:2350
+#: src/journal/views.py:2516
+#, fuzzy
+#| msgid "No file uploaded"
+msgid "Galley file uploaded."
+msgstr "Nessun file caricato"
+
+#: src/journal/views.py:2552
 msgid "Proofing file uploaded."
 msgstr "File caricato per la correzione."
 
-#: src/journal/views.py:2603
+#: src/journal/views.py:2558
+#, fuzzy
+#| msgid "Upload files"
+msgid "Saved file."
+msgstr "Carica files"
+
+#: src/journal/views.py:2568
+#, fuzzy
+#| msgid "Supplementary Files"
+msgid "Supplementary file uploaded."
+msgstr "File supplementari"
+
+#: src/journal/views.py:2578
+#, fuzzy
+#| msgid "Proofing file uploaded."
+msgid "Typesetting source file uploaded."
+msgstr "File caricato per la correzione."
+
+#: src/journal/views.py:2849
 #, fuzzy
 #| msgid "Published"
 msgid "Published after"
 msgstr "Pubblicato"
 
-#: src/journal/views.py:2607
+#: src/journal/views.py:2853
 #, fuzzy
 #| msgid "Published on"
 msgid "Published before"
 msgstr "Pubblicato su"
 
-#: src/journal/views.py:2612
-#: src/templates/admin/submission/submit_review.html:70
+#: src/journal/views.py:2858
+#: src/templates/admin/submission/submit_review.html:75
 msgid "Section"
 msgstr "Sezione"
 
-#: src/journal/views.py:2631 src/themes/OLH/templates/repository/list.html:77
+#: src/journal/views.py:2870 src/themes/OLH/templates/repository/list.html:77
 #: src/themes/material/templates/preprints/list.html:80
 #: src/themes/material/templates/repository/list.html:61
 msgid "Author Name"
 msgstr "Nome dell'autore"
 
-#: src/journal/views.py:2632
+#: src/journal/views.py:2871
 msgid "Volume"
 msgstr ""
 
-#: src/plugins_bak/typesetting/forms.py:16
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to create a typesetting assignment?"
-msgstr ""
-"Inserisci la nuova password due volte per completare la procedura di "
-"ripristino"
-
-#: src/plugins_bak/typesetting/forms.py:90
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to create a proofreading assignment?"
-msgstr ""
-"Inserisci la nuova password due volte per completare la procedura di "
-"ripristino"
-
-#: src/plugins_bak/typesetting/forms.py:160
-msgid "Text to show as the download link on the article page"
-msgstr ""
-
-#: src/plugins_bak/typesetting/forms.py:199
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to complete the proofreading task?"
-msgstr ""
-"Inserisci la nuova password due volte per completare la procedura di "
-"ripristino"
-
-#: src/plugins_bak/typesetting/forms.py:224
-msgid "You have not proofed some galleys:"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:164
-msgid "Article has no typeset files"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:165
-msgid "One or more typeset files are missing images"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:167
-msgid "One or more typesetting or proofing tasks haven't been completed"
-msgstr ""
-
-#: src/plugins_bak/typesetting/templates/typesetting/typesetting_proofreading_assignment.html:116
-msgid "Mark Task as Complete"
-msgstr ""
-
-#: src/press/views.py:406
+#: src/press/views.py:405
 #, fuzzy
 #| msgid "Description"
 msgid "Description deleted."
 msgstr "Descrizione"
 
-#: src/press/views.py:419
+#: src/press/views.py:418
 #, fuzzy
 #| msgid "Description"
 msgid "Description saved."
 msgstr "Descrizione"
 
-#: src/repository/forms.py:44 src/submission/forms.py:75
+#: src/repository/forms.py:42 src/submission/forms.py:87
 #: src/templates/admin/core/manager/sections/section_articles.html:30
-#: src/templates/admin/submission/submit_review.html:46
+#: src/templates/admin/submission/submit_review.html:51
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:21
 #: src/themes/OLH/templates/repository/list.html:75
 #: src/themes/clean/templates/journal/articles.html:65
@@ -826,7 +844,7 @@ msgstr "Descrizione"
 msgid "Title"
 msgstr "Titolo"
 
-#: src/repository/forms.py:47 src/submission/forms.py:79
+#: src/repository/forms.py:45
 msgid "Enter your article's abstract here"
 msgstr "Inserisci l'abstract del tuo articolo qui"
 
@@ -846,64 +864,49 @@ msgid ""
 "files."
 msgstr ""
 
-#: src/repository/models.py:350
+#: src/repository/models.py:375
 msgid ""
 "If this field is to be output as a dc metadata field you can addthe type "
 "here."
 msgstr ""
 
-#: src/repository/models.py:396 src/repository/models.py:983
-#: src/repository/models.py:1140 src/submission/models.py:632
+#: src/repository/models.py:421 src/repository/models.py:993
+#: src/repository/models.py:1144 src/submission/models.py:622
 msgid "Your article title"
 msgstr "Il titolo dell'articolo"
 
-#: src/repository/models.py:403 src/submission/models.py:645
-msgid "Copying and pasting from word processors is supported."
-msgstr ""
-
-#: src/repository/models.py:949
-#: src/templates/admin/submission/submit_review.html:101
+#: src/repository/models.py:959
+#: src/templates/admin/submission/submit_review.html:117
 msgid "ORCID"
 msgstr ""
 
-#: src/repository/models.py:990 src/repository/models.py:1146
-msgid ""
-"Please avoid pasting content from word processors as they can add unwanted "
-"styling to the abstract. You can retype the abstract here or copy and paste "
-"it into notepad/a plain text editor before pasting here."
-msgstr ""
-"Evita di incollare contenuti da elaboratori di testi in quanto possono "
-"aggiungere una formattazione indesiderato all'abstract. Puoi ridigitare "
-"l'abstract qui o copiarlo e incollarlo in un blocco note/un editor di testo "
-"prima di incollarlo qui."
-
-#: src/repository/models.py:1209
+#: src/repository/models.py:1206
 msgid "Approved"
 msgstr ""
 
-#: src/repository/models.py:1211
+#: src/repository/models.py:1208
 #, fuzzy
 #| msgid "Peer Review"
 msgid "Under Review"
 msgstr "Peer review"
 
-#: src/repository/models.py:1213 src/templates/admin/review/view_review.html:64
+#: src/repository/models.py:1210 src/templates/admin/review/view_review.html:64
 #, fuzzy
 #| msgid "Disciplines"
 msgid "Declined"
 msgstr "Discipline"
 
-#: src/repository/views.py:1076
+#: src/repository/views.py:1097
 #, fuzzy
 #| msgid "Author Information"
 msgid "Author information saved"
 msgstr "Informazioni sull'autore"
 
-#: src/review/forms.py:237
+#: src/review/forms.py:242
 msgid "Are you sure you want to request revisions?"
 msgstr ""
 
-#: src/review/forms.py:281
+#: src/review/forms.py:292
 #, fuzzy
 #| msgid "Enter your new password twice to complete the reset process"
 msgid "Are you sure you want to complete the revision request?"
@@ -911,36 +914,40 @@ msgstr ""
 "Inserisci la nuova password due volte per completare la procedura di "
 "ripristino"
 
-#: src/review/forms.py:406
+#: src/review/forms.py:415
 msgid "Author can access this review"
 msgstr ""
 
-#: src/review/forms.py:407
+#: src/review/forms.py:416
 msgid "Author can access review file"
 msgstr ""
 
-#: src/review/forms.py:427
+#: src/review/forms.py:436
 #, python-format
 msgid "Author can see ‘%(name)s’"
 msgstr ""
 
-#: src/review/models.py:195
+#: src/review/models.py:198
 msgid "Anonymity"
 msgstr ""
 
-#: src/review/models.py:331
+#: src/review/models.py:334
 msgid "available for the author to access"
 msgstr ""
 
-#: src/review/models.py:332
+#: src/review/models.py:335
 msgid "not available for the author to access"
 msgstr ""
 
-#: src/review/views.py:1605
+#: src/review/views.py:1664
 #, fuzzy
 #| msgid "This article has been peer reviewed."
 msgid "This article has already been accepted or declined."
 msgstr "Questo articolo è stato soggetto a peer review."
+
+#: src/security/templatetags/securitytags.py:102
+msgid "[Anonymised data]"
+msgstr ""
 
 #: src/submission/decorators.py:22
 msgid "This page can only be accessed on Journals."
@@ -950,104 +957,108 @@ msgstr "Questa pagina è accessibile solo tramite Riviste."
 msgid "Submission is disabled for this journal."
 msgstr "L'invio di contributi non è consentito per questa rivista."
 
-#: src/submission/forms.py:76
-#: src/templates/admin/submission/submit_review.html:48
+#: src/submission/forms.py:88
+#: src/templates/admin/submission/submit_review.html:53
 msgid "Subtitle"
 msgstr "Sottotitolo"
 
-#: src/submission/forms.py:274
+#: src/submission/forms.py:289
 msgid "Enter biography here"
 msgstr ""
 
-#: src/submission/forms.py:277
+#: src/submission/forms.py:292
 #, fuzzy
 #| msgid "Twitter"
 msgid "Twitter handle"
 msgstr "Twitter"
 
-#: src/submission/forms.py:278
+#: src/submission/forms.py:293
 #, fuzzy
 #| msgid "Edit Profile"
 msgid "LinkedIn profile"
 msgstr "Modifica il profilo"
 
-#: src/submission/forms.py:279
+#: src/submission/forms.py:294
 msgid "ImpactStory profile"
 msgstr ""
 
-#: src/submission/forms.py:280
+#: src/submission/forms.py:295
 msgid "ORCID ID"
 msgstr ""
 
-#: src/submission/forms.py:281
+#: src/submission/forms.py:296
 #, fuzzy
 #| msgid "Email Address"
 msgid "Email address"
 msgstr "Indirizzo email"
 
-#: src/submission/forms.py:338
+#: src/submission/forms.py:352
 #, python-format
 msgid "Currently linked to %s, leave blank to use this address"
 msgstr ""
 
-#: src/submission/forms.py:343
+#: src/submission/forms.py:357
 #, python-format
 msgid "If left blank, the account ORCiD will be used (%s)"
 msgstr ""
 
-#: src/submission/logic.py:98
+#: src/submission/logic.py:99
 msgid "You must upload a file that is either a Doc, Docx, RTF or ODT."
 msgstr ""
 
-#: src/submission/models.py:639
+#: src/submission/models.py:347
+msgid "Additional information regarding this funding entry"
+msgstr ""
+
+#: src/submission/models.py:629
 msgid "Do not use--deprecated in version 1.4.1 and later."
 msgstr ""
 
-#: src/submission/models.py:654
+#: src/submission/models.py:644
 msgid "The primary language of the article"
 msgstr "La lingua principale dell'articolo"
 
-#: src/submission/models.py:715
+#: src/submission/models.py:719
 msgid "Custom page range. e.g.: 'I-VII' or 1-3,4-8"
 msgstr ""
 
-#: src/submission/models.py:738
+#: src/submission/models.py:742
 msgid "Add any comments you'd like the editor to consider here."
 msgstr ""
 
-#: src/submission/models.py:761
+#: src/submission/models.py:765
 msgid ""
 "Custom 'how to cite' text. To be used only if the block generated by Janeway "
 "is not suitable."
 msgstr ""
 
-#: src/submission/models.py:767 src/submission/models.py:774
+#: src/submission/models.py:771 src/submission/models.py:778
 msgid ""
 "Name of the publisher who published this article Only relevant to migrated "
 "articles from a different publisher"
 msgstr ""
 
-#: src/submission/models.py:780
+#: src/submission/models.py:784
 msgid ""
 "Original ISSN of this article's journal when published Only relevant for "
 "back content published under a different title"
 msgstr ""
 
-#: src/submission/models.py:1898
+#: src/submission/models.py:1948
 msgid "Optional name prefix (e.g: Prof or Dr)"
 msgstr ""
 
-#: src/submission/models.py:1903
+#: src/submission/models.py:1954
 msgid "Optional name suffix (e.g.: Jr or III)"
 msgstr ""
 
-#: src/submission/models.py:1914
+#: src/submission/models.py:1985
 #, fuzzy
 #| msgid "Biography"
 msgid "Frozen Biography"
 msgstr "Biografia"
 
-#: src/submission/models.py:1915
+#: src/submission/models.py:1986
 msgid ""
 "The author's biography at the time they published the linked article. For "
 "this article only, it overrides any main biography attached to the author's "
@@ -1055,106 +1066,106 @@ msgid ""
 "account will be populated instead."
 msgstr ""
 
-#: src/submission/models.py:1939
+#: src/submission/models.py:2009
 #, fuzzy
 #| msgid "Author Name"
 msgid "Author Email"
 msgstr "Nome dell'autore"
 
-#: src/submission/models.py:1944
+#: src/submission/models.py:2015
 msgid ""
 "ORCiD to be displayed when no account is associated with this author. It "
 "should be introduced in code format (e.g: 0000-0000-0000-000X)"
 msgstr ""
 
-#: src/submission/models.py:1951
+#: src/submission/models.py:2022
 msgid ""
 "If checked, this authors email address link will be displayed on the article "
 "page."
 msgstr ""
 
-#: src/submission/models.py:2311
-#: src/templates/admin/submission/submit_files.html:69
+#: src/submission/models.py:2387
+#: src/templates/admin/submission/submit_files.html:75
 msgid "Figures and Data Files"
 msgstr "Figure e file di dati"
 
-#: src/submission/models.py:2318
+#: src/submission/models.py:2394
 msgid "The default license applied when no option is presented"
 msgstr ""
 "La licenza predefinita applicata quando non viene presentata alcuna opzione"
 
-#: src/submission/models.py:2326
+#: src/submission/models.py:2402
 msgid "The default language of articles when lang is hidden"
 msgstr "La lingua predefinita degli articoli quando la lingua è nascosta"
 
-#: src/submission/models.py:2332
+#: src/submission/models.py:2408
 msgid "The default section of articles when no option is presented"
 msgstr ""
 "La sezione predefinita degli articoli quando non viene selezionata alcuna "
 "opzione"
 
-#: src/submission/views.py:260 src/submission/views.py:295
-#: src/submission/views.py:320
+#: src/submission/views.py:284 src/submission/views.py:319
+#: src/submission/views.py:344
 #, python-brace-format
 msgid "{author_name} added to the article."
 msgstr "{author_name} aggiunto all'articolo."
 
-#: src/submission/views.py:288
+#: src/submission/views.py:312
 msgid "Errors found in the new author form"
 msgstr "Errori trovati nel modulo per il nuovo autore"
 
-#: src/submission/views.py:309
+#: src/submission/views.py:333
 msgid "An empty search is not allowed."
 msgstr "Ricerca vuota non consentita."
 
-#: src/submission/views.py:327
+#: src/submission/views.py:351
 msgid "No author found with those details."
 msgstr "Nessun autore trovato con quei dettagli."
 
-#: src/submission/views.py:337
+#: src/submission/views.py:361
 msgid "You must select a main author."
 msgstr "Devi selezionare un autore principale."
 
-#: src/submission/views.py:447
+#: src/submission/views.py:569
 msgid "File deleted"
 msgstr "File eliminato"
 
-#: src/submission/views.py:501
+#: src/submission/views.py:624
 msgid "You must upload a manuscript file."
 msgstr ""
 
-#: src/submission/views.py:564
+#: src/submission/views.py:692
 #, python-brace-format
 msgid "Article {title} submitted"
 msgstr "L'articolo {title} è stato inviato"
 
-#: src/submission/views.py:661
+#: src/submission/views.py:791
 msgid "Metadata updated."
 msgstr "Metadati aggiornati."
 
-#: src/submission/views.py:673
+#: src/submission/views.py:803
 msgid "Primary author set."
 msgstr ""
 
-#: src/submission/views.py:690
+#: src/submission/views.py:820
 #, python-brace-format
 msgid "Author {author_name} updated."
 msgstr "Autore {author_name} aggiornato."
 
-#: src/submission/views.py:708
+#: src/submission/views.py:838
 msgid "Frozen Author deleted."
 msgstr "Autore Bloccato eliminato."
 
-#: src/submission/views.py:823
+#: src/submission/views.py:953
 msgid "License saved."
 msgstr "Licenza salvata."
 
-#: src/submission/views.py:868
+#: src/submission/views.py:998
 #, python-brace-format
 msgid "License {license_name} deleted."
 msgstr "Licenza {license_name} eliminata."
 
-#: src/submission/views.py:904
+#: src/submission/views.py:1034
 msgid "Configuration updated."
 msgstr "Configurazione aggiornata."
 
@@ -1187,6 +1198,439 @@ msgstr ""
 #: src/templates/admin/copyediting/author_review.html:92
 msgid "Complete Copyedit Task"
 msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:5
+#: src/templates/admin/core/accounts/activate_account.html:10
+#: src/templates/admin/core/accounts/activate_account.html:15
+#: src/templates/admin/core/accounts/activate_account.html:29
+#: src/themes/OLH/templates/core/accounts/activate_account.html:9
+#: src/themes/OLH/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:30
+#: src/themes/clean/templates/core/accounts/activate_account.html:9
+#: src/themes/clean/templates/core/accounts/activate_account.html:17
+#: src/themes/clean/templates/core/accounts/activate_account.html:21
+#: src/themes/hourglass/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:18
+#: src/themes/material/templates/core/accounts/activate_account.html:23
+msgid "Activate Account"
+msgstr "Attiva l'account"
+
+#: src/templates/admin/core/accounts/activate_account.html:17
+#, fuzzy
+#| msgid "Account"
+msgid "No account to activate"
+msgstr "Account"
+
+#: src/templates/admin/core/accounts/activate_account.html:24
+#, fuzzy
+#| msgid ""
+#| "You can complete the activation process by clicking the button below."
+msgid ""
+"\n"
+"      You can complete the activation process by clicking the button\n"
+"      below.\n"
+"    "
+msgstr ""
+"Puoi completare il processo di attivazione cliccando il tasto di sotto."
+
+#: src/templates/admin/core/accounts/activate_account.html:32
+msgid ""
+"\n"
+"      Sorry, we could not find an account to activate, or your account is "
+"active\n"
+"      already. You can check if it is active by attempting to log in.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:38
+#: src/templates/admin/core/accounts/login.html:5
+#: src/templates/admin/core/accounts/login.html:13
+#: src/templates/admin/core/accounts/orcid_registration.html:38
+#: src/themes/OLH/templates/core/login.html:43
+#: src/themes/clean/templates/core/login.html:40
+msgid "Log in"
+msgstr "Accedi"
+
+#: src/templates/admin/core/accounts/edit_profile.html:9
+#: src/templates/admin/core/accounts/edit_profile.html:17
+#: src/themes/OLH/templates/core/accounts/edit_profile.html:8
+#: src/themes/clean/templates/core/accounts/edit_profile.html:9
+#: src/themes/hourglass/templates/core/accounts/edit_profile.html:11
+#: src/themes/material/templates/core/accounts/edit_profile.html:8
+msgid "Edit Profile"
+msgstr "Modifica il profilo"
+
+#: src/templates/admin/core/accounts/edit_profile.html:26
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
+msgid "Change Your Email Address"
+msgstr "Cambia il tuo indirizzo email"
+
+#: src/templates/admin/core/accounts/edit_profile.html:28
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                <p>If you want to change your email address you may do so "
+#| "below, however, you will be logged out and your\n"
+#| "                account will be marked as inactive until you follow the "
+#| "instructions in the verfication email. <strong>Note: </strong>\n"
+#| "                Changing your email address will also change your "
+#| "username as these are one and the same.</p>\n"
+#| "                "
+msgid ""
+"\n"
+"          <p>If you want to change your email address you may do so below,\n"
+"          however, you will be logged out and your\n"
+"          account will be marked as inactive until you follow the\n"
+"          instructions in the verification email. <strong>Note: </strong>\n"
+"          Changing your email address will also change your username as "
+"these\n"
+"          are one and the same.</p>\n"
+"        "
+msgstr ""
+"\n"
+"                <p> Se vuoi cambiare il tuo indirizzo e-mail puoi farlo "
+"sotto, tuttavia, sarai disconnesso e il tuo\n"
+"                l'account verrà contrassegnato come inattivo finché non "
+"seguirai le istruzioni nell'e-mail di verifica. <strong> Nota: </ strong>\n"
+"                Cambiando il tuo indirizzo email cambierai anche il tuo nome "
+"utente in quanto questi corrispondono. </ P>\n"
+"                "
+
+#: src/templates/admin/core/accounts/edit_profile.html:36
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
+#, fuzzy
+#| msgid "Email Address"
+msgid "Current Email Address"
+msgstr "Indirizzo email"
+
+#: src/templates/admin/core/accounts/edit_profile.html:43
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
+#, fuzzy
+#| msgid "Email Address"
+msgid "New Email Address"
+msgstr "Indirizzo email"
+
+#: src/templates/admin/core/accounts/edit_profile.html:50
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
+msgid "Update Email Address"
+msgstr "Aggiorna l'indirizzo email"
+
+#: src/templates/admin/core/accounts/edit_profile.html:58
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
+#, fuzzy
+#| msgid "Register for"
+msgid "Register for Article Notifications"
+msgstr "Registrati per"
+
+#: src/templates/admin/core/accounts/edit_profile.html:61
+msgid ""
+"\n"
+"              Use the button below to register to receive notifications of "
+"new articles\n"
+"              published in this journal.\n"
+"            "
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:68
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
+msgid "Unsubscribe from Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:72
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
+msgid "Subscribe to Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:80
+#: src/templates/admin/core/accounts/edit_profile.html:115
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
+msgid "Update Password"
+msgstr "Aggiorna la password"
+
+#: src/templates/admin/core/accounts/edit_profile.html:82
+#, fuzzy
+#| msgid ""
+#| "You can update your password by entering your existing password plus your "
+#| "new password."
+msgid ""
+"\n"
+"          You can update your password by entering your existing\n"
+"          password plus your new password.\n"
+"        "
+msgstr ""
+"Puoi aggiornare la password inserendo la password esistente e la nuova "
+"password."
+
+#: src/templates/admin/core/accounts/edit_profile.html:91
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
+msgid "Current Password"
+msgstr "Password attuale"
+
+#: src/templates/admin/core/accounts/edit_profile.html:98
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
+msgid "New Password"
+msgstr "Nuova password"
+
+#: src/templates/admin/core/accounts/edit_profile.html:105
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
+msgid "Enter Password Again"
+msgstr "Inserisci di nuovo la password"
+
+#: src/templates/admin/core/accounts/edit_profile.html:122
+#, fuzzy
+#| msgid "Profile Image"
+msgid "Profile Details"
+msgstr "Foto profilo"
+
+#: src/templates/admin/core/accounts/edit_profile.html:132
+#: src/templates/admin/core/accounts/reset_password.html:31
+#: src/templates/admin/press/edit_press_journal_description.html:24
+#: src/templates/admin/review/view_review.html:168
+#: src/templates/admin/review/view_review.html:189
+msgid "Save"
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:5
+#: src/templates/admin/core/accounts/get_reset_token.html:10
+#: src/templates/admin/core/accounts/get_reset_token.html:14
+#, fuzzy
+#| msgid "Reset Password"
+msgid "Reset password"
+msgstr "Resetta la password"
+
+#: src/templates/admin/core/accounts/get_reset_token.html:20
+msgid ""
+"\n"
+"      Enter your email address and then follow the link sent to you by "
+"email.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:27
+#, fuzzy
+#| msgid "Request Token"
+msgid "Request link"
+msgstr "Richiedi un token"
+
+#: src/templates/admin/core/accounts/login.html:24
+#: src/themes/OLH/templates/core/login.html:28
+#: src/themes/clean/templates/core/login.html:16
+#: src/themes/material/templates/core/login.html:18
+msgid "Log in with ORCiD"
+msgstr "Accedi con ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:33
+#, fuzzy
+#| msgid "Login with ORCiD"
+msgid "Log in with"
+msgstr "Accedi con ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:45
+#: src/themes/OLH/templates/core/login.html:27
+#: src/themes/OLH/templates/press/core/login.html:25
+#: src/themes/clean/templates/core/login.html:14
+msgid "Log in with your account"
+msgstr "Accedi con il tuo account"
+
+#: src/templates/admin/core/accounts/login.html:50
+#: src/templates/admin/core/accounts/orcid_registration.html:43
+#: src/themes/OLH/templates/core/login.html:44
+#: src/themes/clean/templates/core/login.html:44
+msgid "Forgotten your password?"
+msgstr "Hai dimenticato la password?"
+
+#: src/templates/admin/core/accounts/login.html:55
+#: src/templates/admin/core/accounts/orcid_registration.html:48
+#: src/themes/OLH/templates/core/login.html:45
+#: src/themes/clean/templates/core/login.html:48
+msgid "Register a new account"
+msgstr "Crea un nuovo account"
+
+#: src/templates/admin/core/accounts/orcid_registration.html:5
+#: src/templates/admin/core/accounts/orcid_registration.html:10
+#: src/templates/admin/core/accounts/orcid_registration.html:14
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:9
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:23
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:8
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:13
+msgid "Unregistered ORCiD"
+msgstr "ORCiD non registrato"
+
+#: src/templates/admin/core/accounts/orcid_registration.html:19
+#, fuzzy
+#| msgid ""
+#| "The ORCiD you logged in with is not currently linked with an account in "
+#| "our system. You can either register a new account, or login with an "
+#| "existing account to link your ORCiD for future use."
+msgid ""
+"\n"
+"    The ORCiD you logged in with is not currently linked with an\n"
+"    account in our system. You can either register a new account, or login "
+"with\n"
+"    an existing account to link your ORCiD for future use.\n"
+"  "
+msgstr ""
+"L'ORCiD con cui hai fatto il log in non è al momento connesso con un account "
+"sul nostro sistema. Puoi creare un nuovo account, o fare il log in con un "
+"account già esistente a cui connettere il tuo ORCiD per uso futuro."
+
+#: src/templates/admin/core/accounts/password_guide.html:11
+#: src/themes/OLH/templates/core/accounts/register.html:110
+#: src/themes/OLH/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/register.html:54
+#: src/themes/clean/templates/core/accounts/reset_password.html:47
+#: src/themes/material/templates/core/accounts/register.html:53
+#: src/themes/material/templates/core/accounts/reset_password.html:43
+msgid "Password Guide"
+msgstr "Guida password"
+
+#: src/templates/admin/core/accounts/password_guide.html:15
+#, fuzzy
+#| msgid "When it comes to passwords, length is better than complexity."
+msgid ""
+"\n"
+"        When it comes to passwords, length is better than complexity.\n"
+"      "
+msgstr ""
+"Quando si tratta di password, la lunghezza è preferibile alla complessità."
+
+#: src/templates/admin/core/accounts/password_guide.html:18
+#, fuzzy
+#| msgid ""
+#| "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
+#| "secure than a long and uncomplicated password (our awesome moon base "
+#| "rocks)."
+msgid ""
+"\n"
+"        Its a common myth that a short and complex password\n"
+"        (Jfjfy&65^87) is more secure than a long and uncomplicated password\n"
+"        (our awesome moon base rocks).\n"
+"      "
+msgstr ""
+"È un mito comune che una password breve e complessa (Jfjfy e 65 ^ 87) sia "
+"più sicura di una password lunga e semplice (le nostre fantastiche rocce "
+"dalla base lunare)."
+
+#: src/templates/admin/core/accounts/password_guide.html:23
+#, fuzzy
+#| msgid ""
+#| "We recommend selecting a long, but easy to remember password such as our "
+#| "awesome moon base rocks which would take an estimated septillion years to "
+#| "crack as opposed to a complex one like Jfjfy&65^87 which would take just "
+#| "over 600 years on a standard computer."
+msgid ""
+"\n"
+"        We recommend selecting a long, but easy to remember\n"
+"        password such as our awesome moon base rocks which would take an\n"
+"        estimated septillion years to crack as opposed to a complex one "
+"like\n"
+"        Jfjfy&65^87 which would take just over 600 years on a standard\n"
+"        computer.\n"
+"      "
+msgstr ""
+"Ti consigliamo di selezionare una password lunga ma facile da ricordare come "
+"\"le nostre fantastiche rocce dalla base lunare\", che richiederebbe circa "
+"un settilione di anni per essere decifrata, nvece di una complessa come "
+"\"Jfjfy&65^87\" che richiederebbe poco più di 600 anni su un computer "
+"standard."
+
+#: src/templates/admin/core/accounts/register.html:5
+#: src/templates/admin/core/accounts/register.html:10
+#: src/templates/admin/core/accounts/register.html:14
+#, fuzzy
+#| msgid "Register for"
+msgid "Register for an account"
+msgstr "Registrati per"
+
+#: src/templates/admin/core/accounts/register.html:39
+#: src/templates/admin/core/accounts/reset_password.html:19
+#: src/themes/OLH/templates/core/accounts/register.html:31
+#: src/themes/OLH/templates/core/accounts/reset_password.html:31
+#: src/themes/clean/templates/core/accounts/register.html:22
+#: src/themes/clean/templates/core/accounts/reset_password.html:21
+#: src/themes/material/templates/core/accounts/register.html:24
+#: src/themes/material/templates/core/accounts/reset_password.html:21
+#, fuzzy
+#| msgid "Password Guide"
+msgid "Password Rules"
+msgstr "Guida password"
+
+#: src/templates/admin/core/accounts/register.html:43
+#: src/templates/admin/core/accounts/reset_password.html:23
+msgid ""
+"\n"
+"    For more information read our <a href=\"#\"\n"
+"    data-open=\"password-modal\">password guide</a>.\n"
+"  "
+msgstr ""
+
+#: src/templates/admin/core/accounts/register.html:55
+#: src/themes/OLH/templates/core/accounts/register.html:91
+#: src/themes/clean/templates/core/accounts/register.html:31
+#: src/themes/hourglass/templates/custom/register.html:24
+#: src/themes/material/templates/core/accounts/register.html:37
+msgid "By registering an account you agree to our"
+msgstr "Registrando un account accetti il ​​nostro"
+
+#: src/templates/admin/core/accounts/register.html:63
+#: src/templates/admin/journal/submissions.html:35
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:52
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:54
+#: src/themes/OLH/templates/core/accounts/register.html:9
+#: src/themes/OLH/templates/core/accounts/register.html:100
+#: src/themes/OLH/templates/core/base.html:142
+#: src/themes/OLH/templates/core/nav.html:76
+#: src/themes/OLH/templates/journal/submissions.html:30
+#: src/themes/OLH/templates/press/nav.html:58
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:45
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:47
+#: src/themes/clean/templates/core/accounts/register.html:9
+#: src/themes/clean/templates/core/accounts/register.html:39
+#: src/themes/clean/templates/core/nav.html:104
+#: src/themes/clean/templates/journal/submissions.html:17
+#: src/themes/clean/templates/press/nav.html:79
+#: src/themes/hourglass/templates/core/accounts/register.html:11
+#: src/themes/material/templates/core/accounts/register.html:10
+#: src/themes/material/templates/core/accounts/register.html:44
+#: src/themes/material/templates/core/nav.html:79
+#: src/themes/material/templates/core/nav.html:134
+#: src/themes/material/templates/journal/submissions.html:33
+#: src/themes/material/templates/press/nav.html:67
+#: src/themes/material/templates/press/nav.html:115
+#: src/themes/material/templates/repository/nav.html:60
+msgid "Register"
+msgstr "Iscrizione"
+
+#: src/templates/admin/core/accounts/reset_password.html:5
+#: src/templates/admin/core/accounts/reset_password.html:10
+#: src/templates/admin/core/accounts/reset_password.html:14
+#, fuzzy
+#| msgid "Enter New Password"
+msgid "Enter your new password"
+msgstr "Inserisci la nuova password"
 
 #: src/templates/admin/core/manager/sections/manage_section.html:15
 #: src/templates/admin/core/manager/sections/manage_section.html:22
@@ -1327,6 +1771,30 @@ msgid ""
 "the section if you want to delete it."
 msgstr ""
 
+#: src/templates/admin/core/manager/users/list.html:16
+#, fuzzy
+#| msgid "Journals"
+msgid "Journal Users"
+msgstr "Riviste"
+
+#: src/templates/admin/core/manager/users/list.html:18
+#, fuzzy
+#| msgid "All Preprints"
+msgid "All Users"
+msgstr "Tutti i preprint"
+
+#: src/templates/admin/core/manager/users/list.html:40
+#, fuzzy
+#| msgid "Username"
+msgid "Users"
+msgstr "Nome utente"
+
+#: src/templates/admin/core/manager/users/list.html:70
+#, fuzzy
+#| msgid "No articles to display."
+msgid "No accounts to display."
+msgstr "Nessun articolo da mostrare."
+
 #: src/templates/admin/core/request_submission_access.html:14
 msgid "requires that you request permission to make a submission."
 msgstr ""
@@ -1342,44 +1810,64 @@ msgid "You have an active access request that was submitted on: "
 msgstr ""
 
 #: src/templates/admin/elements/accounts/user_form.html:4
-#: src/themes/OLH/templates/elements/accounts/user_form.html:5
-#: src/themes/clean/templates/elements/accounts/user_form.html:5
-#: src/themes/material/templates/elements/accounts/user_form.html:6
-msgid "Core Data"
-msgstr "Dati principali"
+#: src/templates/admin/repository/article.html:212
+#: src/templates/admin/repository/author_article.html:91
+#: src/templates/admin/repository/submit/authors.html:76
+#: src/templates/admin/submission/submit_authors.html:69
+#: src/templates/admin/submission/submit_funding.html:72
+#: src/templates/common/elements/funder_info_for_readers.html:4
+msgid "Name"
+msgstr "Nome"
 
-#: src/templates/admin/elements/accounts/user_form.html:61
+#: src/templates/admin/elements/accounts/user_form.html:13
+#, fuzzy
+#| msgid "Affiliation"
+msgid "Affiliations"
+msgstr "Affiliazione"
+
+#: src/templates/admin/elements/accounts/user_form.html:20
+#: src/themes/OLH/templates/elements/accounts/user_form.html:41
+#: src/themes/clean/templates/elements/accounts/user_form.html:38
+#: src/themes/material/templates/elements/accounts/user_form.html:39
+msgid "Social Media and Accounts"
+msgstr "Social media e account"
+
+#: src/templates/admin/elements/accounts/user_form.html:30
 #: src/themes/OLH/templates/elements/accounts/user_form.html:65
 #: src/themes/clean/templates/elements/accounts/user_form.html:62
 #: src/themes/material/templates/elements/accounts/user_form.html:63
 msgid "Biography and Signature"
 msgstr "Biografia e firma"
 
-#: src/templates/admin/elements/accounts/user_form.html:70
+#: src/templates/admin/elements/accounts/user_form.html:40
+#: src/templates/admin/elements/accounts/user_form.html:43
 #: src/themes/OLH/templates/elements/accounts/user_form.html:74
 #: src/themes/clean/templates/elements/accounts/user_form.html:71
 #: src/themes/material/templates/elements/accounts/user_form.html:72
 msgid "Review Interests"
 msgstr "Revisiona i tuoi interessi"
 
-#: src/templates/admin/elements/accounts/user_form.html:71
+#: src/templates/admin/elements/accounts/user_form.html:50
 #: src/themes/OLH/templates/elements/accounts/user_form.html:75
 #: src/themes/clean/templates/elements/accounts/user_form.html:72
 #: src/themes/material/templates/elements/accounts/user_form.html:73
 msgid "Hit Enter to add a new interest"
 msgstr "Premi Invio per aggiungere un nuovo interesse"
 
-#: src/templates/admin/elements/accounts/user_form.html:75
+#: src/templates/admin/elements/accounts/user_form.html:53
 #: src/themes/OLH/templates/elements/accounts/user_form.html:79
 #: src/themes/clean/templates/elements/accounts/user_form.html:76
 #: src/themes/material/templates/elements/accounts/user_form.html:77
 msgid "Profile Image"
 msgstr "Foto profilo"
 
-#: src/templates/admin/elements/accounts/user_form.html:91
-#, fuzzy
-#| msgid "Options"
-msgid "Email Options"
+#: src/templates/admin/elements/accounts/user_form.html:69
+#: src/themes/OLH/templates/elements/accounts/user_form.html:95
+#: src/themes/OLH/templates/journal/article.html:107
+#: src/themes/OLH/templates/journal/article.html:108
+#: src/themes/clean/templates/elements/accounts/user_form.html:92
+#: src/themes/material/templates/elements/accounts/user_form.html:93
+msgid "Options"
 msgstr "Opzioni"
 
 #: src/templates/admin/elements/confirm_modal.html:7
@@ -1403,7 +1891,7 @@ msgstr ""
 msgid "No, go back"
 msgstr ""
 
-#: src/templates/admin/elements/forms/field.html:7
+#: src/templates/admin/elements/forms/field.html:13
 msgid "translatable"
 msgstr ""
 
@@ -1420,6 +1908,10 @@ msgstr ""
 msgid ""
 "If you don't want to display metrics you can disable them all, or you can "
 "disable the display of citation metrics below"
+msgstr ""
+
+#: src/templates/admin/elements/forms/group_article.html:37
+msgid "Enable the display of the dates an article was submitted and accepted."
 msgstr ""
 
 #: src/templates/admin/elements/forms/group_journal.html:32
@@ -1454,7 +1946,7 @@ msgstr "Esportare"
 msgid "How should editors and staff members get help with Janeway?"
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_journal_images.html:10
+#: src/templates/admin/elements/forms/group_journal_images.html:11
 msgid ""
 "For details about where each image appears, see the Janeway documentation: "
 msgstr ""
@@ -1473,15 +1965,15 @@ msgstr ""
 msgid "Review Form manager"
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_review.html:29
+#: src/templates/admin/elements/forms/group_review.html:28
 msgid "Settings here determine the review form experience."
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_review.html:41
+#: src/templates/admin/elements/forms/group_review.html:40
 msgid "Settings here determine the review experience for editors."
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_review.html:49
+#: src/templates/admin/elements/forms/group_review.html:48
 msgid "Settings here determine the review experience for authors."
 msgstr ""
 
@@ -1495,15 +1987,31 @@ msgid ""
 "Agreement that authors accept."
 msgstr ""
 
-#: src/templates/admin/elements/fundref/fundref.html:24
+#: src/templates/admin/elements/forms/messages_in_callout.html:11
+msgid "Problems processing the form"
+msgstr ""
+
+#: src/templates/admin/elements/fundref/fundref.html:22
 msgid "Funder"
 msgstr "Finanziatore"
 
-#: src/templates/admin/elements/fundref/fundref.html:61
-#: src/templates/admin/elements/fundref/fundref.html:82
-#: src/templates/admin/elements/fundref/fundref.html:166
-#: src/templates/admin/submission/submit_funding.html:85
-#: src/templates/admin/submission/submit_funding.html:108
+#: src/templates/admin/elements/fundref/fundref.html:23
+#: src/templates/admin/submission/submit_funding.html:73
+#: src/templates/common/elements/funder_info_for_readers.html:5
+#, fuzzy
+#| msgid "Funder DOI"
+msgid "FundRef ID"
+msgstr "DOI del finanziatore"
+
+#: src/templates/admin/elements/fundref/fundref.html:24
+#, fuzzy
+#| msgid "Add funder"
+msgid "Add Funder"
+msgstr "Aggiungi finanziatore"
+
+#: src/templates/admin/elements/fundref/fundref.html:39
+#: src/templates/admin/submission/submit_funding.html:121
+#: src/templates/admin/submission/submit_funding.html:128
 msgid "Add funder"
 msgstr "Aggiungi finanziatore"
 
@@ -1523,6 +2031,34 @@ msgstr ""
 #| msgid "Your article title"
 msgid "Sort Articles"
 msgstr "Il titolo dell'articolo"
+
+#: src/templates/admin/elements/list_filters.html:7
+#, fuzzy
+#| msgid "Sort and Filter"
+msgid "Search and filter"
+msgstr "Ordina e filtra"
+
+#: src/templates/admin/elements/list_filters.html:28
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
+msgid "Apply"
+msgstr ""
+
+#: src/templates/admin/elements/list_filters.html:32
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:10
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:11
+#: src/themes/material/templates/elements/journal/article_list_filters.html:15
+#, fuzzy
+#| msgid "Clear Filters"
+msgid "Clear all"
+msgstr "Rimuovi filtri"
+
+#: src/templates/admin/elements/metadata.html:143
+#: src/templates/admin/submission/edit/metadata.html:244
+#: src/templates/admin/submission/submit_funding.html:75
+#: src/templates/common/elements/funder_info_for_readers.html:7
+msgid "Funding Statement"
+msgstr ""
 
 #: src/templates/admin/elements/move_to_next_modal.html:7
 msgid "Workflow Info"
@@ -1559,7 +2095,7 @@ msgid "Save Publisher Note"
 msgstr "Salva il commento editoriale"
 
 #: src/templates/admin/elements/repository/metadata_form.html:39
-#: src/templates/admin/repository/submit/start.html:73 src/utils/forms.py:55
+#: src/templates/admin/repository/submit/start.html:71 src/utils/forms.py:60
 msgid "Hit Enter to add a new keyword."
 msgstr "Premi Invio per aggiungere una nuova parola chiave."
 
@@ -1569,10 +2105,10 @@ msgid "Additional Fields"
 msgstr "Campi aggiuntivi"
 
 #: src/templates/admin/elements/submit/author.html:8
-#: src/templates/admin/repository/submit/authors.html:65
-#: src/templates/admin/repository/submit/authors.html:116
-#: src/templates/admin/repository/submit/authors.html:123
-#: src/templates/admin/submission/submit_authors.html:49
+#: src/templates/admin/repository/submit/authors.html:62
+#: src/templates/admin/repository/submit/authors.html:113
+#: src/templates/admin/repository/submit/authors.html:120
+#: src/templates/admin/submission/submit_authors.html:54
 #: src/themes/OLH/templates/elements/submit/author.html:8
 msgid "Add New Author"
 msgstr "Aggiungi un nuovo autore"
@@ -1582,14 +2118,13 @@ msgstr "Aggiungi un nuovo autore"
 msgid "Add Author"
 msgstr "Aggiungi un autore"
 
-#: src/templates/admin/elements/submit/file.html:7
+#: src/templates/admin/elements/submit/file.html:9
 #: src/themes/OLH/templates/elements/submit/file.html:6
 #: src/themes/OLH/templates/elements/submit/preprint_file.html:6
 msgid "Add New File"
 msgstr "Aggiungi un nuovo file"
 
-#: src/templates/admin/elements/submit/file.html:35
-#: src/templates/admin/elements/submit/file.html:51
+#: src/templates/admin/elements/submit/file.html:33
 #: src/themes/OLH/templates/elements/submit/file.html:25
 #: src/themes/OLH/templates/elements/submit/preprint_file.html:25
 msgid "Add File"
@@ -1641,6 +2176,7 @@ msgstr "Contatti"
 #: src/themes/clean/templates/journal/contact.html:5
 #: src/themes/clean/templates/journal/contact.html:21
 #: src/themes/clean/templates/press/nav.html:53
+#: src/themes/hourglass/templates/press/contact.html:4
 #: src/themes/material/templates/core/nav.html:42
 #: src/themes/material/templates/core/nav.html:103
 #: src/themes/material/templates/journal/contact.html:5
@@ -1650,13 +2186,6 @@ msgstr "Contatti"
 msgid "Contact"
 msgstr "Contatto"
 
-#: src/templates/admin/journal/contact.html:38
-#: src/themes/OLH/templates/journal/contact.html:30
-#: src/themes/OLH/templates/press/journal/contact.html:22
-#: src/themes/clean/templates/journal/contact.html:27
-msgid "Who would you like to contact?"
-msgstr "Chi vorresti contattare?"
-
 #: src/templates/admin/journal/contact.html:52
 #: src/themes/OLH/templates/journal/contact.html:39
 #: src/themes/OLH/templates/press/journal/contact.html:30
@@ -1665,39 +2194,39 @@ msgstr "Chi vorresti contattare?"
 msgid "Send Message"
 msgstr "Invia messaggio"
 
-#: src/templates/admin/journal/manage/archive_article.html:24
+#: src/templates/admin/journal/manage/archive_article.html:25
 #, fuzzy
 #| msgid "Edit Article"
 msgid "Edit Article Images"
 msgstr "Modifica articolo"
 
-#: src/templates/admin/journal/manage/archive_article.html:26
+#: src/templates/admin/journal/manage/archive_article.html:27
 #, fuzzy
 #| msgid "Publications"
 msgid "Edit Publication Info"
 msgstr "Pubblicazioni"
 
-#: src/templates/admin/journal/manage/archive_article.html:28
+#: src/templates/admin/journal/manage/archive_article.html:29
 #, fuzzy
 #| msgid "Latest Articles & News"
 msgid "Remote Article View"
 msgstr "Ultimi articoli e news"
 
-#: src/templates/admin/journal/manage/archive_article.html:178
+#: src/templates/admin/journal/manage/archive_article.html:179
 msgid "Undo Article Rejection"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:182
+#: src/templates/admin/journal/manage/archive_article.html:183
 msgid "Review"
 msgstr "Revisione"
 
-#: src/templates/admin/journal/manage/archive_article.html:184
+#: src/templates/admin/journal/manage/archive_article.html:185
 #, fuzzy
 #| msgid "Assign"
 msgid "Unassigned"
 msgstr "Assegna"
 
-#: src/templates/admin/journal/manage/archive_article.html:186
+#: src/templates/admin/journal/manage/archive_article.html:187
 #, python-format
 msgid ""
 "You will have the opportunity to send an email to the author, and then the "
@@ -1722,52 +2251,26 @@ msgid ""
 "                 "
 msgstr ""
 
-#: src/templates/admin/journal/submissions.html:35
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:48
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:50
-#: src/themes/OLH/templates/core/accounts/register.html:5
-#: src/themes/OLH/templates/core/accounts/register.html:96
-#: src/themes/OLH/templates/core/base.html:141
-#: src/themes/OLH/templates/core/nav.html:77
-#: src/themes/OLH/templates/journal/submissions.html:30
-#: src/themes/OLH/templates/press/nav.html:58
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:41
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:43
-#: src/themes/clean/templates/core/accounts/register.html:5
-#: src/themes/clean/templates/core/accounts/register.html:39
-#: src/themes/clean/templates/core/nav.html:104
-#: src/themes/clean/templates/journal/submissions.html:17
-#: src/themes/clean/templates/press/nav.html:79
-#: src/themes/material/templates/core/accounts/register.html:6
-#: src/themes/material/templates/core/accounts/register.html:44
-#: src/themes/material/templates/core/nav.html:79
-#: src/themes/material/templates/core/nav.html:134
-#: src/themes/material/templates/journal/submissions.html:33
-#: src/themes/material/templates/press/nav.html:67
-#: src/themes/material/templates/press/nav.html:115
-#: src/themes/material/templates/repository/nav.html:60
-msgid "Register"
-msgstr "Iscrizione"
-
 #: src/templates/admin/journal/submissions.html:36
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:28
-#: src/themes/OLH/templates/core/base.html:141
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/themes/OLH/templates/core/base.html:142
 #: src/themes/OLH/templates/core/login.html:6
-#: src/themes/OLH/templates/core/nav.html:76
+#: src/themes/OLH/templates/core/nav.html:75
 #: src/themes/OLH/templates/elements/journal_footer.html:30
 #: src/themes/OLH/templates/journal/become_reviewer.html:16
 #: src/themes/OLH/templates/journal/submissions.html:31
 #: src/themes/OLH/templates/press/core/login.html:5
 #: src/themes/OLH/templates/press/elements/press_footer.html:15
 #: src/themes/OLH/templates/press/nav.html:57
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:19
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:23
 #: src/themes/clean/templates/core/login.html:5
 #: src/themes/clean/templates/core/nav.html:103
-#: src/themes/clean/templates/elements/journal_footer.html:41
+#: src/themes/clean/templates/elements/journal_footer.html:43
 #: src/themes/clean/templates/elements/press_footer.html:19
 #: src/themes/clean/templates/journal/become_reviewer.html:13
 #: src/themes/clean/templates/journal/submissions.html:18
 #: src/themes/clean/templates/press/nav.html:77
+#: src/themes/hourglass/templates/core/accounts/login.html:11
 #: src/themes/material/templates/core/login.html:5
 #: src/themes/material/templates/core/login.html:42
 #: src/themes/material/templates/core/nav.html:78
@@ -1781,7 +2284,7 @@ msgid "Login"
 msgstr "Accesso"
 
 #: src/templates/admin/journal/submissions.html:38
-#: src/templates/admin/submission/start.html:72
+#: src/templates/admin/submission/start.html:77
 #: src/themes/OLH/templates/core/nav.html:43
 #: src/themes/OLH/templates/journal/submissions.html:32
 #: src/themes/clean/templates/core/nav.html:71
@@ -1802,10 +2305,13 @@ msgid "Licences"
 msgstr "Licenze"
 
 #: src/templates/admin/journal/submissions.html:48
+#: src/templates/admin/submission/submit_info.html:109
 #: src/themes/OLH/templates/journal/submissions.html:40
 #: src/themes/clean/templates/journal/submissions.html:27
 #: src/themes/material/templates/journal/submissions.html:46
-msgid "allows the following licences for submission"
+#, fuzzy
+#| msgid "allows the following licences for submission"
+msgid "The following licences are allowed:"
 msgstr "consente le seguenti licenze per l'invio"
 
 #: src/templates/admin/press/edit_press_journal_description.html:5
@@ -1816,8 +2322,9 @@ msgstr ""
 #: src/templates/admin/press/edit_press_journal_description.html:11
 #: src/templates/admin/press/edit_press_journal_description.html:17
 #: src/templates/admin/repository/article.html:215
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 #: src/templates/admin/review/view_review.html:112
+#: src/templates/admin/submission/submit_funding.html:76
 #: src/themes/OLH/templates/elements/edit_author.html:4
 msgid "Edit"
 msgstr "Modifica"
@@ -1834,12 +2341,6 @@ msgid ""
 "description is used."
 msgstr ""
 
-#: src/templates/admin/press/edit_press_journal_description.html:24
-#: src/templates/admin/review/view_review.html:168
-#: src/templates/admin/review/view_review.html:189
-msgid "Save"
-msgstr ""
-
 #: src/templates/admin/press/edit_press_journal_description.html:25
 #, fuzzy
 #| msgid "Description"
@@ -1854,31 +2355,24 @@ msgstr "Ogni round di correzione ha un limite di"
 msgid "proofreaders"
 msgstr "Revisori"
 
-#: src/templates/admin/repository/article.html:212
-#: src/templates/admin/repository/author_article.html:91
-#: src/templates/admin/repository/submit/authors.html:79
-#: src/templates/admin/submission/submit_authors.html:64
-#: src/templates/admin/submission/submit_funding.html:49
-msgid "Name"
-msgstr "Nome"
-
 #: src/templates/admin/repository/article.html:214
 #: src/templates/admin/repository/author_article.html:93
-#: src/templates/admin/repository/submit/authors.html:81
-#: src/templates/admin/submission/submit_review.html:102
-#: src/themes/OLH/templates/core/accounts/public_profile.html:14
-#: src/themes/clean/templates/core/accounts/public_profile.html:14
-#: src/themes/material/templates/core/accounts/public_profile.html:14
+#: src/templates/admin/repository/submit/authors.html:78
+#: src/templates/admin/submission/submit_review.html:118
+#: src/themes/OLH/templates/core/accounts/public_profile.html:42
+#: src/themes/clean/templates/core/accounts/public_profile.html:18
+#: src/themes/material/templates/core/accounts/public_profile.html:18
 msgid "Affiliation"
 msgstr "Affiliazione"
 
 #: src/templates/admin/repository/article.html:216
-#: src/templates/admin/repository/submit/authors.html:82
+#: src/templates/admin/repository/submit/authors.html:79
+#: src/templates/admin/submission/submit_funding.html:77
 msgid "Delete"
 msgstr ""
 
 #: src/templates/admin/repository/article.html:239
-#: src/templates/admin/repository/submit/authors.html:97
+#: src/templates/admin/repository/submit/authors.html:94
 #, fuzzy
 #| msgid "No funders added."
 msgid "No authors added."
@@ -1900,37 +2394,37 @@ msgstr ""
 msgid "Add Authors to"
 msgstr "Aggiungi autori a"
 
-#: src/templates/admin/repository/submit/authors.html:23
-#: src/themes/clean/templates/journal/article.html:217
+#: src/templates/admin/repository/submit/authors.html:20
+#: src/themes/clean/templates/journal/article.html:219
 msgid "Information"
 msgstr "Informazioni"
 
-#: src/templates/admin/repository/submit/authors.html:27
+#: src/templates/admin/repository/submit/authors.html:24
 msgid ""
 "You can add yourself as an author using the button below. This will copy "
 "metadata from your profile to create a"
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:27
+#: src/templates/admin/repository/submit/authors.html:24
 msgid "author record."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:28
+#: src/templates/admin/repository/submit/authors.html:25
 msgid ""
 "You can search the database of existing authors and add them as authors."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:29
+#: src/templates/admin/repository/submit/authors.html:26
 msgid "You can create a new record for an author using the form below."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:34
-#: src/templates/admin/submission/submit_authors.html:46
+#: src/templates/admin/repository/submit/authors.html:31
+#: src/templates/admin/submission/submit_authors.html:51
 msgid "Add Self as Author"
 msgstr "Aggiungi te stesso come autore"
 
-#: src/templates/admin/repository/submit/authors.html:37
-#: src/templates/admin/submission/submit_authors.html:44
+#: src/templates/admin/repository/submit/authors.html:34
+#: src/templates/admin/submission/submit_authors.html:49
 msgid ""
 "By default, your account is the owner of this submission, but is not an "
 "Author on record. You can add yourself using the button below."
@@ -1939,26 +2433,26 @@ msgstr ""
 "proposta, ma non è un autore registrato. Puoi aggiungerti usando il pulsante "
 "qui sotto."
 
-#: src/templates/admin/repository/submit/authors.html:45
+#: src/templates/admin/repository/submit/authors.html:42
 #, fuzzy
 #| msgid "Search for Existing Authors"
 msgid "Search for an Author"
 msgstr "Cerca gli autori esistenti"
 
-#: src/templates/admin/repository/submit/authors.html:48
+#: src/templates/admin/repository/submit/authors.html:45
 msgid ""
 "You can search by email or ORCiD. eg. person@example.com or "
 "0000-0003-2126-266X."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/repository/submit/authors.html:58
 #, fuzzy
 #| msgid "Add Author"
 msgid "Add an Author"
 msgstr "Aggiungi un autore"
 
-#: src/templates/admin/repository/submit/authors.html:64
-#: src/templates/admin/submission/submit_authors.html:48
+#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/submission/submit_authors.html:53
 msgid ""
 "If you cannot find the author record by searching, and you are not the only "
 "author, you can add one by clicking the button below. This will open a popup "
@@ -1968,40 +2462,40 @@ msgstr ""
 "sei l'unico autore, puoi aggiungerne uno facendo clic sul pulsante in basso. "
 "Questo aprirà una finestra popup per completare i loro dettagli."
 
-#: src/templates/admin/repository/submit/authors.html:70
+#: src/templates/admin/repository/submit/authors.html:67
 #: src/themes/OLH/templates/journal/article.html:27
 #: src/themes/OLH/templates/journal/article.html:63
-#: src/themes/OLH/templates/journal/article.html:158
-#: src/themes/OLH/templates/journal/article.html:332
+#: src/themes/OLH/templates/journal/article.html:161
+#: src/themes/OLH/templates/journal/article.html:313
 #: src/themes/OLH/templates/journal/authors.html:4
 #: src/themes/OLH/templates/journal/authors.html:5
 #: src/themes/OLH/templates/journal/authors.html:11
 #: src/themes/OLH/templates/journal/print.html:15
 #: src/themes/OLH/templates/repository/preprint.html:33
 #: src/themes/clean/templates/journal/article.html:37
-#: src/themes/clean/templates/journal/article.html:167
+#: src/themes/clean/templates/journal/article.html:153
 #: src/themes/clean/templates/journal/authors.html:9
 #: src/themes/clean/templates/journal/print.html:15
-#: src/themes/material/templates/journal/article.html:269
+#: src/themes/material/templates/journal/article.html:250
 #: src/themes/material/templates/journal/authors.html:5
 #: src/themes/material/templates/journal/authors.html:6
 #: src/themes/material/templates/journal/authors.html:10
 #: src/themes/material/templates/preprints/article.html:28
-#: src/themes/material/templates/repository/preprint.html:149
+#: src/themes/material/templates/repository/preprint.html:147
 msgid "Authors"
 msgstr "Autori"
 
-#: src/templates/admin/repository/submit/authors.html:73
+#: src/templates/admin/repository/submit/authors.html:70
 msgid ""
 "You can reorder the authors by dragging and dropping rows in the table below."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:103
+#: src/templates/admin/repository/submit/authors.html:100
 msgid "Once you have added all of your authors you can complete this stage."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:106
-msgid "Complete Step 2 of 3"
+#: src/templates/admin/repository/submit/authors.html:103
+msgid "Complete Step 2 of 4"
 msgstr ""
 
 #: src/templates/admin/repository/submit/files.html:8
@@ -2010,65 +2504,59 @@ msgstr ""
 msgid "Upload Files for"
 msgstr "Carica files"
 
-#: src/templates/admin/repository/submit/files.html:29
+#: src/templates/admin/repository/submit/files.html:25
 msgid "You can use the form below to select and upload your manuscript file."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:43
 #, fuzzy
 #| msgid "Supplementary Files"
 msgid "Supplementary files"
 msgstr "File supplementari"
 
-#: src/templates/admin/repository/submit/files.html:50
+#: src/templates/admin/repository/submit/files.html:46
 msgid "Optional links to externaly hosted supplementary files."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:51
-#: src/templates/admin/repository/submit/files.html:101
-#: src/templates/admin/repository/submit/files.html:108
+#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:97
+#: src/templates/admin/repository/submit/files.html:104
 #: src/templates/admin/repository/supp_files_body.html:53
 #, fuzzy
 #| msgid "Supplementary Files"
 msgid "Add New Supplementary File"
 msgstr "File supplementari"
 
-#: src/templates/admin/repository/submit/files.html:60
+#: src/templates/admin/repository/submit/files.html:56
 msgid ""
 "If you want to change this file you can upload a new one and it will be "
 "overwritten."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:93
-msgid "Complete Step 3 of 3"
+#: src/templates/admin/repository/submit/files.html:89
+msgid "Complete Step 3 of 4"
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:120
+#: src/templates/admin/repository/submit/files.html:116
 #, fuzzy
 #| msgid "Sections submission information"
 msgid "Submission Information"
 msgstr "Informazione per l'invio delle sezioni"
 
-#: src/templates/admin/repository/submit/review.html:8
-#, fuzzy
-#| msgid "Submission Checklist"
-msgid "Submission Complete"
-msgstr "Checklist per la proposta"
-
-#: src/templates/admin/repository/submit/start.html:26
+#: src/templates/admin/repository/submit/start.html:24
 #, fuzzy
 #| msgid "Submission Started"
 msgid "Submission Agreement"
 msgstr "Proposta iniziata"
 
-#: src/templates/admin/repository/submit/start.html:38
+#: src/templates/admin/repository/submit/start.html:36
 #: src/themes/OLH/templates/repository/preprint.html:122
 #: src/themes/material/templates/preprints/article.html:121
 msgid "Metadata"
 msgstr "Metadati"
 
-#: src/templates/admin/repository/submit/start.html:94
-msgid "Complete Step 1 of 3"
+#: src/templates/admin/repository/submit/start.html:92
+msgid "Complete Step 1 of 4"
 msgstr ""
 
 #: src/templates/admin/repository/version_queue.html:19
@@ -2080,17 +2568,25 @@ msgstr ""
 #: src/templates/admin/review/add_review_assignment.html:27
 msgid ""
 "\n"
-"                        You can select a reviewer using the radio buttons in "
-"the first column and complete the section under \"Set Options\".\n"
-"                        If you cannot find the reviewer you want in this "
-"list you can use \"Enroll Existing User\" to search the database and give "
-"users the Reviewer role, or \"Add New Reviewer\" to create a new account for "
-"a reviewer (this process is silent, they will not receive an account "
-"creation email).\n"
-"                        "
+"                                You can select a reviewer using the radio\n"
+"                                buttons in the first column and complete "
+"the\n"
+"                                section under 'Set Options'.\n"
+"                                If you cannot find the reviewer you want in\n"
+"                                this list you can use 'Enroll Existing User' "
+"to\n"
+"                                search the database and give users the "
+"Reviewer\n"
+"                                role, or 'Add New Reviewer' to create a new\n"
+"                                account for a reviewer (this process is "
+"silent,\n"
+"                                so they will not receive an account "
+"creation\n"
+"                                email).\n"
+"                            "
 msgstr ""
 
-#: src/templates/admin/review/decision.html:44
+#: src/templates/admin/review/decision.html:57
 msgid ""
 "Note: This article has completed reviews that have not been made available "
 "to the author:"
@@ -2109,33 +2605,33 @@ msgstr ""
 msgid "No"
 msgstr "Commento"
 
-#: src/templates/admin/review/in_review.html:25
+#: src/templates/admin/review/in_review.html:23
 #, fuzzy
 #| msgid "This article has not been peer reviewed."
 msgid "This article is not yet in the review stage"
 msgstr "Questo articolo non è stato sottoposto a peer review."
 
-#: src/templates/admin/review/in_review.html:27
+#: src/templates/admin/review/in_review.html:25
 msgid "Before you can move this paper into review you need to"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:28
+#: src/templates/admin/review/in_review.html:26
 msgid "assign an editor"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
 msgid ""
 "This paper has not had an automatic plagiarism check. If you wish to do so "
 "you can run a"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
 msgid "Similarity Check via iThenticate"
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:68
+#: src/templates/admin/review/in_review.html:66
 #, python-format
 msgid ""
 "\n"
@@ -2144,7 +2640,7 @@ msgid ""
 "                                            "
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:217
+#: src/templates/admin/review/in_review.html:215
 msgid ""
 "\n"
 "                                The latest manuscript and figure files for "
@@ -2153,19 +2649,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:287
+#: src/templates/admin/review/in_review.html:285
 msgid "Move to Next Stage"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:20
+#: src/templates/admin/review/projected_issue.html:27
 msgid "Save Projected Issue"
 msgstr "Salva la pubblicazione selezionata"
 
-#: src/templates/admin/review/projected_issue.html:30
+#: src/templates/admin/review/projected_issue.html:37
 msgid "What is this for?"
 msgstr "A cosa serve?"
 
-#: src/templates/admin/review/projected_issue.html:31
+#: src/templates/admin/review/projected_issue.html:38
 msgid ""
 "The projected issue field can be used internally to keep track of plans and "
 "communicate with typesetters, without affecting issue assignment or "
@@ -2173,21 +2669,21 @@ msgid ""
 "to issues on a rolling basis and publish them individually."
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:32
+#: src/templates/admin/review/projected_issue.html:39
 msgid ""
 "You can assign articles directly to issues in the prepublication stage or "
 "through "
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:32
+#: src/templates/admin/review/projected_issue.html:39
 msgid "issue management"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:33
+#: src/templates/admin/review/projected_issue.html:40
 msgid "How does it work?"
 msgstr "Come funziona?"
 
-#: src/templates/admin/review/projected_issue.html:34
+#: src/templates/admin/review/projected_issue.html:41
 #, fuzzy
 #| msgid ""
 #| "Select an issue from the drop down on the left and press save, this "
@@ -2199,11 +2695,11 @@ msgstr ""
 "Seleziona una pubblicazione dal menù a sinistra e clicca \"Salva\". "
 "L'articolo verrà pubblicato nella pubblicazione selezionata."
 
-#: src/templates/admin/review/projected_issue.html:35
+#: src/templates/admin/review/projected_issue.html:42
 msgid "Can I unset a projected issue?"
 msgstr "Posso rimuovere la pubblicazione selezionata?"
 
-#: src/templates/admin/review/projected_issue.html:36
+#: src/templates/admin/review/projected_issue.html:43
 #, fuzzy
 #| msgid "Yes, simply select the blank option (-------) from the drop down."
 msgid "Yes, you can select the blank option (-------) from the dropdown."
@@ -2218,23 +2714,23 @@ msgid ""
 "revisions once you click 'Submit Revisions'"
 msgstr ""
 
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 msgid "Assign"
 msgstr "Assegna"
 
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 msgid "Projected Issue"
 msgstr "Seleziona una pubblicazione"
 
-#: src/templates/admin/review/unassigned_article.html:122
+#: src/templates/admin/review/unassigned_article.html:125
 msgid "This article is projected to be published as part of"
 msgstr "Questo articolo verrà pubblicato in"
 
-#: src/templates/admin/review/unassigned_article.html:124
+#: src/templates/admin/review/unassigned_article.html:127
 msgid "This article is not projected to be published as part of any issue."
 msgstr "La pubblicazione di cui l'articolo farà parte non è stata selezionata."
 
-#: src/templates/admin/review/unassigned_article.html:137
+#: src/templates/admin/review/unassigned_article.html:140
 msgid ""
 "To check an article for possible plagiarism, you can send an article for an "
 "automated Similarity Check via iThenticate by clicking Send below. The "
@@ -2319,7 +2815,6 @@ msgid "Withdrawn"
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:63
-#: src/themes/material/templates/journal/article.html:394
 msgid "Accepted"
 msgstr "Accettato"
 
@@ -2399,7 +2894,7 @@ msgstr ""
 msgid "Suggested Reviewers"
 msgstr "Peer reviewed"
 
-#: src/templates/admin/submission/edit/metadata.html:178
+#: src/templates/admin/submission/edit/metadata.html:195
 msgid ""
 "\n"
 "                            You can search the <a href=\"https://www."
@@ -2409,7 +2904,7 @@ msgid ""
 "                        "
 msgstr ""
 
-#: src/templates/admin/submission/manager/delete_license.html:26
+#: src/templates/admin/submission/manager/delete_license.html:25
 msgid ""
 "This license is currently used by the following articles. If you delete it "
 "these articles will no longer have a license listed."
@@ -2417,9 +2912,13 @@ msgstr ""
 "Questa licenza è attualmente utilizzata dai seguenti articoli. Se la "
 "elimini, questi articoli non avranno più una licenza."
 
-#: src/templates/admin/submission/manager/delete_license.html:27
+#: src/templates/admin/submission/manager/delete_license.html:26
+#, fuzzy
+#| msgid ""
+#| "You should only delete this license if you are absolutley sure you want "
+#| "to remove it."
 msgid ""
-"You should only delete this license if you are absolutley sure you want to "
+"You should only delete this license if you are absolutely sure you want to "
 "remove it."
 msgstr ""
 "Elimina la licenza solo se sei completamente sicuro di volerla rimuovere."
@@ -2439,43 +2938,43 @@ msgstr ""
 "Si prega di leggere attentamente le dichiarazioni sottostanti prima di "
 "selezionare ciascuna voce"
 
-#: src/templates/admin/submission/start.html:24
+#: src/templates/admin/submission/start.html:29
 msgid ""
 "All authors must agree to the below statements in order to submit an article "
 "to"
 msgstr ""
 
-#: src/templates/admin/submission/start.html:24
+#: src/templates/admin/submission/start.html:29
 msgid ""
 "If you do not agree with these terms you will be unable to proceed with your "
 "submission."
 msgstr ""
 
-#: src/templates/admin/submission/start.html:29
+#: src/templates/admin/submission/start.html:34
 msgid "Publication Fees"
 msgstr "Tariffe di pubblicazione"
 
-#: src/templates/admin/submission/start.html:36
+#: src/templates/admin/submission/start.html:41
 msgid "Author(s) agrees to the above statement"
 msgstr "L'autore/i è d'accordo con la dichiarazione di cui sopra"
 
-#: src/templates/admin/submission/start.html:42
+#: src/templates/admin/submission/start.html:47
 msgid "Submission Checklist"
 msgstr "Checklist per la proposta"
 
-#: src/templates/admin/submission/start.html:48
+#: src/templates/admin/submission/start.html:53
 msgid "Author(s) confirms that this article adheres to the above requirements"
 msgstr ""
 "L'autore/i conferma che questo articolo rispetta i requisiti di cui sopra"
 
-#: src/templates/admin/submission/start.html:54
+#: src/templates/admin/submission/start.html:59
 msgid "Copyright Notice"
 msgstr "Avviso sul copyright"
 
-#: src/templates/admin/submission/start.html:66
-#: src/themes/OLH/templates/journal/article.html:428
-#: src/themes/clean/templates/journal/article.html:255
-#: src/themes/material/templates/journal/article.html:424
+#: src/templates/admin/submission/start.html:71
+#: src/themes/OLH/templates/journal/article.html:419
+#: src/themes/clean/templates/journal/article.html:265
+#: src/themes/material/templates/journal/article.html:400
 msgid "Competing Interests"
 msgstr "Conflitto di interessi"
 
@@ -2485,11 +2984,11 @@ msgstr "Conflitto di interessi"
 msgid "Author Information"
 msgstr "Informazioni sull'autore"
 
-#: src/templates/admin/submission/submit_authors.html:18
+#: src/templates/admin/submission/submit_authors.html:23
 msgid "Search for Existing Authors"
 msgstr "Cerca gli autori esistenti"
 
-#: src/templates/admin/submission/submit_authors.html:25
+#: src/templates/admin/submission/submit_authors.html:30
 msgid ""
 "Search for a user using email address or ORCiD. If a user is matched, they "
 "will be automatically added as an author. This search only returns exact "
@@ -2499,12 +2998,12 @@ msgstr ""
 "corrispondente sarà automaticamente aggiunto come autore. Questa ricerca "
 "restituisce solo corrispondenze esatte."
 
-#: src/templates/admin/submission/submit_authors.html:31
+#: src/templates/admin/submission/submit_authors.html:36
 msgid "Search by email address or ORCiD"
 msgstr "Cerca per indirizzo email o ORDi"
 
-#: src/templates/admin/submission/submit_authors.html:35
-#: src/themes/OLH/templates/core/base.html:153
+#: src/templates/admin/submission/submit_authors.html:40
+#: src/themes/OLH/templates/core/base.html:154
 #: src/themes/OLH/templates/journal/full-text-search.html:8
 #: src/themes/OLH/templates/journal/full-text-search.html:10
 #: src/themes/OLH/templates/journal/full-text-search.html:70
@@ -2527,23 +3026,23 @@ msgstr "Cerca per indirizzo email o ORDi"
 msgid "Search"
 msgstr "Ricerca"
 
-#: src/templates/admin/submission/submit_authors.html:40
+#: src/templates/admin/submission/submit_authors.html:45
 msgid "Add Authors"
 msgstr "Aggiungi autori"
 
-#: src/templates/admin/submission/submit_authors.html:55
+#: src/templates/admin/submission/submit_authors.html:60
 msgid "Current Authors"
 msgstr "Autori correnti"
 
-#: src/templates/admin/submission/submit_authors.html:57
+#: src/templates/admin/submission/submit_authors.html:62
 msgid "Drag and drop an author to re-order them."
 msgstr "Seleziona e trascina un autore per cambiarne l'ordine."
 
-#: src/templates/admin/submission/submit_authors.html:81
+#: src/templates/admin/submission/submit_authors.html:86
 msgid "No authors yet, add one!"
 msgstr "Non ci sono ancora autori, aggiungine uno!"
 
-#: src/templates/admin/submission/submit_authors.html:88
+#: src/templates/admin/submission/submit_authors.html:93
 msgid ""
 "You are required to select a main author, this author will receive the "
 "communications regarding your articles process through our systems. This "
@@ -2553,14 +3052,14 @@ msgstr ""
 "comunicazioni relative al processo degli articoli sul nostro sistema. Non "
 "devi essere necessariamente tu."
 
-#: src/templates/admin/submission/submit_authors.html:89
+#: src/templates/admin/submission/submit_authors.html:94
 msgid "Select main author"
 msgstr "Seleziona l'autore principale"
 
-#: src/templates/admin/submission/submit_authors.html:99
-#: src/templates/admin/submission/submit_files.html:112
-#: src/templates/admin/submission/submit_funding.html:75
-#: src/templates/admin/submission/submit_info.html:83
+#: src/templates/admin/submission/submit_authors.html:104
+#: src/templates/admin/submission/submit_files.html:118
+#: src/templates/admin/submission/submit_funding.html:111
+#: src/templates/admin/submission/submit_info.html:93
 msgid "Save and Continue"
 msgstr "Salva e continua"
 
@@ -2568,77 +3067,90 @@ msgstr "Salva e continua"
 msgid "Upload files"
 msgstr "Carica files"
 
-#: src/templates/admin/submission/submit_files.html:33
-#: src/templates/admin/submission/submit_files.html:74
+#: src/templates/admin/submission/submit_files.html:39
+#: src/templates/admin/submission/submit_files.html:80
 msgid "Upload"
 msgstr "Carica"
 
-#: src/templates/admin/submission/submit_files.html:41
-#: src/templates/admin/submission/submit_files.html:81
-#: src/templates/admin/submission/submit_review.html:121
+#: src/templates/admin/submission/submit_files.html:47
+#: src/templates/admin/submission/submit_files.html:87
+#: src/templates/admin/submission/submit_review.html:137
 msgid "File Name"
 msgstr "Nome del file"
 
-#: src/templates/admin/submission/submit_files.html:59
-#: src/templates/admin/submission/submit_files.html:97
+#: src/templates/admin/submission/submit_files.html:65
+#: src/templates/admin/submission/submit_files.html:103
 msgid "No files uploaded"
 msgstr "Nessun file caricato"
 
 #: src/templates/admin/submission/submit_funding.html:7
-#: src/templates/admin/submission/submit_info.html:6
-#: src/templates/admin/submission/submit_review.html:43
-msgid "Article Info"
-msgstr "Informazioni sull'articolo"
+#, fuzzy
+#| msgid "License Information"
+msgid "Funding Information"
+msgstr "Informazioni sulla licenza"
 
-#: src/templates/admin/submission/submit_funding.html:16
+#: src/templates/admin/submission/submit_funding.html:25
 #: src/templates/admin/submission/timeline.html:36
 #: src/templates/admin/submission/timeline.html:37
-#: src/themes/OLH/templates/journal/article.html:229
-#: src/themes/clean/templates/journal/article.html:123
-#: src/themes/material/templates/journal/article.html:151
+#: src/templates/common/elements/funder_info_for_readers.html:3
 msgid "Funding"
 msgstr "Finanziamento"
 
-#: src/templates/admin/submission/submit_funding.html:20
+#: src/templates/admin/submission/submit_funding.html:30
+msgid ""
+"\n"
+"                         Here you can search the FundRef database to add "
+"grant IDs to your article's metadata. If you can't find a specific funder, "
+"you can manually enter the details. You can also edit or delete entries as "
+"necessary.\n"
+"                    "
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:36
 msgid "Add Funding Source"
 msgstr "Aggiungi una fonte di finanziamento"
 
-#: src/templates/admin/submission/submit_funding.html:27
+#: src/templates/admin/submission/submit_funding.html:47
 msgid "Search for funder"
 msgstr "Cerca un finanzatore"
 
-#: src/templates/admin/submission/submit_funding.html:31
+#: src/templates/admin/submission/submit_funding.html:53
 msgid "Add funder manually"
 msgstr "Aggiungi il finanziatore manualmente"
 
-#: src/templates/admin/submission/submit_funding.html:41
+#: src/templates/admin/submission/submit_funding.html:64
 msgid "Current Funders"
 msgstr "Finanziatori attuali"
 
-#: src/templates/admin/submission/submit_funding.html:50
+#: src/templates/admin/submission/submit_funding.html:74
 msgid "Grant Number"
 msgstr "Numero del fondo di finanziamento"
 
-#: src/templates/admin/submission/submit_funding.html:65
+#: src/templates/admin/submission/submit_funding.html:100
 msgid "No funders added."
 msgstr "Nessun finanziatore aggiunto."
 
-#: src/templates/admin/submission/submit_info.html:16
+#: src/templates/admin/submission/submit_info.html:6
+#: src/templates/admin/submission/submit_review.html:48
+msgid "Article Info"
+msgstr "Informazioni sull'articolo"
+
+#: src/templates/admin/submission/submit_info.html:26
 msgid "This article is a preprint"
 msgstr "Questo articolo è un preprint"
 
-#: src/templates/admin/submission/submit_info.html:21
+#: src/templates/admin/submission/submit_info.html:31
 #, fuzzy
 #| msgid "Information"
 msgid "Basic Information"
 msgstr "Informazioni"
 
-#: src/templates/admin/submission/submit_info.html:58
+#: src/templates/admin/submission/submit_info.html:68
 msgid "View license information"
 msgstr "Visualizza le informazioni sulla licenza"
 
-#: src/templates/admin/submission/submit_info.html:67
-#: src/themes/OLH/templates/journal/article.html:178
+#: src/templates/admin/submission/submit_info.html:77
+#: src/themes/OLH/templates/journal/article.html:181
 #: src/themes/OLH/templates/journal/keywords.html:6
 #: src/themes/OLH/templates/journal/keywords.html:12
 #: src/themes/OLH/templates/journal/print.html:33
@@ -2658,17 +3170,13 @@ msgstr "Visualizza le informazioni sulla licenza"
 #: src/themes/material/templates/journal/search.html:50
 #: src/themes/material/templates/preprints/list.html:79
 #: src/themes/material/templates/repository/list.html:60
-#: src/themes/material/templates/repository/preprint.html:172
+#: src/themes/material/templates/repository/preprint.html:170
 msgid "Keywords"
 msgstr "Parole chiave"
 
-#: src/templates/admin/submission/submit_info.html:96
+#: src/templates/admin/submission/submit_info.html:106
 msgid "License Information"
 msgstr "Informazioni sulla licenza"
-
-#: src/templates/admin/submission/submit_info.html:99
-msgid "allows the following licenses for submission"
-msgstr "consente le seguenti licenze per l'invio"
 
 #: src/templates/admin/submission/submit_review.html:7
 #: src/templates/admin/submission/timeline.html:43
@@ -2680,7 +3188,7 @@ msgstr "consente le seguenti licenze per l'invio"
 msgid "Review your submission"
 msgstr "Revisiona il Preprint"
 
-#: src/templates/admin/submission/submit_review.html:21
+#: src/templates/admin/submission/submit_review.html:26
 msgid ""
 "Please review your submission use the details below. If you need to make "
 "changes use the links above to move back along the submission steps. You "
@@ -2689,120 +3197,120 @@ msgid ""
 "receipt email. "
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:25
+#: src/templates/admin/submission/submit_review.html:30
 #, fuzzy
 #| msgid "Author Agreement"
 msgid "Agreements"
 msgstr "Contratto di edizione"
 
-#: src/templates/admin/submission/submit_review.html:29
+#: src/templates/admin/submission/submit_review.html:34
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Agreed to Publication Fees statement"
 msgstr "Tariffe di pubblicazione"
 
-#: src/templates/admin/submission/submit_review.html:33
+#: src/templates/admin/submission/submit_review.html:38
 #, fuzzy
 #| msgid "Submission Checklist"
 msgid "Agreed to Submission Checklist"
 msgstr "Checklist per la proposta"
 
-#: src/templates/admin/submission/submit_review.html:37
+#: src/templates/admin/submission/submit_review.html:42
 msgid "Agreed to Copyright statement"
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:59
-#: src/themes/OLH/templates/journal/article.html:175
+#: src/templates/admin/submission/submit_review.html:64
+#: src/themes/OLH/templates/journal/article.html:178
 #: src/themes/OLH/templates/journal/print.html:30
 #: src/themes/OLH/templates/repository/preprint.html:45
 #: src/themes/clean/templates/journal/article.html:78
 #: src/themes/clean/templates/journal/print.html:30
 #: src/themes/material/templates/journal/article.html:73
 #: src/themes/material/templates/preprints/article.html:43
-#: src/themes/material/templates/repository/preprint.html:157
+#: src/themes/material/templates/repository/preprint.html:155
 msgid "Abstract"
 msgstr "Abstract"
 
-#: src/templates/admin/submission/submit_review.html:68
+#: src/templates/admin/submission/submit_review.html:73
 msgid "Language"
 msgstr "Lingua"
 
-#: src/templates/admin/submission/submit_review.html:72
-#: src/themes/material/templates/journal/article.html:413
+#: src/templates/admin/submission/submit_review.html:77
+#: src/themes/material/templates/journal/article.html:389
 msgid "Licence"
 msgstr "Licenza"
 
-#: src/templates/admin/submission/submit_review.html:94
+#: src/templates/admin/submission/submit_review.html:110
 msgid "Author Info"
 msgstr "Informazioni sull'autore"
 
-#: src/templates/admin/submission/submit_review.html:97
+#: src/templates/admin/submission/submit_review.html:113
 #, fuzzy
 #| msgid "First name"
 msgid "First Name"
 msgstr "Nome"
 
-#: src/templates/admin/submission/submit_review.html:98
+#: src/templates/admin/submission/submit_review.html:114
 #, fuzzy
 #| msgid "Middle name"
 msgid "Middle Name"
 msgstr "Secondo nome"
 
-#: src/templates/admin/submission/submit_review.html:99
+#: src/templates/admin/submission/submit_review.html:115
 #, fuzzy
 #| msgid "Last name"
 msgid "Last Name"
 msgstr "Cognome"
 
-#: src/templates/admin/submission/submit_review.html:100
+#: src/templates/admin/submission/submit_review.html:116
 #, fuzzy
 #| msgid "Email Address"
 msgid "Email Address"
 msgstr "Indirizzo email"
 
-#: src/templates/admin/submission/submit_review.html:110
+#: src/templates/admin/submission/submit_review.html:126
 #, fuzzy
 #| msgid "No Issue Editor ID supplied."
 msgid "No ORCID supplied"
 msgstr "ID dell'editore della pubblicazione non fornito."
 
-#: src/templates/admin/submission/submit_review.html:117
+#: src/templates/admin/submission/submit_review.html:133
 #: src/templates/admin/submission/timeline.html:28
 #: src/templates/admin/submission/timeline.html:29
 msgid "Article Files"
 msgstr "File degli articoli"
 
-#: src/templates/admin/submission/submit_review.html:122
+#: src/templates/admin/submission/submit_review.html:138
 #, fuzzy
 #| msgid "File Name"
 msgid "File Type"
 msgstr "Nome del file"
 
-#: src/templates/admin/submission/submit_review.html:128
+#: src/templates/admin/submission/submit_review.html:144
 #, fuzzy
 #| msgid "Manuscript File"
 msgid "Manuscript"
 msgstr "File manoscritto"
 
-#: src/templates/admin/submission/submit_review.html:136
+#: src/templates/admin/submission/submit_review.html:152
 msgid "Figure/Data"
 msgstr "Figura/data"
 
-#: src/templates/admin/submission/submit_review.html:146
+#: src/templates/admin/submission/submit_review.html:162
 msgid "Comments to the Editor"
 msgstr "Commenti per l'editore"
 
-#: src/templates/admin/submission/submit_review.html:149
+#: src/templates/admin/submission/submit_review.html:165
 msgid ""
 "Before submitting you have the option to add additional comments for the "
 "editor using the field below. Only the editor will see anything you add here."
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:155
+#: src/templates/admin/submission/submit_review.html:171
 msgid "Complete"
 msgstr "Completa"
 
-#: src/templates/admin/submission/submit_review.html:155
+#: src/templates/admin/submission/submit_review.html:171
 #: src/themes/OLH/templates/core/nav.html:40
 #: src/themes/clean/templates/core/nav.html:47
 #: src/themes/material/templates/core/nav.html:39
@@ -2819,15 +3327,38 @@ msgstr "Proposta iniziata"
 msgid "Article Information"
 msgstr "Informazioni sull'articolo"
 
+#: src/templates/common/accounts/register_privacy_policy.html:3
+#: src/templates/common/accounts/register_privacy_policy.html:7
+#: src/templates/common/accounts/register_privacy_policy.html:11
+#: src/themes/OLH/templates/elements/journal_footer.html:25
+#: src/themes/OLH/templates/elements/journal_footer.html:27
+#: src/themes/OLH/templates/press/elements/press_footer.html:9
+#: src/themes/OLH/templates/press/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/journal_footer.html:33
+#: src/themes/clean/templates/elements/journal_footer.html:37
+#: src/themes/clean/templates/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/press_footer.html:14
+#: src/themes/hourglass/templates/custom/register.html:29
+#: src/themes/hourglass/templates/custom/register.html:35
+#: src/themes/material/templates/elements/journal_footer.html:28
+msgid "Privacy Policy"
+msgstr "Privacy Policy"
+
+#: src/templates/common/elements/funder_info_for_readers.html:6
+#, fuzzy
+#| msgid "Funding"
+msgid "Funding ID"
+msgstr "Finanziamento"
+
 #: src/templates/common/elements/journal/article_issue_list.html:4
 #: src/themes/OLH/templates/core/nav.html:25
+#: src/themes/OLH/templates/journal/issues.html:5
 #: src/themes/OLH/templates/journal/issues.html:7
-#: src/themes/OLH/templates/journal/issues.html:9
 #: src/themes/clean/templates/core/nav.html:24
 #: src/themes/clean/templates/journal/issues.html:6
 #: src/themes/material/templates/core/nav.html:33
 #: src/themes/material/templates/core/nav.html:94
-#: src/themes/material/templates/journal/issues.html:6
+#: src/themes/material/templates/journal/issues.html:5
 msgid "Issues"
 msgstr "Pubblicazioni"
 
@@ -2847,6 +3378,30 @@ msgstr ""
 #: src/templates/common/elements/journal/article_issue_list.html:21
 msgid "This article is not a part of any issues"
 msgstr "Questo articolo non è parte di alcuna pubblicazione."
+
+#: src/templates/common/elements/orcid_registration.html:16
+#, fuzzy
+#| msgid "Login with ORCiD"
+msgid "Register with ORCiD"
+msgstr "Accedi con ORCiD"
+
+#: src/templates/common/elements/password_rules.html:2
+#, python-format
+msgid "Your password should be %(password_length)s characters long."
+msgstr ""
+
+#: src/templates/common/elements/password_rules.html:6
+msgid "Your password should contain at least one upper case letter."
+msgstr ""
+
+#: src/templates/common/elements/password_rules.html:11
+msgid "Your password should contain at least one number."
+msgstr ""
+
+#: src/templates/common/elements/skip_to_main_content.html:3
+#: src/themes/clean/templates/500.html:21
+msgid "Skip to main content"
+msgstr ""
 
 #: src/templates/common/elements/sorting.html:7
 #: src/themes/clean/templates/elements/sorting.html:7
@@ -2894,32 +3449,29 @@ msgstr "Errore del server"
 msgid "A server error has occurred"
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:5
-#: src/themes/OLH/templates/core/accounts/activate_account.html:22
-#: src/themes/OLH/templates/core/accounts/activate_account.html:26
-#: src/themes/clean/templates/core/accounts/activate_account.html:5
-#: src/themes/clean/templates/core/accounts/activate_account.html:13
-#: src/themes/clean/templates/core/accounts/activate_account.html:17
-#: src/themes/material/templates/core/accounts/activate_account.html:5
-#: src/themes/material/templates/core/accounts/activate_account.html:14
-#: src/themes/material/templates/core/accounts/activate_account.html:19
-msgid "Activate Account"
-msgstr "Attiva l'account"
+#: src/themes/OLH/templates/cms/page.html:22
+#: src/themes/clean/templates/cms/page.html:19
+#: src/themes/clean/templates/journal/article.html:340
+#: src/themes/material/templates/cms/page.html:25
+#: src/themes/material/templates/journal/article.html:484
+#: src/themes/material/templates/journal/submissions.html:72
+msgid "Table of Contents"
+msgstr "Sommario"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:25
-#: src/themes/clean/templates/core/accounts/activate_account.html:16
-#: src/themes/material/templates/core/accounts/activate_account.html:17
+#: src/themes/OLH/templates/core/accounts/activate_account.html:29
+#: src/themes/clean/templates/core/accounts/activate_account.html:20
+#: src/themes/material/templates/core/accounts/activate_account.html:21
 msgid "You can complete the activation process by clicking the button below."
 msgstr ""
 "Puoi completare il processo di attivazione cliccando il tasto di sotto."
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:29
-#: src/themes/clean/templates/core/accounts/activate_account.html:20
-#: src/themes/material/templates/core/accounts/activate_account.html:23
+#: src/themes/OLH/templates/core/accounts/activate_account.html:33
+#: src/themes/clean/templates/core/accounts/activate_account.html:24
+#: src/themes/material/templates/core/accounts/activate_account.html:27
 msgid "Error"
 msgstr "Errore"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:31
+#: src/themes/OLH/templates/core/accounts/activate_account.html:35
 msgid ""
 "There was no inactive account with this activation code found. It is "
 "possible that your account is already active, you can check by attempting to"
@@ -2927,50 +3479,33 @@ msgstr ""
 "Nessun account inattivo trovato con questo codice di attivazione. E' "
 "possibile che il tuo account sia già attivo, puoi verificarlo provando a"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:32
-#: src/themes/clean/templates/core/accounts/activate_account.html:22
-#: src/themes/material/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:36
+#: src/themes/clean/templates/core/accounts/activate_account.html:26
+#: src/themes/material/templates/core/accounts/activate_account.html:30
 msgid "login"
 msgstr "accesso"
 
-#: src/themes/OLH/templates/core/accounts/edit_profile.html:4
-#: src/themes/clean/templates/core/accounts/edit_profile.html:5
-#: src/themes/material/templates/core/accounts/edit_profile.html:4
-msgid "Edit Profile"
-msgstr "Modifica il profilo"
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:5
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:9
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:86
 #: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:105
 #: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:100
 msgid "Update"
 msgstr "Aggiorna"
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:25
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:15
-#: src/themes/material/templates/core/accounts/get_reset_token.html:14
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:20
+#: src/themes/material/templates/core/accounts/get_reset_token.html:20
 msgid "Enter your email address to begin the reset process"
 msgstr ""
 "Inserisci il tuo indirizzo email per iniziare il processo di ripristino"
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:27
-msgid "somebody"
-msgstr "qualcuno"
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:21
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:31
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:24
+#: src/themes/material/templates/core/accounts/get_reset_token.html:25
 msgid "Request Token"
 msgstr "Richiedi un token"
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:5
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:19
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:4
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:9
-msgid "Unregistered ORCiD"
-msgstr "ORCiD non registrato"
-
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:20
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:24
 msgid ""
 "The ORCiD you logged in with is not currently linked with an account in our "
 "system. You can either register a new account, or login with an existing "
@@ -2980,27 +3515,27 @@ msgstr ""
 "sul nostro sistema. Puoi creare un nuovo account, o fare il log in con un "
 "account già esistente a cui connettere il tuo ORCiD per uso futuro."
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:40
 #: src/themes/OLH/templates/press/core/login.html:36
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:29
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:33
 msgid "Log In"
 msgstr "Accesso"
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:37
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:41
 #: src/themes/OLH/templates/press/core/login.html:37
 msgid "Forgot your password?"
 msgstr "Hai dimenticato la password?"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:5
-#: src/themes/OLH/templates/core/nav.html:73
+#: src/themes/OLH/templates/core/accounts/public_profile.html:9
+#: src/themes/OLH/templates/core/nav.html:72
 #: src/themes/OLH/templates/elements/right_hand_menu.html:38
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:12
 #: src/themes/OLH/templates/press/nav.html:54
 #: src/themes/OLH/templates/repository/elements/right_hand_menu.html:10
-#: src/themes/clean/templates/core/accounts/public_profile.html:4
+#: src/themes/clean/templates/core/accounts/public_profile.html:8
 #: src/themes/clean/templates/core/nav.html:98
 #: src/themes/clean/templates/press/nav.html:71
-#: src/themes/material/templates/core/accounts/public_profile.html:5
+#: src/themes/material/templates/core/accounts/public_profile.html:9
 #: src/themes/material/templates/core/nav.html:165
 #: src/themes/material/templates/core/nav.html:200
 #: src/themes/material/templates/press/nav.html:135
@@ -3008,124 +3543,56 @@ msgstr "Hai dimenticato la password?"
 msgid "Profile"
 msgstr "Profilo"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:13
-#: src/themes/clean/templates/core/accounts/public_profile.html:13
-#: src/themes/material/templates/core/accounts/public_profile.html:13
+#: src/themes/OLH/templates/core/accounts/public_profile.html:19
+#: src/themes/clean/templates/core/accounts/public_profile.html:17
+#: src/themes/material/templates/core/accounts/public_profile.html:17
 msgid "Roles"
 msgstr "Ruoli"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:25
-#: src/themes/clean/templates/core/accounts/public_profile.html:25
-#: src/themes/material/templates/core/accounts/public_profile.html:25
+#: src/themes/OLH/templates/core/accounts/public_profile.html:27
+#, fuzzy
+#| msgid "Editorial Team"
+msgid "Editorial groups"
+msgstr "Team editoriale"
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:35
+msgid "Staff roles"
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:56
+#: src/themes/clean/templates/core/accounts/public_profile.html:29
+#: src/themes/material/templates/core/accounts/public_profile.html:29
 msgid "Publications"
 msgstr "Pubblicazioni"
 
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
+#: src/themes/OLH/templates/core/accounts/register.html:29
+#: src/themes/clean/templates/core/accounts/register.html:21
+#: src/themes/material/templates/core/accounts/register.html:19
 #, fuzzy
 #| msgid "Register for"
 msgid "Register for an account with"
 msgstr "Registrati per"
 
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
-#, fuzzy
-#| msgid "Account"
-msgid "account"
-msgstr "Account"
-
-#: src/themes/OLH/templates/core/accounts/register.html:26
-#: src/themes/OLH/templates/core/accounts/reset_password.html:27
-#: src/themes/clean/templates/core/accounts/register.html:18
-#: src/themes/clean/templates/core/accounts/reset_password.html:17
-#: src/themes/material/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/reset_password.html:17
-#, fuzzy
-#| msgid "Password Guide"
-msgid "Password Rules"
-msgstr "Guida password"
-
-#: src/themes/OLH/templates/core/accounts/register.html:28
-#: src/themes/clean/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/register.html:22
-#: src/themes/material/templates/core/accounts/reset_password.html:19
-#, python-format
-msgid "Your password should be %(password_length)s characters long."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:29
-#: src/themes/OLH/templates/core/accounts/reset_password.html:30
-#: src/themes/clean/templates/core/accounts/register.html:21
-#: src/themes/clean/templates/core/accounts/reset_password.html:20
-#: src/themes/material/templates/core/accounts/register.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:20
-msgid "Your password should contain at least one upper case letter.\""
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:30
-#: src/themes/OLH/templates/core/accounts/reset_password.html:31
-#: src/themes/clean/templates/core/accounts/register.html:22
-#: src/themes/clean/templates/core/accounts/reset_password.html:21
-#: src/themes/material/templates/core/accounts/register.html:24
-#: src/themes/material/templates/core/accounts/reset_password.html:21
-#, python-format
-msgid "Your password should contain at least one number.\" %%}"
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/register.html:32
+#: src/themes/OLH/templates/core/accounts/register.html:35
+#: src/themes/OLH/templates/core/accounts/reset_password.html:36
 msgid ""
-"For more information read our <a href=\"#\" data-open=\"password-modal"
-"\">password guide</a>."
+"For more information read our <a href=\"#\" data-open=\"password-"
+"modal\">password guide</a>."
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/register.html:83
-#: src/themes/clean/templates/core/accounts/register.html:27
-#: src/themes/material/templates/core/accounts/register.html:33
-msgid "By registering an account you agree to our"
-msgstr "Registrando un account accetti il ​​nostro"
-
-#: src/themes/OLH/templates/core/accounts/register.html:85
-#: src/themes/OLH/templates/core/accounts/register.html:87
-#: src/themes/OLH/templates/elements/journal_footer.html:25
-#: src/themes/OLH/templates/elements/journal_footer.html:27
-#: src/themes/OLH/templates/press/elements/press_footer.html:9
-#: src/themes/OLH/templates/press/elements/press_footer.html:11
-#: src/themes/clean/templates/core/accounts/register.html:29
-#: src/themes/clean/templates/core/accounts/register.html:31
-#: src/themes/clean/templates/elements/journal_footer.html:33
-#: src/themes/clean/templates/elements/journal_footer.html:37
-#: src/themes/clean/templates/elements/press_footer.html:11
-#: src/themes/clean/templates/elements/press_footer.html:14
-#: src/themes/material/templates/core/accounts/register.html:35
-#: src/themes/material/templates/core/accounts/register.html:37
-#: src/themes/material/templates/elements/journal_footer.html:28
-msgid "Privacy Policy"
-msgstr "Privacy Policy"
-
-#: src/themes/OLH/templates/core/accounts/register.html:106
-#: src/themes/OLH/templates/core/accounts/reset_password.html:48
-#: src/themes/clean/templates/core/accounts/register.html:54
-#: src/themes/clean/templates/core/accounts/reset_password.html:43
-#: src/themes/material/templates/core/accounts/register.html:53
-#: src/themes/material/templates/core/accounts/reset_password.html:41
-msgid "Password Guide"
-msgstr "Guida password"
-
-#: src/themes/OLH/templates/core/accounts/register.html:107
-#: src/themes/OLH/templates/core/accounts/reset_password.html:49
-#: src/themes/clean/templates/core/accounts/reset_password.html:49
+#: src/themes/OLH/templates/core/accounts/register.html:111
+#: src/themes/OLH/templates/core/accounts/reset_password.html:53
+#: src/themes/clean/templates/core/accounts/reset_password.html:53
 #: src/themes/material/templates/core/accounts/register.html:54
-#: src/themes/material/templates/core/accounts/reset_password.html:42
+#: src/themes/material/templates/core/accounts/reset_password.html:44
 msgid "When it comes to passwords, length is better than complexity."
 msgstr ""
 "Quando si tratta di password, la lunghezza è preferibile alla complessità."
 
-#: src/themes/OLH/templates/core/accounts/register.html:108
-#: src/themes/OLH/templates/core/accounts/reset_password.html:50
+#: src/themes/OLH/templates/core/accounts/register.html:112
+#: src/themes/OLH/templates/core/accounts/reset_password.html:54
 #: src/themes/material/templates/core/accounts/register.html:55
-#: src/themes/material/templates/core/accounts/reset_password.html:43
+#: src/themes/material/templates/core/accounts/reset_password.html:45
 msgid ""
 "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
 "secure than a long and uncomplicated password (our awesome moon base rocks)."
@@ -3134,8 +3601,8 @@ msgstr ""
 "più sicura di una password lunga e semplice (le nostre fantastiche rocce "
 "dalla base lunare)."
 
-#: src/themes/OLH/templates/core/accounts/register.html:109
-#: src/themes/OLH/templates/core/accounts/reset_password.html:51
+#: src/themes/OLH/templates/core/accounts/register.html:113
+#: src/themes/OLH/templates/core/accounts/reset_password.html:55
 msgid ""
 "We recommend selecting a long, but easy to remember password such as our "
 "awesome moon base rocks which would take an estimated septillion years to "
@@ -3148,42 +3615,28 @@ msgstr ""
 "\"Jfjfy&65^87\" che richiederebbe poco più di 600 anni su un computer "
 "standard."
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:6
-#: src/themes/OLH/templates/core/accounts/reset_password.html:38
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:4
-#: src/themes/clean/templates/core/accounts/reset_password.html:5
-#: src/themes/clean/templates/core/accounts/reset_password.html:29
-#: src/themes/material/templates/core/accounts/get_reset_token.html:4
-#: src/themes/material/templates/core/accounts/reset_password.html:5
-#: src/themes/material/templates/core/accounts/reset_password.html:29
+#: src/themes/OLH/templates/core/accounts/reset_password.html:10
+#: src/themes/OLH/templates/core/accounts/reset_password.html:42
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:8
+#: src/themes/clean/templates/core/accounts/reset_password.html:9
+#: src/themes/clean/templates/core/accounts/reset_password.html:33
+#: src/themes/hourglass/templates/core/accounts/get_reset_token.html:9
+#: src/themes/hourglass/templates/core/accounts/reset_password.html:10
+#: src/themes/material/templates/core/accounts/get_reset_token.html:8
+#: src/themes/material/templates/core/accounts/reset_password.html:9
+#: src/themes/material/templates/core/accounts/reset_password.html:31
 msgid "Reset Password"
 msgstr "Resetta la password"
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:26
-#: src/themes/clean/templates/core/accounts/reset_password.html:16
-#: src/themes/material/templates/core/accounts/reset_password.html:16
+#: src/themes/OLH/templates/core/accounts/reset_password.html:30
+#: src/themes/clean/templates/core/accounts/reset_password.html:20
+#: src/themes/material/templates/core/accounts/reset_password.html:20
 msgid "Enter your new password twice to complete the reset process"
 msgstr ""
 "Inserisci la nuova password due volte per completare la procedura di "
 "ripristino"
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:29
-#: src/themes/clean/templates/core/accounts/reset_password.html:19
-#, python-format
-msgid ""
-"Your password should be %(request.press.password_length)s characters long."
-msgstr ""
-
-#: src/themes/OLH/templates/core/accounts/reset_password.html:33
-#: src/themes/material/templates/core/accounts/register.html:26
-msgid ""
-"For more information read our\n"
-"                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-"\">password guide</a>\n"
-"                        ."
-msgstr ""
-
-#: src/themes/OLH/templates/core/base.html:60
+#: src/themes/OLH/templates/core/base.html:61
 #: src/themes/OLH/templates/core/nav.html:7
 #: src/themes/OLH/templates/press/nav.html:6
 #: src/themes/OLH/templates/press/press_index.html:5
@@ -3199,18 +3652,6 @@ msgstr ""
 msgid "Home"
 msgstr "Home"
 
-#: src/themes/OLH/templates/core/login.html:27
-#: src/themes/OLH/templates/press/core/login.html:25
-#: src/themes/clean/templates/core/login.html:14
-msgid "Log in with your account"
-msgstr "Accedi con il tuo account"
-
-#: src/themes/OLH/templates/core/login.html:28
-#: src/themes/clean/templates/core/login.html:16
-#: src/themes/material/templates/core/login.html:18
-msgid "Log in with ORCiD"
-msgstr "Accedi con ORCiD"
-
 #: src/themes/OLH/templates/core/login.html:31
 #: src/themes/OLH/templates/press/core/login.html:28
 #: src/themes/clean/templates/core/login.html:20
@@ -3219,38 +3660,6 @@ msgstr "Accedi con ORCiD"
 #| msgid "Login with ORCiD"
 msgid "Login with"
 msgstr "Accedi con ORCiD"
-
-#: src/themes/OLH/templates/core/login.html:43
-#: src/themes/clean/templates/core/login.html:40
-msgid "Log in"
-msgstr "Accedi"
-
-#: src/themes/OLH/templates/core/login.html:44
-#: src/themes/clean/templates/core/login.html:44
-msgid "Forgotten your password?"
-msgstr "Hai dimenticato la password?"
-
-#: src/themes/OLH/templates/core/login.html:45
-#: src/themes/clean/templates/core/login.html:48
-msgid "Register a new account"
-msgstr "Crea un nuovo account"
-
-#: src/themes/OLH/templates/core/nav.html:29
-#: src/themes/OLH/templates/core/nav.html:37
-#: src/themes/OLH/templates/journal/editorial_team.html:10
-#: src/themes/OLH/templates/journal/editorial_team.html:20
-#: src/themes/OLH/templates/press/nav.html:39
-#: src/themes/clean/templates/core/nav.html:32
-#: src/themes/clean/templates/core/nav.html:41
-#: src/themes/clean/templates/journal/editorial_team.html:4
-#: src/themes/clean/templates/journal/editorial_team.html:9
-#: src/themes/material/templates/core/nav.html:36
-#: src/themes/material/templates/core/nav.html:97
-#: src/themes/material/templates/journal/editorial_team.html:11
-#: src/themes/material/templates/preprints/editors.html:5
-#: src/themes/material/templates/preprints/editors.html:6
-msgid "Editorial Team"
-msgstr "Team editoriale"
 
 #: src/themes/OLH/templates/core/nav.html:44
 #: src/themes/OLH/templates/journal/become_reviewer.html:5
@@ -3329,13 +3738,13 @@ msgstr "Modifica articolo"
 msgid "Edit Issue"
 msgstr "Modifica pubblicazione"
 
-#: src/themes/OLH/templates/core/nav.html:66
+#: src/themes/OLH/templates/core/nav.html:65
 #: src/themes/OLH/templates/elements/right_hand_menu.html:31
 #: src/themes/material/templates/core/nav.html:194
 msgid "Edit News Item"
 msgstr "Modifica la notizia"
 
-#: src/themes/OLH/templates/core/nav.html:70
+#: src/themes/OLH/templates/core/nav.html:69
 #: src/themes/OLH/templates/elements/right_hand_menu.html:35
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:8
 #: src/themes/OLH/templates/press/nav.html:51
@@ -3351,7 +3760,7 @@ msgstr "Modifica la notizia"
 msgid "Admin"
 msgstr "Admin"
 
-#: src/themes/OLH/templates/core/nav.html:74
+#: src/themes/OLH/templates/core/nav.html:73
 #: src/themes/OLH/templates/elements/right_hand_menu.html:39
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:13
 #: src/themes/OLH/templates/press/nav.html:55
@@ -3367,42 +3776,43 @@ msgstr "Admin"
 msgid "Logout"
 msgstr "Esci"
 
-#: src/themes/OLH/templates/core/news/index.html:11
-#: src/themes/material/templates/core/news/index.html:11
+#: src/themes/OLH/templates/core/news/index.html:12
+#: src/themes/material/templates/core/news/index.html:12
 #: src/themes/material/templates/press/core/news/index.html:11
 msgid "Filtering tag"
 msgstr "Tag filtrante"
 
-#: src/themes/OLH/templates/core/news/index.html:24
-#: src/themes/OLH/templates/core/news/item.html:24
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:27
-#: src/themes/OLH/templates/press/core/news/index.html:22
-#: src/themes/OLH/templates/press/core/news/item.html:24
-#: src/themes/OLH/templates/press/core/news/item.html:33
-#: src/themes/material/templates/core/news/index.html:30
-#: src/themes/material/templates/core/news/item.html:30
+#: src/themes/OLH/templates/core/news/index.html:25
+#: src/themes/OLH/templates/core/news/item.html:25
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:28
+#: src/themes/OLH/templates/press/core/news/index.html:23
+#: src/themes/OLH/templates/press/core/news/item.html:25
+#: src/themes/OLH/templates/press/core/news/item.html:34
+#: src/themes/hourglass/templates/custom/news-item.html:16
+#: src/themes/material/templates/core/news/index.html:31
+#: src/themes/material/templates/core/news/item.html:31
 #: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
+#: src/themes/material/templates/press/core/news/item.html:18
 msgid "on"
 msgstr "su"
 
-#: src/themes/OLH/templates/core/news/index.html:26
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:29
-#: src/themes/OLH/templates/press/core/news/index.html:24
+#: src/themes/OLH/templates/core/news/index.html:27
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:30
+#: src/themes/OLH/templates/press/core/news/index.html:25
 #: src/themes/clean/templates/core/news/index.html:17
 #: src/themes/clean/templates/press/core/news/index.html:17
-#: src/themes/material/templates/core/news/index.html:34
-#: src/themes/material/templates/journal/homepage_elements/news.html:36
+#: src/themes/material/templates/core/news/index.html:35
+#: src/themes/material/templates/journal/homepage_elements/news.html:37
 #: src/themes/material/templates/press/core/news/index.html:25
 msgid "Read More"
 msgstr "Leggi di più"
 
-#: src/themes/OLH/templates/core/news/index.html:33
+#: src/themes/OLH/templates/core/news/index.html:34
 #: src/themes/material/templates/press/core/news/index.html:30
 msgid "This journal currently has no news items to display."
 msgstr "Al momento questa rivista non ha notizie da mostrare."
 
-#: src/themes/OLH/templates/core/news/item.html:40
+#: src/themes/OLH/templates/core/news/item.html:41
 #: src/themes/clean/templates/core/news/item.html:20
 #: src/themes/clean/templates/press/core/news/item.html:16
 #, fuzzy
@@ -3410,23 +3820,17 @@ msgstr "Al momento questa rivista non ha notizie da mostrare."
 msgid "Tags "
 msgstr "Tag"
 
-#: src/themes/OLH/templates/core/news/item.html:47
+#: src/themes/OLH/templates/core/news/item.html:48
 #: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
+#: src/themes/material/templates/core/news/item.html:44
 msgid "Back to"
 msgstr ""
 
-#: src/themes/OLH/templates/core/news/item.html:47
+#: src/themes/OLH/templates/core/news/item.html:48
 #: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
+#: src/themes/material/templates/core/news/item.html:44
 msgid "List"
 msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
-msgid "Change Your Email Address"
-msgstr "Cambia il tuo indirizzo email"
 
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:8
 #, fuzzy
@@ -3458,62 +3862,12 @@ msgstr ""
 "utente in quanto questi corrispondono. </ P>\n"
 "                "
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
-#, fuzzy
-#| msgid "Email Address"
-msgid "Current Email Address"
-msgstr "Indirizzo email"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
-#, fuzzy
-#| msgid "Email Address"
-msgid "New Email Address"
-msgstr "Indirizzo email"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
-msgid "Update Email Address"
-msgstr "Aggiorna l'indirizzo email"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
-#, fuzzy
-#| msgid "Register for"
-msgid "Register for Article Notifications"
-msgstr "Registrati per"
-
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:31
 #: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:43
 msgid ""
 "Use the button below to register to receive notifications of new articles\n"
 "                            published in this journal "
 msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
-msgid "Unsubscribe from Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
-msgid "Subscribe to Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
-msgid "Update Password"
-msgstr "Aggiorna la password"
 
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:53
 #: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:66
@@ -3524,34 +3878,11 @@ msgstr ""
 "Puoi aggiornare la password inserendo la password esistente e la nuova "
 "password."
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
-msgid "Current Password"
-msgstr "Password attuale"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
-msgid "New Password"
-msgstr "Nuova password"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
-msgid "Enter Password Again"
-msgstr "Inserisci di nuovo la password"
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:41
-#: src/themes/clean/templates/elements/accounts/user_form.html:38
-#: src/themes/material/templates/elements/accounts/user_form.html:39
-msgid "Social Media and Accounts"
-msgstr "Social media e account"
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:95
-#: src/themes/OLH/templates/journal/article.html:108
-#: src/themes/clean/templates/elements/accounts/user_form.html:92
-#: src/themes/material/templates/elements/accounts/user_form.html:93
-msgid "Options"
-msgstr "Opzioni"
+#: src/themes/OLH/templates/elements/accounts/user_form.html:5
+#: src/themes/clean/templates/elements/accounts/user_form.html:5
+#: src/themes/material/templates/elements/accounts/user_form.html:6
+msgid "Core Data"
+msgstr "Dati principali"
 
 #: src/themes/OLH/templates/elements/edit_author.html:5
 msgid "NB."
@@ -3603,13 +3934,13 @@ msgid "Date"
 msgstr "Data"
 
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:26
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:34
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:35
 #: src/themes/OLH/templates/elements/journal/article_list_filters.html:6
 #: src/themes/OLH/templates/elements/journal/search_form.html:19
 #: src/themes/OLH/templates/press/press_journals.html:93
 #: src/themes/OLH/templates/press/press_journals.html:94
 #: src/themes/clean/templates/elements/journal/article_list_filters.html:7
-#: src/themes/clean/templates/journal/articles.html:81
+#: src/themes/clean/templates/journal/articles.html:82
 #: src/themes/clean/templates/journal/full-text-search.html:54
 #: src/themes/clean/templates/press/press_journals.html:56
 #: src/themes/material/templates/journal/articles.html:95
@@ -3619,18 +3950,14 @@ msgstr "Data"
 msgid "Filter"
 msgstr "Filtro"
 
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:36
-#: src/themes/clean/templates/journal/articles.html:84
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:37
+#: src/themes/clean/templates/journal/articles.html:85
 #: src/themes/material/templates/journal/articles.html:109
 msgid "Clear Filters"
 msgstr "Rimuovi filtri"
 
-#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
-#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
-msgid "Apply"
-msgstr ""
-
 #: src/themes/OLH/templates/elements/journal/authors_block.html:4
+#: src/themes/clean/templates/elements/article_listing.html:27
 #: src/themes/clean/templates/elements/journal/authors_block.html:4
 #: src/themes/material/templates/elements/article_listing.html:25
 msgid "and"
@@ -3644,7 +3971,7 @@ msgstr "Anche parte di:"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:5
 #: src/themes/clean/templates/elements/journal/citation_modals.html:6
-#: src/themes/clean/templates/journal/article.html:294
+#: src/themes/clean/templates/journal/article.html:304
 msgid "Harvard-style Citation"
 msgstr "Citazione Harvard Style"
 
@@ -3657,37 +3984,37 @@ msgid "Preprints"
 msgstr "Preprint"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:19
-#: src/themes/OLH/templates/journal/article.html:135
+#: src/themes/OLH/templates/journal/article.html:137
 msgid "Vancouver Citation Style"
 msgstr "Citazione Vancouver Style"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:19
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:40
-#: src/themes/OLH/templates/journal/article.html:136
+#: src/themes/OLH/templates/journal/article.html:138
 msgid "APA Citation Style"
 msgstr "Citazione APA Style"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:27
 #: src/themes/clean/templates/elements/journal/citation_modals.html:28
-#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/clean/templates/journal/article.html:305
 msgid "Vancouver-style Citation"
 msgstr "Citazione Vancouver-Style"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:40
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:63
-#: src/themes/OLH/templates/journal/article.html:134
+#: src/themes/OLH/templates/journal/article.html:136
 msgid "Harvard Citation Style"
 msgstr "Citazione Harvard Style"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:49
 #: src/themes/clean/templates/elements/journal/citation_modals.html:49
-#: src/themes/clean/templates/journal/article.html:296
+#: src/themes/clean/templates/journal/article.html:306
 msgid "APA-style Citation"
 msgstr "Citazione APA-Style"
 
 #: src/themes/OLH/templates/elements/journal/editorial_social_content.html:4
 #: src/themes/clean/templates/elements/journal/editorial_social_content.html:4
-#: src/themes/clean/templates/journal/article.html:283
+#: src/themes/clean/templates/journal/article.html:293
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -3706,17 +4033,45 @@ msgstr "Github"
 msgid "Linkedin"
 msgstr "Linkedin"
 
+#: src/themes/OLH/templates/elements/journal/issue_list.html:16
+#: src/themes/clean/templates/elements/journal/issue_list.html:5
+#: src/themes/clean/templates/journal/issues.html:14
+#: src/themes/material/templates/elements/journal/issue_list.html:16
+#: src/themes/material/templates/elements/journal/issue_list.html:20
+msgid "items"
+msgstr "elementi"
+
+#: src/themes/OLH/templates/elements/journal/issue_list.html:24
+msgid "There are no issues published in this journal yet."
+msgstr "Non ci sono ancora pubblicazioni di questa rivista."
+
+#: src/themes/OLH/templates/elements/journal/issue_list_by_decade.html:3
+#: src/themes/material/templates/elements/journal/issue_list_by_decade.html:3
+msgid ""
+"\n"
+"            Issues are grouped by decade. Select a decade to view the "
+"issues\n"
+"            published during that decade.\n"
+"        "
+msgstr ""
+
 #: src/themes/OLH/templates/elements/journal/issue_sidebar.html:7
-#: src/themes/OLH/templates/journal/article.html:208
-#: src/themes/OLH/templates/journal/article.html:263
+#: src/themes/OLH/templates/journal/article.html:210
+#: src/themes/OLH/templates/journal/article.html:246
+#: src/themes/OLH/templates/journal/article.html:334
 #: src/themes/OLH/templates/repository/preprint.html:114
+#: src/themes/OLH/templates/repository/preprint.html:152
 #: src/themes/clean/templates/elements/journal/issue_sidebar.html:6
-#: src/themes/clean/templates/journal/article.html:102
-#: src/themes/clean/templates/journal/article.html:281
+#: src/themes/clean/templates/journal/article.html:101
+#: src/themes/clean/templates/journal/article.html:184
+#: src/themes/clean/templates/journal/article.html:291
 #: src/themes/material/templates/elements/journal/issue_sidebar.html:5
-#: src/themes/material/templates/journal/article.html:188
+#: src/themes/material/templates/journal/article.html:123
+#: src/themes/material/templates/journal/article.html:169
+#: src/themes/material/templates/journal/article.html:273
 #: src/themes/material/templates/preprints/article.html:133
-#: src/themes/material/templates/repository/preprint.html:132
+#: src/themes/material/templates/repository/preprint.html:130
+#: src/themes/material/templates/repository/preprint.html:203
 msgid "Downloads"
 msgstr "Download"
 
@@ -3776,11 +4131,11 @@ msgid "Sort articles by"
 msgstr "Il titolo dell'articolo"
 
 #: src/themes/OLH/templates/elements/journal/summary_modal.html:3
-#: src/themes/OLH/templates/journal/article.html:437
+#: src/themes/OLH/templates/journal/article.html:428
 #: src/themes/clean/templates/elements/journal/summary_modal.html:6
-#: src/themes/clean/templates/journal/article.html:250
+#: src/themes/clean/templates/journal/article.html:260
 #: src/themes/material/templates/elements/summary_modal.html:5
-#: src/themes/material/templates/journal/article.html:380
+#: src/themes/material/templates/journal/article.html:382
 msgid "Non Specialist Summary"
 msgstr "Riepilogo non specializzato"
 
@@ -3845,9 +4200,9 @@ msgid "Public Submissions"
 msgstr "Proposte pubbliche"
 
 #: src/themes/OLH/templates/elements/section_block.html:12
-#: src/themes/OLH/templates/journal/article.html:298
+#: src/themes/OLH/templates/journal/article.html:279
 #: src/themes/clean/templates/elements/sections_block.html:9
-#: src/themes/clean/templates/journal/article.html:242
+#: src/themes/clean/templates/journal/article.html:252
 #: src/themes/material/templates/elements/sections_display.html:11
 msgid "Peer Reviewed"
 msgstr "Peer reviewed"
@@ -3940,7 +4295,7 @@ msgstr "Articolo"
 
 #: src/themes/OLH/templates/journal/article.html:28
 #: src/themes/OLH/templates/journal/article.html:64
-#: src/themes/OLH/templates/journal/article.html:159
+#: src/themes/OLH/templates/journal/article.html:162
 #: src/themes/OLH/templates/journal/print.html:15
 #: src/themes/clean/templates/journal/article.html:38
 #: src/themes/clean/templates/journal/print.html:15
@@ -3948,41 +4303,86 @@ msgid "Author"
 msgstr "Autore"
 
 #: src/themes/OLH/templates/journal/article.html:115
-#: src/themes/material/templates/journal/article.html:250
+#: src/themes/clean/templates/journal/article.html:172
+#: src/themes/material/templates/journal/article.html:231
 msgid "Share"
 msgstr "Condividi"
 
+#: src/themes/OLH/templates/journal/article.html:116
+#: src/themes/clean/templates/journal/article.html:176
+#: src/themes/material/templates/journal/article.html:236
+#, fuzzy
+#| msgid "Facebook"
+msgid "Share on Facebook"
+msgstr "Facebook"
+
+#: src/themes/OLH/templates/journal/article.html:118
+#: src/themes/clean/templates/journal/article.html:179
+#: src/themes/material/templates/journal/article.html:239
+#, fuzzy
+#| msgid "Share"
+msgid "Share on X"
+msgstr "Condividi"
+
+#: src/themes/OLH/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:182
+#: src/themes/material/templates/journal/article.html:242
+msgid "Share on LinkedIn"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:128
+#, fuzzy
+#| msgid "Edit Article"
+msgid "print article"
+msgstr "Modifica articolo"
+
+#: src/themes/OLH/templates/journal/article.html:129
+msgid "decrease text size"
+msgstr ""
+
 #: src/themes/OLH/templates/journal/article.html:130
+msgid "increase text size"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:132
+#, fuzzy
+#| msgid "Dyslexia"
+msgid "Dyslexia mode"
+msgstr "Dislessia"
+
+#: src/themes/OLH/templates/journal/article.html:132
 msgid "Dyslexia"
 msgstr "Dislessia"
 
-#: src/themes/OLH/templates/journal/article.html:137
-#: src/themes/OLH/templates/journal/article.html:210
-#: src/themes/OLH/templates/journal/article.html:353
-#: src/themes/OLH/templates/journal/article.html:357
+#: src/themes/OLH/templates/journal/article.html:134
+#, fuzzy
+#| msgid "Edit Article"
+msgid "Cite article"
+msgstr "Modifica articolo"
+
+#: src/themes/OLH/templates/journal/article.html:139
+#: src/themes/OLH/templates/journal/article.html:213
+#: src/themes/OLH/templates/journal/article.html:339
 #: src/themes/clean/templates/journal/article.html:104
-#: src/themes/clean/templates/journal/article.html:186
-#: src/themes/clean/templates/journal/article.html:191
-#: src/themes/clean/templates/journal/article.html:298
-#: src/themes/clean/templates/journal/article.html:301
+#: src/themes/clean/templates/journal/article.html:190
+#: src/themes/clean/templates/journal/article.html:308
+#: src/themes/clean/templates/journal/article.html:311
 #: src/themes/material/templates/elements/journal/issue_sidebar.html:8
-#: src/themes/material/templates/journal/article.html:124
 #: src/themes/material/templates/journal/article.html:127
-#: src/themes/material/templates/journal/article.html:293
-#: src/themes/material/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:279
 #: src/themes/material/templates/preprints/article.html:113
 #: src/themes/material/templates/preprints/article.html:117
 #: src/themes/material/templates/preprints/article.html:139
 msgid "Download"
 msgstr "Download"
 
-#: src/themes/OLH/templates/journal/article.html:138
+#: src/themes/OLH/templates/journal/article.html:140
 #, fuzzy
 #| msgid "Download"
 msgid " Download"
 msgstr "Download"
 
-#: src/themes/OLH/templates/journal/article.html:183
+#: src/themes/OLH/templates/journal/article.html:186
 #: src/themes/OLH/templates/journal/print.html:35
 #: src/themes/clean/templates/journal/article.html:89
 #: src/themes/clean/templates/journal/print.html:35
@@ -3990,139 +4390,158 @@ msgstr "Download"
 msgid "How to Cite"
 msgstr "Come citare"
 
-#: src/themes/OLH/templates/journal/article.html:190
+#: src/themes/OLH/templates/journal/article.html:193
 #: src/themes/clean/templates/journal/article.html:95
 #: src/themes/material/templates/journal/article.html:101
 msgid "Rights"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:195
-#: src/themes/clean/templates/journal/article.html:143
+#: src/themes/OLH/templates/journal/article.html:198
+#: src/themes/clean/templates/journal/article.html:129
 #: src/themes/material/templates/journal/article.html:110
 msgid "Publisher Notes"
 msgstr "Note dell'editore"
 
-#: src/themes/OLH/templates/journal/article.html:213
-#: src/themes/OLH/templates/journal/article.html:361
+#: src/themes/OLH/templates/journal/article.html:216
+#: src/themes/OLH/templates/journal/article.html:343
 #, fuzzy
 #| msgid "View"
 msgid "View PDF"
 msgstr "Vista"
 
-#: src/themes/OLH/templates/journal/article.html:239
-#, python-format
-msgid ""
-"\n"
-"                                                        (grant %(id)s)\n"
-"                                                    "
+#: src/themes/OLH/templates/journal/article.html:227
+#: src/themes/OLH/templates/journal/article.html:356
+#: src/themes/clean/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:207
+#: src/themes/material/templates/journal/article.html:143
+#: src/themes/material/templates/journal/article.html:298
+msgid "Downloads are not available for this article."
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:257
-#: src/themes/clean/templates/journal/article.html:280
-#: src/themes/material/templates/journal/article.html:182
+#: src/themes/OLH/templates/journal/article.html:240
+#: src/themes/OLH/templates/repository/preprint.html:151
+#: src/themes/clean/templates/journal/article.html:290
+#: src/themes/material/templates/journal/article.html:163
 #: src/themes/material/templates/preprints/article.html:132
+#: src/themes/material/templates/repository/preprint.html:202
 msgid "Views"
 msgstr "Visualizzazioni"
 
-#: src/themes/OLH/templates/journal/article.html:269
-#: src/themes/clean/templates/journal/article.html:289
-#: src/themes/material/templates/journal/article.html:220
+#: src/themes/OLH/templates/journal/article.html:253
+#: src/themes/clean/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:201
 msgid "Citations"
 msgstr "Citazioni"
 
-#: src/themes/OLH/templates/journal/article.html:283
-#: src/themes/clean/templates/journal/article.html:221
+#: src/themes/OLH/templates/journal/article.html:267
+#: src/themes/clean/templates/journal/article.html:233
+#: src/themes/material/templates/journal/article.html:354
 #: src/themes/material/templates/preprints/article.html:123
 msgid "Published on"
 msgstr "Pubblicato su"
 
 #: src/themes/OLH/templates/journal/article.html:287
-#: src/themes/clean/templates/journal/article.html:224
-msgid "Accepted on"
-msgstr "Accettato "
-
-#: src/themes/OLH/templates/journal/article.html:306
-#: src/themes/OLH/templates/repository/preprint.html:126
-#: src/themes/clean/templates/journal/article.html:245
+#: src/themes/OLH/templates/repository/preprint.html:127
+#: src/themes/clean/templates/journal/article.html:255
 #: src/themes/material/templates/preprints/article.html:124
-#: src/themes/material/templates/repository/preprint.html:190
+#: src/themes/material/templates/repository/preprint.html:189
 msgid "License"
 msgstr "Licenza"
 
-#: src/themes/OLH/templates/journal/article.html:374
+#: src/themes/OLH/templates/journal/article.html:359
 msgid "Downloads are not available until this article is published "
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:383
-#: src/themes/material/templates/journal/article.html:434
+#: src/themes/OLH/templates/journal/article.html:368
+#: src/themes/material/templates/journal/article.html:410
 msgid "Identifiers"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:393
-#: src/themes/material/templates/journal/article.html:326
+#: src/themes/OLH/templates/journal/article.html:378
+#: src/themes/material/templates/journal/article.html:308
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Publication details"
 msgstr "Tariffe di pubblicazione"
 
-#: src/themes/OLH/templates/journal/article.html:396
-#: src/themes/clean/templates/journal/article.html:227
-#: src/themes/material/templates/journal/article.html:330
+#: src/themes/OLH/templates/journal/article.html:381
+#: src/themes/clean/templates/journal/article.html:237
+#: src/themes/material/templates/journal/article.html:312
 msgid "Pages"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:399
-#: src/themes/clean/templates/journal/article.html:230
+#: src/themes/OLH/templates/journal/article.html:384
+#: src/themes/clean/templates/journal/article.html:240
 #, fuzzy
 #| msgid "Grant Number"
 msgid "Article Number"
 msgstr "Numero del fondo di finanziamento"
 
-#: src/themes/OLH/templates/journal/article.html:402
-#: src/themes/clean/templates/journal/article.html:233
-#: src/themes/material/templates/journal/article.html:342
+#: src/themes/OLH/templates/journal/article.html:387
+#: src/themes/clean/templates/journal/article.html:243
+#: src/themes/material/templates/journal/article.html:324
 #, fuzzy
 #| msgid "Published"
 msgid "Publisher"
 msgstr "Pubblicato"
 
-#: src/themes/OLH/templates/journal/article.html:405
-#: src/themes/clean/templates/journal/article.html:236
+#: src/themes/OLH/templates/journal/article.html:390
+#: src/themes/clean/templates/journal/article.html:246
 #, fuzzy
 #| msgid "Publications"
 msgid "Original Publication"
 msgstr "Pubblicazioni"
 
-#: src/themes/OLH/templates/journal/article.html:408
-#: src/themes/clean/templates/journal/article.html:239
-#: src/themes/material/templates/journal/article.html:354
+#: src/themes/OLH/templates/journal/article.html:393
+#: src/themes/clean/templates/journal/article.html:249
+#: src/themes/material/templates/journal/article.html:336
 msgid "Original ISSN"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:416
-#: src/themes/clean/templates/journal/article.html:209
-#: src/themes/material/templates/journal/article.html:366
-#: src/themes/material/templates/repository/preprint.html:140
+#: src/themes/OLH/templates/journal/article.html:396
+#: src/themes/clean/templates/journal/article.html:223
+#: src/themes/material/templates/journal/article.html:342
+#, fuzzy
+#| msgid "Submitted"
+msgid "Submitted on"
+msgstr "Inviato"
+
+#: src/themes/OLH/templates/journal/article.html:399
+#: src/themes/clean/templates/journal/article.html:228
+#: src/themes/material/templates/journal/article.html:348
+msgid "Accepted on"
+msgstr "Accettato "
+
+#: src/themes/OLH/templates/journal/article.html:407
+#: src/themes/clean/templates/journal/article.html:211
+#: src/themes/material/templates/journal/article.html:368
+#: src/themes/material/templates/repository/preprint.html:138
 msgid "Supplementary Files"
 msgstr "File supplementari"
 
-#: src/themes/OLH/templates/journal/article.html:439
-#: src/themes/material/templates/journal/article.html:381
+#: src/themes/OLH/templates/journal/article.html:430
+#: src/themes/material/templates/journal/article.html:383
 msgid "View Summary"
 msgstr "Visualizza riepilogo"
 
-#: src/themes/OLH/templates/journal/article.html:446
+#: src/themes/OLH/templates/journal/article.html:437
 msgid "Jump to"
 msgstr "Vai a"
 
-#: src/themes/OLH/templates/journal/article.html:472
-#: src/themes/clean/templates/journal/article.html:305
-#: src/themes/material/templates/journal/article.html:478
+#: src/themes/OLH/templates/journal/article.html:463
+#: src/themes/clean/templates/journal/article.html:324
+#: src/themes/material/templates/journal/article.html:464
 msgid "File Checksums"
 msgstr "Checksum dei file"
 
-#: src/themes/OLH/templates/journal/article.html:485
-#: src/themes/material/templates/journal/article.html:446
+#: src/themes/OLH/templates/journal/article.html:473
+#: src/themes/clean/templates/journal/article.html:334
+#: src/themes/material/templates/journal/article.html:475
+msgid "File Checksums are not available for this article."
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:480
+#: src/themes/material/templates/journal/article.html:422
 msgid "Peer Review"
 msgstr "Peer review"
 
@@ -4158,7 +4577,6 @@ msgstr "Raccolta"
 
 #: src/themes/OLH/templates/journal/collections.html:29
 #: src/themes/OLH/templates/repository/preprint.html:124
-#: src/themes/material/templates/journal/article.html:400
 msgid "Published"
 msgstr "Pubblicato"
 
@@ -4193,21 +4611,21 @@ msgstr "Riviste in primo piano"
 msgid "Unnamed Journal"
 msgstr "Rivista senza nome"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
 #: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
 #, fuzzy
 #| msgid "Dates"
 msgid "Latest"
 msgstr "Date"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
 #: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
 msgid "Posts"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:35
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:36
 #: src/themes/clean/templates/press/core/news/index.html:21
 msgid "This journal currently has no news items to display"
 msgstr "Al momento questa rivista non ha notizie da mostrare"
@@ -4222,18 +4640,6 @@ msgstr "Articoli più popolari"
 #: src/themes/clean/templates/journal/homepage_elements/preprints.html:6
 msgid "Featured Preprints"
 msgstr "Preprints in evidenza"
-
-#: src/themes/OLH/templates/journal/issues.html:31
-#: src/themes/clean/templates/journal/issues.html:19
-#: src/themes/clean/templates/journal/issues.html:28
-#: src/themes/material/templates/journal/issues.html:29
-#: src/themes/material/templates/journal/issues.html:31
-msgid "items"
-msgstr "elementi"
-
-#: src/themes/OLH/templates/journal/issues.html:39
-msgid "There are no issues published in this journal yet."
-msgstr "Non ci sono ancora pubblicazioni di questa rivista."
 
 #: src/themes/OLH/templates/journal/keyword.html:6
 #: src/themes/OLH/templates/journal/keyword.html:12
@@ -4279,37 +4685,38 @@ msgstr "Proposte"
 msgid "Login with ORCiD"
 msgstr "Accedi con ORCiD"
 
-#: src/themes/OLH/templates/press/core/news/index.html:5
-#: src/themes/OLH/templates/press/core/news/index.html:10
-#: src/themes/OLH/templates/press/core/news/item.html:5
+#: src/themes/OLH/templates/press/core/news/index.html:6
+#: src/themes/OLH/templates/press/core/news/index.html:11
+#: src/themes/OLH/templates/press/core/news/item.html:6
 #: src/themes/clean/templates/press/core/news/index.html:9
 #: src/themes/clean/templates/press/nav.html:16
+#: src/themes/hourglass/templates/press/news/index.html:4
 #: src/themes/material/templates/core/nav.html:88
 #: src/themes/material/templates/press/core/news/index.html:5
 #: src/themes/material/templates/press/core/news/index.html:10
-#: src/themes/material/templates/press/core/news/item.html:5
+#: src/themes/material/templates/press/core/news/item.html:6
 msgid "News"
 msgstr "Notizie"
 
-#: src/themes/OLH/templates/press/core/news/index.html:31
+#: src/themes/OLH/templates/press/core/news/index.html:32
 msgid "This press currently has no news items to display."
 msgstr "Questa casa editrice al momento non ha notizie da mostrare."
 
-#: src/themes/OLH/templates/press/core/news/item.html:33
+#: src/themes/OLH/templates/press/core/news/item.html:34
 #: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
+#: src/themes/material/templates/press/core/news/item.html:18
 msgid "Posted by"
 msgstr "Pubblicato da"
 
-#: src/themes/OLH/templates/press/core/news/item.html:40
-#: src/themes/material/templates/core/news/item.html:35
-#: src/themes/material/templates/press/core/news/item.html:22
+#: src/themes/OLH/templates/press/core/news/item.html:41
+#: src/themes/material/templates/core/news/item.html:36
+#: src/themes/material/templates/press/core/news/item.html:23
 msgid "Tags"
 msgstr "Tag"
 
-#: src/themes/OLH/templates/press/core/news/item.html:45
+#: src/themes/OLH/templates/press/core/news/item.html:46
 #: src/themes/clean/templates/press/core/news/item.html:18
-#: src/themes/material/templates/press/core/news/item.html:30
+#: src/themes/material/templates/press/core/news/item.html:31
 msgid "Back to News List"
 msgstr "Torna all'elenco delle notizie"
 
@@ -4322,6 +4729,7 @@ msgstr "Mappa del sito"
 #: src/themes/OLH/templates/press/press_journals.html:5
 #: src/themes/clean/templates/press/nav.html:37
 #: src/themes/clean/templates/press/press_journals.html:10
+#: src/themes/hourglass/templates/press/press_journals.html:9
 #: src/themes/material/templates/press/press_journals.html:9
 msgid "Journals"
 msgstr "Riviste"
@@ -4337,16 +4745,22 @@ msgstr "Conferenze"
 msgid "Repositories"
 msgstr ""
 
+#: src/themes/OLH/templates/press/nav.html:39
+#: src/themes/material/templates/preprints/editors.html:5
+#: src/themes/material/templates/preprints/editors.html:6
+msgid "Editorial Team"
+msgstr "Team editoriale"
+
 #: src/themes/OLH/templates/press/press_journals.html:48
 msgid "Disciplines"
 msgstr "Discipline"
 
 #: src/themes/OLH/templates/press/press_journals.html:61
 #: src/themes/OLH/templates/press/press_journals.html:68
-#: src/themes/clean/templates/journal/article.html:195
+#: src/themes/clean/templates/journal/article.html:194
 #: src/themes/clean/templates/press/press_journals.html:32
 #: src/themes/clean/templates/press/press_journals.html:39
-#: src/themes/material/templates/journal/article.html:303
+#: src/themes/material/templates/journal/article.html:283
 #: src/themes/material/templates/press/press_journals.html:36
 #: src/themes/material/templates/press/press_journals.html:43
 msgid "View"
@@ -4402,7 +4816,7 @@ msgstr "Affiliazione dell'autore"
 #: src/themes/OLH/templates/repository/nav.html:6
 #: src/themes/material/templates/repository/nav.html:21
 #: src/themes/material/templates/repository/nav.html:45
-#: src/themes/material/templates/repository/preprint.html:168
+#: src/themes/material/templates/repository/preprint.html:166
 #, fuzzy
 #| msgid "Subject"
 msgid "Subjects"
@@ -4417,7 +4831,7 @@ msgstr "Preprint"
 
 #: src/themes/OLH/templates/repository/preprint.html:60
 #: src/themes/material/templates/preprints/article.html:63
-#: src/themes/material/templates/repository/preprint.html:87
+#: src/themes/material/templates/repository/preprint.html:85
 msgid "Comments"
 msgstr "Commenti"
 
@@ -4441,16 +4855,23 @@ msgstr ""
 msgid "Last Updated"
 msgstr "Aggiorna"
 
-#: src/themes/OLH/templates/repository/preprint.html:134
+#: src/themes/OLH/templates/repository/preprint.html:138
 #: src/themes/material/templates/preprints/article.html:135
 msgid "Versions"
 msgstr "Versioni"
 
-#: src/themes/OLH/templates/repository/preprint.html:139
+#: src/themes/OLH/templates/repository/preprint.html:143
 msgid "This is the only version of the preprint."
 msgstr "Questa è l'unica versione del preprint."
 
-#: src/themes/OLH/templates/repository/preprint.html:143
+#: src/themes/OLH/templates/repository/preprint.html:149
+#: src/themes/clean/templates/journal/article.html:288
+#: src/themes/material/templates/preprints/article.html:130
+#: src/themes/material/templates/repository/preprint.html:201
+msgid "Metrics"
+msgstr "Metrica"
+
+#: src/themes/OLH/templates/repository/preprint.html:156
 #: src/themes/material/templates/preprints/article.html:152
 #: src/themes/material/templates/preprints/list.html:6
 #: src/themes/material/templates/preprints/list.html:14
@@ -4461,16 +4882,11 @@ msgstr "Tutti i preprint"
 msgid "You do not have permission to view this page"
 msgstr ""
 
-#: src/themes/clean/templates/500.html:21
-#: src/themes/clean/templates/core/base.html:37
-msgid "Skip to main content"
-msgstr ""
-
 #: src/themes/clean/templates/500.html:27
 msgid "A server error has occurred."
 msgstr ""
 
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:10
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:14
 msgid ""
 "The ORCiD you logged in with is not currently linked with an account in our "
 "system. You can either\n"
@@ -4481,15 +4897,12 @@ msgstr ""
 "sul nostro sistema. Puoi creare un nuovo account, o fare il log in con un "
 "account già esistente a cui connettere il tuo ORCiD per uso futuro."
 
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:34
 msgid "Forgot your password"
 msgstr "Password dimenticata"
 
-#: src/themes/clean/templates/core/accounts/public_profile.html:10
-msgid "profile photo"
-msgstr "foto del profilo"
-
-#: src/themes/clean/templates/core/accounts/register.html:24
+#: src/themes/clean/templates/core/accounts/register.html:26
+#: src/themes/clean/templates/core/accounts/reset_password.html:26
 msgid ""
 "For more information read our <a href=\"#\" data-toggle=\"modal\" data-"
 "target=\"#passwordmodal\">password guide</a>."
@@ -4526,16 +4939,7 @@ msgstr ""
 "come <em>Jfjfy&65^87</em> che richiederebbe poco più di 600 anni su un "
 "computer standard."
 
-#: src/themes/clean/templates/core/accounts/reset_password.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:23
-msgid ""
-"For more information read our\n"
-"                                    <a href=\"#passwordmodal\" class=\"modal-"
-"trigger\">password guide</a>\n"
-"                                    ."
-msgstr ""
-
-#: src/themes/clean/templates/core/accounts/reset_password.html:50
+#: src/themes/clean/templates/core/accounts/reset_password.html:54
 msgid ""
 "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
 "secure than a long and\n"
@@ -4545,7 +4949,7 @@ msgstr ""
 "sicura di una lunga e semplice (le nostre fantastiche rocce dalla base "
 "lunare)."
 
-#: src/themes/clean/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/reset_password.html:56
 msgid ""
 "We recommend selecting a long, but easy to remember password such as <em>our "
 "awesome moon base\n"
@@ -4612,10 +5016,22 @@ msgstr "Inserisci la nuova password"
 msgid "Enter New Password Again"
 msgstr "Inserisci di nuovo la nuova password"
 
+#: src/themes/clean/templates/elements/journal/issue_list.html:8
+msgid "This journal has no issues"
+msgstr "Questa rivista non ha pubblicazioni"
+
+#: src/themes/clean/templates/elements/journal/issue_list_by_decade.html:2
+msgid ""
+"\n"
+"        Issues are grouped by decade. Select a decade to view the issues\n"
+"        published during that decade.\n"
+"    "
+msgstr ""
+
 #: src/themes/clean/templates/elements/journal/table_modal.html:12
 #: src/themes/clean/templates/elements/public_reviews.html:35
 #: src/themes/material/templates/core/accounts/register.html:61
-#: src/themes/material/templates/core/accounts/reset_password.html:49
+#: src/themes/material/templates/core/accounts/reset_password.html:51
 #: src/themes/material/templates/elements/summary_modal.html:13
 msgid "Close"
 msgstr "Chiudi"
@@ -4645,47 +5061,28 @@ msgstr ""
 msgid "Sections submission information"
 msgstr "Informazione per l'invio delle sezioni"
 
-#: src/themes/clean/templates/journal/article.html:133
-#, python-format
-msgid ""
-"\n"
-"                                        (grant %(id)s)\n"
-"                                    "
-msgstr ""
-
-#: src/themes/clean/templates/journal/article.html:268
+#: src/themes/clean/templates/journal/article.html:278
 #, fuzzy
 #| msgid "Peer Review"
 msgid "Open Peer Reviews"
 msgstr "Peer review"
 
-#: src/themes/clean/templates/journal/article.html:278
-#: src/themes/material/templates/preprints/article.html:130
-msgid "Metrics"
-msgstr "Metrica"
-
-#: src/themes/clean/templates/journal/article.html:285
-#: src/themes/material/templates/journal/article.html:203
+#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/material/templates/journal/article.html:184
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: src/themes/clean/templates/journal/article.html:287
-#: src/themes/material/templates/journal/article.html:211
+#: src/themes/clean/templates/journal/article.html:297
+#: src/themes/material/templates/journal/article.html:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/themes/clean/templates/journal/article.html:292
+#: src/themes/clean/templates/journal/article.html:302
 #: src/themes/material/templates/preprints/article.html:145
 msgid "Citation"
 msgstr "Citazione"
 
-#: src/themes/clean/templates/journal/article.html:317
-#: src/themes/material/templates/journal/article.html:494
-#: src/themes/material/templates/journal/submissions.html:72
-msgid "Table of Contents"
-msgstr "Sommario"
-
-#: src/themes/clean/templates/journal/article.html:343
+#: src/themes/clean/templates/journal/article.html:366
 msgid "View Larger Table"
 msgstr ""
 
@@ -4701,7 +5098,7 @@ msgstr "Sezioni"
 
 #: src/themes/clean/templates/journal/authors.html:26
 #: src/themes/material/templates/journal/authors.html:31
-#: src/themes/material/templates/journal/editorial_team.html:36
+#: src/themes/material/templates/journal/editorial_team.html:34
 #, fuzzy
 #| msgid "Edit Profile"
 msgid "View Profile"
@@ -4733,13 +5130,9 @@ msgstr "Seguente"
 msgid "Play"
 msgstr "Play"
 
-#: src/themes/clean/templates/journal/issues.html:16
+#: src/themes/clean/templates/journal/issues.html:14
 msgid "The current issue is"
 msgstr "La pubblicazione corrente è"
-
-#: src/themes/clean/templates/journal/issues.html:30
-msgid "This journal has no issues"
-msgstr "Questa rivista non ha pubblicazioni"
 
 #: src/themes/clean/templates/press/press_journals.html:52
 #, fuzzy
@@ -4752,7 +5145,65 @@ msgstr "Questa rivista non ha pubblicazioni"
 msgid "Start typing to filter."
 msgstr ""
 
-#: src/themes/material/templates/core/accounts/activate_account.html:25
+#: src/themes/hourglass/templates/core/accounts/orcid_registration.html:10
+#, fuzzy
+#| msgid "Unregistered ORCiD"
+msgid "Unregistered ORCID"
+msgstr "ORCiD non registrato"
+
+#: src/themes/hourglass/templates/custom/get-reset-token.html:27
+#, fuzzy
+#| msgid "Enter your email address to begin the reset process"
+msgid ""
+"\n"
+"                  Enter your email address to begin the reset process\n"
+"                "
+msgstr ""
+"Inserisci il tuo indirizzo email per iniziare il processo di ripristino"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:19
+#, fuzzy
+#| msgid ""
+#| "The ORCiD you logged in with is not currently linked with an account in "
+#| "our system. You can either register a new account, or login with an "
+#| "existing account to link your ORCiD for future use."
+msgid ""
+"\n"
+"          <p>The ORCiD you logged in with is not currently linked with\n"
+"          an account in our system. You can either register a new account, "
+"or\n"
+"          login with an existing account to link your ORCiD for future use.</"
+"p>\n"
+"        "
+msgstr ""
+"L'ORCiD con cui hai fatto il log in non è al momento connesso con un account "
+"sul nostro sistema. Puoi creare un nuovo account, o fare il log in con un "
+"account già esistente a cui connettere il tuo ORCiD per uso futuro."
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:43
+#, fuzzy
+#| msgid "Register an Account"
+msgid "Register an account"
+msgstr "Registra un account"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:46
+#, fuzzy
+#| msgid "Reset Your Password"
+msgid "Reset your password"
+msgstr "Reimposta la tua password"
+
+#: src/themes/hourglass/templates/custom/profile.html:40
+msgid ""
+"\n"
+"                    Please note: If you update your email,\n"
+"                    You will be logged out, and you won't be\n"
+"                    able to log in again until you follow\n"
+"                    the verification link in an email\n"
+"                    sent to your new email address.\n"
+"                  "
+msgstr ""
+
+#: src/themes/material/templates/core/accounts/activate_account.html:29
 msgid ""
 "There was no inactive account with this activation code found. It is "
 "possible that your account is already active, you can check by attempting to "
@@ -4760,8 +5211,15 @@ msgstr ""
 "Nessun account inattivo trovato con questo codice di attivazione. E' "
 "possibile che il tuo account sia già attivo, puoi verificarlo provando a "
 
+#: src/themes/material/templates/core/accounts/register.html:29
+#: src/themes/material/templates/core/accounts/reset_password.html:26
+msgid ""
+"For more information read our <a href=\"#\" data-target=\"passwordmodal\" "
+"class=\"modal-trigger\">password guide</a>."
+msgstr ""
+
 #: src/themes/material/templates/core/accounts/register.html:56
-#: src/themes/material/templates/core/accounts/reset_password.html:44
+#: src/themes/material/templates/core/accounts/reset_password.html:46
 msgid ""
 "We recommend selecting a long, but easy to remember password such as <i>our "
 "awesome moon base\n"
@@ -4790,7 +5248,7 @@ msgstr "Registra un account"
 msgid "Reset Your Password"
 msgstr "Reimposta la tua password"
 
-#: src/themes/material/templates/core/news/index.html:39
+#: src/themes/material/templates/core/news/index.html:40
 #, fuzzy
 #| msgid "This journal currently has no news items to display."
 msgid "This journal currently has no items to display."
@@ -4836,57 +5294,45 @@ msgstr "Puoi esportare i tuoi dati in un file JSON per riutilizzarli."
 msgid "Export"
 msgstr "Esportare"
 
+#: src/themes/material/templates/elements/journal/issue_list.html:26
+#, fuzzy
+#| msgid "Close"
+msgid "close"
+msgstr "Chiudi"
+
+#: src/themes/material/templates/elements/journal/issue_list.html:30
+msgid "View Issue"
+msgstr "Visualizza la pubblicazione"
+
 #: src/themes/material/templates/elements/license_block.html:4
 #, fuzzy
 #| msgid "Author Information"
 msgid "More Information "
 msgstr "Informazioni sull'autore"
 
-#: src/themes/material/templates/journal/article.html:161
-#, python-format
-msgid ""
-"\n"
-"                                                (grant %(id)s)\n"
-"                                            "
-msgstr ""
-
-#: src/themes/material/templates/journal/article.html:195
+#: src/themes/material/templates/journal/article.html:176
 msgid "Tweets"
 msgstr "Tweets"
 
-#: src/themes/material/templates/journal/article.html:336
+#: src/themes/material/templates/journal/article.html:318
 #, fuzzy
 #| msgid "Article Info"
 msgid "Article No."
 msgstr "Informazioni sull'articolo"
 
-#: src/themes/material/templates/journal/article.html:348
+#: src/themes/material/templates/journal/article.html:330
 #, fuzzy
 #| msgid "Publications"
 msgid "Publication"
 msgstr "Pubblicazioni"
 
-#: src/themes/material/templates/journal/article.html:389
-msgid "Dates"
-msgstr "Date"
-
-#: src/themes/material/templates/journal/article.html:450
+#: src/themes/material/templates/journal/article.html:426
 msgid "This article has been peer reviewed."
 msgstr "Questo articolo è stato soggetto a peer review."
 
 #: src/themes/material/templates/journal/collections.html:33
 msgid "View Collection"
 msgstr "Visualizza raccolta"
-
-#: src/themes/material/templates/journal/issues.html:35
-#, fuzzy
-#| msgid "Close"
-msgid "close"
-msgstr "Chiudi"
-
-#: src/themes/material/templates/journal/issues.html:39
-msgid "View Issue"
-msgstr "Visualizza la pubblicazione"
 
 #: src/themes/material/templates/journal/new_search.html:26
 #: src/themes/material/templates/journal/search.html:28
@@ -4951,31 +5397,99 @@ msgstr "Istituzione dell'autore"
 msgid "Start New Submission"
 msgstr "Inizia la proposta"
 
-#: src/themes/material/templates/repository/preprint.html:70
+#: src/themes/material/templates/repository/preprint.html:68
 #, fuzzy
 #| msgid "Comments"
 msgid "Add a Comment"
 msgstr "Commenti"
 
-#: src/utils/forms.py:102
+#: src/utils/forms.py:107
 #, fuzzy, python-format
 #| msgid "What is %(num1)i %(operator)s %(num2)i? "
 msgid "What is %(num1)i %(operator)s %(num2)i? "
 msgstr "Cos'è % (num1)i% (operatore)s %(num2)i? "
 
-#: src/utils/forms.py:103
+#: src/utils/forms.py:108
 msgid "Answer this question: "
 msgstr "Rispondi a questa domanda: "
 
-#: src/utils/transactional_emails.py:370
+#: src/utils/forms.py:153
+msgid "HTML is not allowed in this field"
+msgstr ""
+
+#: src/utils/transactional_emails.py:385
 #, fuzzy
 #| msgid "Accepted"
 msgid "accepted"
 msgstr "Accettato"
 
-#: src/utils/transactional_emails.py:380
+#: src/utils/transactional_emails.py:395
 msgid "declined"
 msgstr ""
+
+#~ msgid "Password 1"
+#~ msgstr "Password 1"
+
+#~ msgid "Password 2"
+#~ msgstr "Password 2"
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to create a typesetting assignment?"
+#~ msgstr ""
+#~ "Inserisci la nuova password due volte per completare la procedura di "
+#~ "ripristino"
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to create a proofreading assignment?"
+#~ msgstr ""
+#~ "Inserisci la nuova password due volte per completare la procedura di "
+#~ "ripristino"
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to complete the proofreading task?"
+#~ msgstr ""
+#~ "Inserisci la nuova password due volte per completare la procedura di "
+#~ "ripristino"
+
+#~ msgid ""
+#~ "Please avoid pasting content from word processors as they can add "
+#~ "unwanted styling to the abstract. You can retype the abstract here or "
+#~ "copy and paste it into notepad/a plain text editor before pasting here."
+#~ msgstr ""
+#~ "Evita di incollare contenuti da elaboratori di testi in quanto possono "
+#~ "aggiungere una formattazione indesiderato all'abstract. Puoi ridigitare "
+#~ "l'abstract qui o copiarlo e incollarlo in un blocco note/un editor di "
+#~ "testo prima di incollarlo qui."
+
+#, fuzzy
+#~| msgid "Options"
+#~ msgid "Email Options"
+#~ msgstr "Opzioni"
+
+#, fuzzy
+#~| msgid "Submission Checklist"
+#~ msgid "Submission Complete"
+#~ msgstr "Checklist per la proposta"
+
+#~ msgid "allows the following licenses for submission"
+#~ msgstr "consente le seguenti licenze per l'invio"
+
+#~ msgid "somebody"
+#~ msgstr "qualcuno"
+
+#, fuzzy
+#~| msgid "Account"
+#~ msgid "account"
+#~ msgstr "Account"
+
+#~ msgid "profile photo"
+#~ msgstr "foto del profilo"
+
+#~ msgid "Dates"
+#~ msgstr "Date"
 
 #~ msgid "File Checksums (MD5)"
 #~ msgstr "File Checksums (MD5)"
@@ -5087,9 +5601,6 @@ msgstr ""
 #~ msgid "Completed"
 #~ msgstr "Completa"
 
-#~ msgid "Funder DOI"
-#~ msgstr "DOI del finanziatore"
-
 #~ msgid "(optional)"
 #~ msgstr "(facoltativo)"
 
@@ -5146,8 +5657,8 @@ msgstr ""
 #~ "                            contain specific\n"
 #~ "                            characters but you should make it as long as "
 #~ "possible. For more information read our\n"
-#~ "                            <a href=\"#\" data-open=\"password-modal"
-#~ "\">password guide</a>"
+#~ "                            <a href=\"#\" data-open=\"password-"
+#~ "modal\">password guide</a>"
 #~ msgstr ""
 #~ "La tua password deve avere una lunghezza minima di 12 caratteri. Non è "
 #~ "necessario che contenga caratteri specifici ma dovresti renderla più "
@@ -5192,8 +5703,8 @@ msgstr ""
 #~| "                                    need to contain specific\n"
 #~| "                                    characters but you should make it as "
 #~| "long as possible. For more information read our\n"
-#~| "                                    <a href=\"#passwordmodal\" class="
-#~| "\"modal-trigger\"> password guide</a>."
+#~| "                                    <a href=\"#passwordmodal\" "
+#~| "class=\"modal-trigger\"> password guide</a>."
 #~ msgid ""
 #~ "Your password should be at minimum 12 characters long. It does not\n"
 #~ "                                    need to contain specific\n"
@@ -5204,8 +5715,8 @@ msgstr ""
 #~ "contenere caratteri specifici ma dovresti renderla più lunga possibile. "
 #~ "Per maggiori\n"
 #~ "                        informazioni leggi la\n"
-#~ "                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-#~ "\"> guida alle password </a>."
+#~ "                        <a href=\"#passwordmodal\" class=\"modal-"
+#~ "trigger\"> guida alle password </a>."
 
 #, fuzzy
 #~| msgid "Password Guide"
@@ -5237,16 +5748,16 @@ msgstr ""
 #~ "                        to contain specific characters but you should "
 #~ "make it as long as possible. For more\n"
 #~ "                        information read on\n"
-#~ "                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-#~ "\"> password guide</a>\n"
+#~ "                        <a href=\"#passwordmodal\" class=\"modal-"
+#~ "trigger\"> password guide</a>\n"
 #~ "                        ."
 #~ msgstr ""
 #~ "La tua password deve avere una lunghezza minima di 12 caratteri. Non deve "
 #~ "contenere caratteri specifici ma dovresti renderla più lunga possibile. "
 #~ "Per maggiori\n"
 #~ "                        informazioni leggi la\n"
-#~ "                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-#~ "\"> guida alle password </a>."
+#~ "                        <a href=\"#passwordmodal\" class=\"modal-"
+#~ "trigger\"> guida alle password </a>."
 
 #~ msgid "hide"
 #~ msgstr "nascondi"
@@ -5262,5 +5773,5 @@ msgstr ""
 #~ msgstr ""
 #~ "La password deve essere lunga almeno 12 caratteri. Non deve contenere "
 #~ "caratteri specifici, ma dovresti renderla il più lunga possibile. Per più "
-#~ "informazioni vedi la <a href=\"#\" data-toggle=\"modal\" data-target="
-#~ "\"#passwordmodal\"> guida password</a>"
+#~ "informazioni vedi la <a href=\"#\" data-toggle=\"modal\" data-"
+#~ "target=\"#passwordmodal\"> guida password</a>"

--- a/src/core/locales/nl/LC_MESSAGES/django.po
+++ b/src/core/locales/nl/LC_MESSAGES/django.po
@@ -2,70 +2,77 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Janeway\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-12 16:34+0000\n"
+"POT-Creation-Date: 2024-12-05 10:48+0000\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: src/comms/models.py:94
+#: src/comms/models.py:119
 #, python-brace-format
 msgid "Posted by {byline}"
 msgstr "Gepost door {byline}"
 
-#: src/comms/models.py:95
+#: src/comms/models.py:120
 #, python-brace-format
 msgid "Posted by  {byline}"
 msgstr "Gepost door {byline}"
 
-#: src/copyediting/forms.py:16
+#: src/copyediting/forms.py:17
 msgid "Are you sure you want to create a copyediting assignment?"
 msgstr ""
 
-#: src/copyediting/forms.py:99
+#: src/copyediting/forms.py:104
 msgid "Are you sure you want to ask the author to review copyedits?"
 msgstr ""
 
-#: src/copyediting/forms.py:146
+#: src/copyediting/forms.py:151
 msgid "Are you sure you want to complete the copyedit task?"
 msgstr ""
 
-#: src/core/forms/forms.py:110
-msgid "Password 1"
-msgstr "Wachtwoord 1"
-
-#: src/core/forms/forms.py:111
-msgid "Password 2"
-msgstr "Wachtwoord 2"
-
-#: src/core/forms/forms.py:129
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/core/forms/forms.py:114 src/core/forms/forms.py:162
+#: src/templates/admin/core/accounts/orcid_registration.html:29
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
 #: src/themes/OLH/templates/press/core/login.html:33
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:24
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:28
 #: src/themes/clean/templates/core/login.html:34
+#: src/themes/hourglass/templates/custom/orcid-registration.html:32
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: src/core/forms/forms.py:130
+#: src/core/forms/forms.py:123 src/core/forms/forms.py:170
 msgid "Repeat Password"
 msgstr "Wachtwoord herhalen"
 
-#: src/core/forms/forms.py:133
+#: src/core/forms/forms.py:148 src/core/models.py:235
+#: src/templates/admin/core/accounts/orcid_registration.html:25
+#: src/templates/admin/repository/article.html:213
+#: src/templates/admin/repository/author_article.html:92
+#: src/templates/admin/repository/submit/authors.html:77
+#: src/templates/admin/submission/submit_authors.html:70
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:33
+#: src/themes/OLH/templates/press/core/login.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:25
+#: src/themes/hourglass/templates/custom/orcid-registration.html:28
+msgid "Email"
+msgstr "E-mail"
+
+#: src/core/forms/forms.py:179
 msgid ""
 "Check this box if you would like to receive notifications of new articles "
 "published in this journal"
 msgstr ""
 
-#: src/core/forms/forms.py:495
+#: src/core/forms/forms.py:578
 msgid "E-mail"
 msgstr "E-mail"
 
-#: src/core/forms/forms.py:694
+#: src/core/forms/forms.py:783
 msgid "Are you sure?"
 msgstr ""
 
-#: src/core/forms/forms.py:725
+#: src/core/forms/forms.py:814
 #, python-format
 msgid ""
 "The account belonging to %(email)s has not yet been activated, so the "
@@ -108,241 +115,233 @@ msgstr ""
 msgid "Issues and Collections"
 msgstr "Nummers en collecties"
 
-#: src/core/janeway_global_settings.py:252
+#: src/core/janeway_global_settings.py:254
 #, fuzzy
 #| msgid "English"
 msgid "English"
 msgstr "Engels"
 
-#: src/core/janeway_global_settings.py:253
+#: src/core/janeway_global_settings.py:255
 #, fuzzy
 #| msgid "English"
 msgid "English (US)"
 msgstr "Engels"
 
-#: src/core/janeway_global_settings.py:254
+#: src/core/janeway_global_settings.py:256
 msgid "French"
 msgstr "Frans"
 
-#: src/core/janeway_global_settings.py:255
+#: src/core/janeway_global_settings.py:257
 msgid "German"
 msgstr "Duits"
 
-#: src/core/janeway_global_settings.py:256
+#: src/core/janeway_global_settings.py:258
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: src/core/janeway_global_settings.py:257
+#: src/core/janeway_global_settings.py:259
 msgid "Welsh"
 msgstr "Welsh"
 
-#: src/core/logic.py:810
+#: src/core/logic.py:833
 msgid "Your password must be {} characters long"
 msgstr "Uw wachtwoord moet {} karakters lang zijn"
 
-#: src/core/logic.py:814
+#: src/core/logic.py:837
 msgid "An uppercase character is required"
 msgstr "Een hoodfletter is vereist"
 
-#: src/core/logic.py:817
+#: src/core/logic.py:840
 msgid "A number is required"
 msgstr "Een nummer is vereist"
 
-#: src/core/models.py:69
+#: src/core/models.py:77
 msgid "Miss"
 msgstr ""
 
-#: src/core/models.py:70
+#: src/core/models.py:78
 msgid "Ms"
 msgstr ""
 
-#: src/core/models.py:71
+#: src/core/models.py:79
 #, fuzzy
 #| msgid "Metrics"
 msgid "Mrs"
 msgstr "Metrieken"
 
-#: src/core/models.py:72
+#: src/core/models.py:80
 msgid "Mr"
 msgstr ""
 
-#: src/core/models.py:73
+#: src/core/models.py:81
 msgid "Mx"
 msgstr ""
 
-#: src/core/models.py:74
+#: src/core/models.py:82
 msgid "Dr"
 msgstr ""
 
-#: src/core/models.py:75
+#: src/core/models.py:83
 #, fuzzy
 #| msgid "Profile"
 msgid "Prof."
 msgstr "Profiel"
 
-#: src/core/models.py:208 src/templates/admin/repository/article.html:213
-#: src/templates/admin/repository/author_article.html:92
-#: src/templates/admin/repository/submit/authors.html:80
-#: src/templates/admin/submission/submit_authors.html:65
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:26
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:29
-#: src/themes/OLH/templates/press/core/login.html:30
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:16
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:18
-msgid "Email"
-msgstr "E-mail"
-
-#: src/core/models.py:209
+#: src/core/models.py:236
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: src/core/models.py:211
+#: src/core/models.py:242
 msgid "First name"
 msgstr "Voornaam"
 
-#: src/core/models.py:212 src/submission/forms.py:271
+#: src/core/models.py:248 src/submission/forms.py:286
 msgid "Middle name"
 msgstr "Tweede naam"
 
-#: src/core/models.py:213 src/submission/forms.py:272
+#: src/core/models.py:254 src/submission/forms.py:287
 msgid "Last name"
 msgstr "Familienaam"
 
-#: src/core/models.py:217
+#: src/core/models.py:263
 msgid "Salutation"
 msgstr "Aanspreking"
 
-#: src/core/models.py:222
+#: src/core/models.py:269
 msgid "Name suffix"
 msgstr ""
 
-#: src/core/models.py:224
-#: src/themes/OLH/templates/core/accounts/public_profile.html:19
-#: src/themes/clean/templates/core/accounts/public_profile.html:19
-#: src/themes/material/templates/core/accounts/public_profile.html:19
+#: src/core/models.py:274
+#: src/themes/OLH/templates/core/accounts/public_profile.html:50
+#: src/themes/clean/templates/core/accounts/public_profile.html:23
+#: src/themes/material/templates/core/accounts/public_profile.html:23
 msgid "Biography"
 msgstr "Biografie"
 
-#: src/core/models.py:225 src/submission/models.py:1943
+#: src/core/models.py:276 src/submission/models.py:2014
 msgid "ORCiD"
 msgstr "ORCiD"
 
-#: src/core/models.py:226 src/submission/forms.py:275
+#: src/core/models.py:280 src/submission/forms.py:290
 msgid "Institution"
 msgstr "Instelling"
 
-#: src/core/models.py:227 src/submission/forms.py:276
+#: src/core/models.py:286 src/submission/forms.py:291
 msgid "Department"
 msgstr "Departement"
 
-#: src/core/models.py:228
+#: src/core/models.py:289
 #, fuzzy
 #| msgid "Twitter"
 msgid "Twitter Handle"
 msgstr "Twitter"
 
-#: src/core/models.py:229
+#: src/core/models.py:290
 #, fuzzy
 #| msgid "Facebook"
 msgid "Facebook Handle"
 msgstr "Facebook"
 
-#: src/core/models.py:230
+#: src/core/models.py:291
 #, fuzzy
 #| msgid "Edit Profile"
 msgid "Linkedin Profile"
 msgstr "Profiel bewerken"
 
-#: src/core/models.py:231
+#: src/core/models.py:292
 #: src/themes/OLH/templates/elements/journal/editorial_social_content.html:3
 #: src/themes/clean/templates/elements/journal/editorial_social_content.html:3
 msgid "Website"
 msgstr "Website"
 
-#: src/core/models.py:232
+#: src/core/models.py:293
 #, fuzzy
 #| msgid "Username"
 msgid "Github Username"
 msgstr "Gebruikersnaam"
 
-#: src/core/models.py:236
+#: src/core/models.py:297
 #, fuzzy
 #| msgid "Information"
 msgid "Confirmation Code"
 msgstr "Informatie"
 
-#: src/core/models.py:237
+#: src/core/models.py:300
 msgid "Signature"
 msgstr ""
 
-#: src/core/models.py:243
-#: src/themes/OLH/templates/core/accounts/public_profile.html:15
-#: src/themes/clean/templates/core/accounts/public_profile.html:15
-#: src/themes/material/templates/core/accounts/public_profile.html:15
+#: src/core/models.py:307
+#: src/themes/OLH/templates/core/accounts/public_profile.html:45
+#: src/themes/clean/templates/core/accounts/public_profile.html:19
+#: src/themes/material/templates/core/accounts/public_profile.html:19
 msgid "Country"
 msgstr "Land"
 
-#: src/core/models.py:246
+#: src/core/models.py:314
 msgid "Preferred Timezone"
 msgstr ""
 
-#: src/core/models.py:254
+#: src/core/models.py:323
 msgid "Enable Digest"
 msgstr ""
 
-#: src/core/models.py:259
+#: src/core/models.py:328
 msgid "If enabled, your basic profile will be available to the public."
 msgstr ""
 
-#: src/core/models.py:261
+#: src/core/models.py:330
 msgid "Enable public profile"
 msgstr ""
 
-#: src/core/models.py:566 src/core/models.py:578
+#: src/core/models.py:639 src/core/models.py:651
 msgid "Expires on"
 msgstr ""
 
-#: src/core/models.py:840 src/core/models.py:1118
+#: src/core/models.py:915 src/core/models.py:1193
 #, fuzzy
 #| msgid "Article"
 msgid "Article PK"
 msgstr "Artikel"
 
-#: src/core/models.py:845 src/core/models.py:1123 src/repository/models.py:838
-#: src/templates/admin/elements/submit/file.html:24
-#: src/templates/admin/submission/submit_files.html:40
-#: src/templates/admin/submission/submit_files.html:80
-#: src/templates/admin/submission/submit_review.html:120
+#: src/core/models.py:920 src/core/models.py:1198 src/repository/models.py:848
+#: src/templates/admin/submission/submit_files.html:46
+#: src/templates/admin/submission/submit_files.html:86
+#: src/templates/admin/submission/submit_review.html:136
 msgid "Label"
 msgstr "Label"
 
-#: src/core/models.py:846 src/core/models.py:1124
-#: src/templates/admin/elements/submit/file.html:31
+#: src/core/models.py:921 src/core/models.py:1199
 msgid "Description"
 msgstr "Beschrijving"
 
-#: src/core/models.py:857
+#: src/core/models.py:932
 msgid "Remote URL of file"
 msgstr ""
 
-#: src/core/models.py:1150
+#: src/core/models.py:1225
 msgid "Other"
 msgstr ""
 
-#: src/core/models.py:1151
+#: src/core/models.py:1226
 msgid "Image"
 msgstr ""
 
-#: src/core/models.py:1493
+#: src/core/models.py:1594 src/templates/admin/journal/contact.html:38
+#: src/themes/OLH/templates/journal/contact.html:30
+#: src/themes/OLH/templates/press/journal/contact.html:22
+#: src/themes/clean/templates/journal/contact.html:27
+msgid "Who would you like to contact?"
+msgstr "Wie wilt u contacteren?"
+
+#: src/core/models.py:1595
 msgid "Your contact email address"
 msgstr "Uw contact e-mailadres"
 
-#: src/core/models.py:1494
+#: src/core/models.py:1596
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: src/core/models.py:1495
+#: src/core/models.py:1597
 msgid "Your message"
 msgstr "Uw bericht"
 
@@ -363,77 +362,77 @@ msgstr ""
 "MIME type {mimetype} is niet geldig. Geldige types zijn: {validator."
 "mimetypes}"
 
-#: src/core/views.py:78
+#: src/core/views.py:80
 msgid "You have been banned from logging in due to failed attempts."
 msgstr ""
 
-#: src/core/views.py:122
+#: src/core/views.py:124
 msgid ""
 "Password reset process has been initiated, please check your inbox for a "
 "reset request link."
 msgstr ""
 
-#: src/core/views.py:132
+#: src/core/views.py:134
 msgid ""
 "Wrong email/password combination or your email address has not been "
 "confirmed yet."
 msgstr ""
 
-#: src/core/views.py:219
+#: src/core/views.py:226
 msgid "You have been logged out."
 msgstr ""
 
-#: src/core/views.py:236
+#: src/core/views.py:249
 msgid "If your account was found, an email has been sent to you."
 msgstr ""
 
-#: src/core/views.py:355
+#: src/core/views.py:377
 msgid ""
 "Your account has been created. Please follow the instructions in the email "
 "that has been sent to you."
 msgstr ""
 
-#: src/core/views.py:400
+#: src/core/views.py:420
 #, fuzzy
 #| msgid "Account"
 msgid "Account activated"
 msgstr "Account"
 
-#: src/core/views.py:442
+#: src/core/views.py:469
 msgid "An account with that email address already exists."
 msgstr ""
 
-#: src/core/views.py:448
+#: src/core/views.py:475
 #, fuzzy
 #| msgid "New Email Address"
 msgid "Email address is not valid."
 msgstr "Nieuw e-mailadres"
 
-#: src/core/views.py:463
+#: src/core/views.py:490
 #, fuzzy
 #| msgid "Password Guide"
 msgid "Password updated."
 msgstr "Wachtwoordgids"
 
-#: src/core/views.py:467
+#: src/core/views.py:494
 msgid "Passwords do not match"
 msgstr ""
 
-#: src/core/views.py:470
+#: src/core/views.py:497
 msgid "Old password is not correct."
 msgstr ""
 
-#: src/core/views.py:480
+#: src/core/views.py:507
 #, fuzzy
 #| msgid "Register for an"
 msgid "Successfully subscribed to article notifications."
 msgstr "Registreer voor een"
 
-#: src/core/views.py:491
+#: src/core/views.py:518
 msgid "Successfully unsubscribed from article notifications."
 msgstr ""
 
-#: src/core/views.py:1943
+#: src/core/views.py:2079
 msgid ""
 "You cannot remove a section that contains articles. Remove articles from the "
 "section if you want to delete it."
@@ -441,77 +440,89 @@ msgstr ""
 "Je kan een sectie die artikels bevat niet verwijderen. Verwijder de artikels "
 "van de sectie om de sectie te kunnen verwijderen."
 
+#: src/core/views.py:2711 src/journal/forms.py:24 src/journal/views.py:2866
+msgid "Newest"
+msgstr ""
+
+#: src/core/views.py:2712 src/journal/forms.py:25 src/journal/views.py:2867
+msgid "Oldest"
+msgstr ""
+
+#: src/core/views.py:2713
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name A-Z"
+msgstr "Familienaam"
+
+#: src/core/views.py:2714
+#, fuzzy
+#| msgid "Last name"
+msgid "Last name Z-A"
+msgstr "Familienaam"
+
 #: src/discussion/models.py:27
 msgid "Max. 300 characters."
 msgstr "Max. 300 karakters"
 
 #. Translators: Search order options
-#: src/journal/forms.py:20
+#: src/journal/forms.py:21
 msgid "Relevance"
 msgstr ""
 
-#: src/journal/forms.py:21 src/journal/views.py:2629
+#: src/journal/forms.py:22 src/journal/views.py:2868
 #, fuzzy
 #| msgid "Title"
 msgid "Titles A-Z"
 msgstr "Titel"
 
-#: src/journal/forms.py:22 src/journal/views.py:2630
+#: src/journal/forms.py:23 src/journal/views.py:2869
 #, fuzzy
 #| msgid "Title"
 msgid "Titles Z-A"
 msgstr "Titel"
 
-#: src/journal/forms.py:23 src/journal/views.py:2627
-msgid "Newest"
-msgstr ""
-
-#: src/journal/forms.py:24 src/journal/views.py:2628
-msgid "Oldest"
-msgstr ""
-
-#: src/journal/forms.py:97
+#: src/journal/forms.py:98
 #: src/themes/clean/templates/core/homepage_elements/search_bar.html:20
 #, fuzzy
 #| msgid "Search"
 msgid "Search term"
 msgstr "Zoeken"
 
-#: src/journal/forms.py:98
+#: src/journal/forms.py:99
 #, fuzzy
 #| msgid "Search preprints"
 msgid "Search Titles"
 msgstr "Preprints zoeken"
 
-#: src/journal/forms.py:99
+#: src/journal/forms.py:100
 #, fuzzy
 #| msgid "Abstract"
 msgid "Search Abstract"
 msgstr "Samenvatting"
 
-#: src/journal/forms.py:100
+#: src/journal/forms.py:101
 #, fuzzy
 #| msgid "Search for Existing Authors"
 msgid "Search Authors"
 msgstr "Naar bestaande auteurs zoeken"
 
-#: src/journal/forms.py:101
+#: src/journal/forms.py:102
 #, fuzzy
 #| msgid "Keywords"
 msgid "Search Keywords"
 msgstr "Trefwoorden"
 
-#: src/journal/forms.py:102
+#: src/journal/forms.py:103
 msgid "Search Full Text"
 msgstr ""
 
-#: src/journal/forms.py:103
+#: src/journal/forms.py:104
 #, fuzzy
 #| msgid "Search"
 msgid "Search ORCIDs"
 msgstr "Zoeken"
 
-#: src/journal/forms.py:104 src/templates/common/elements/sorting.html:16
+#: src/journal/forms.py:105 src/templates/common/elements/sorting.html:16
 #: src/themes/clean/templates/elements/sorting.html:17
 #: src/themes/material/templates/elements/sorting.html:31
 #, fuzzy
@@ -519,12 +530,12 @@ msgstr "Zoeken"
 msgid "Sort results by"
 msgstr "Sorteer artikels op"
 
-#: src/journal/logic.py:212
+#: src/journal/logic.py:216
 msgid "Articles without a section cannot be added to an issue."
 msgstr ""
 "Artikels zonder een sectie kunnen niet aan een nummer worden toegekend."
 
-#: src/journal/models.py:80
+#: src/journal/models.py:101
 msgid ""
 "Short acronym for the journal. Used as part of the journal URLin path mode "
 "and to uniquely identify the journal"
@@ -532,167 +543,189 @@ msgstr ""
 "Kort acroniem voor het tijdschrift. Wordt gebruikt als deel van URL van het "
 "tijdschrift (in path mode) om het tijdschrift uniek te identificeren."
 
-#: src/journal/models.py:98
+#: src/journal/models.py:119
 msgid ""
 "The default thumbnail for articles, not to be confused with 'Default cover "
 "image'."
 msgstr ""
 
-#: src/journal/models.py:106
+#: src/journal/models.py:127
 msgid "Replaces the press logo in the footer."
 msgstr ""
 
-#: src/journal/models.py:113
+#: src/journal/models.py:134
 msgid ""
 "The default cover image for journal issues and for the journal's listing on "
 "the press-level website."
 msgstr ""
 
-#: src/journal/models.py:121
+#: src/journal/models.py:142
 #, fuzzy
 #| msgid "The default language of articles when lang is hidden"
 msgid "The default background image for article openers and carousel items."
 msgstr "De standaard taal van artikels wanneer taal verborgen is."
 
-#: src/journal/models.py:129
+#: src/journal/models.py:150
 msgid ""
 "The logo-sized image at the top of all pages, typically used for journal "
 "logos."
 msgstr ""
 
-#: src/journal/models.py:137
+#: src/journal/models.py:158
 msgid ""
 "The tiny round or square image appearing in browser tabs before the webpage "
 "title"
 msgstr ""
 
-#: src/journal/models.py:148
+#: src/journal/models.py:166
+msgid ""
+"A default image displayed on the profile and editorial team pages when the "
+"user has no set profile image."
+msgstr ""
+
+#: src/journal/models.py:183
 #, fuzzy
 #| msgid "This article has been peer reviewed."
 msgid "This field has been deprecated in v1.4.3"
 msgstr "Dit artikel heeft 'peer review' ondergaan."
 
-#: src/journal/models.py:158
+#: src/journal/models.py:193
 msgid "When enabled, the journal is marked as not hosted in Janeway."
 msgstr ""
 "Indien ingeschakeld, wordt het tijdschrift gemarkeerd als niet gehost in "
 "Janeway."
 
-#: src/journal/models.py:169
+#: src/journal/models.py:204
 msgid "If the journal is remote you can link to its submission page."
 msgstr ""
 "Wanneer het een extern tijdschrift is, kan je linken naar de "
 "inzendingenpagina."
 
-#: src/journal/models.py:174
+#: src/journal/models.py:209
 msgid "If the journal is remote you can link to its home page."
 msgstr "Wanneer het een extern tijdschrift is, kan je linken naar de homepage."
 
-#: src/journal/models.py:178
+#: src/journal/models.py:213
 msgid "Enables a \"View PDF\" link on article pages."
 msgstr "Zorgt voor een \"View PDF\" link op de artikelpagina's."
 
-#: src/journal/models.py:220
+#: src/journal/models.py:255
 msgid ""
 "Whether to display article numbers. Article numbers are distinct from "
 "article ID and can be set in Edit Metadata."
 msgstr ""
 
-#: src/journal/models.py:532
+#: src/journal/models.py:600
 msgid "Please add as much detail as you can."
 msgstr "Gelieve zoveel mogelijk details te geven."
 
-#: src/journal/models.py:573
+#: src/journal/models.py:724
 #, fuzzy
 #| msgid "Subtitle of the article display format; Title: Subtitle"
 msgid "Autogenerated cache of the display format of an issue title"
 msgstr "Ondertitel van het artikel weergave formaat: Titel: Ondertitel"
 
-#: src/journal/models.py:588
+#: src/journal/models.py:739
 msgid "Image representing the cover of a printed issue or volume"
 msgstr ""
 
-#: src/journal/models.py:594
+#: src/journal/models.py:745
 msgid "landscape hero image used in the carousel and issue page"
 msgstr ""
 
-#: src/journal/models.py:613
+#: src/journal/models.py:764
 msgid ""
 "An optional alphanumeric code (Slug) used to generate a verbose  url for "
 "this issue. e.g: 'winter-special-issue'."
 msgstr ""
 
-#: src/journal/models.py:635
+#: src/journal/models.py:786
 msgid ""
 "An ISBN is relevant for non-serial collections such as conference proceedings"
 msgstr ""
 
-#: src/journal/models.py:676
+#: src/journal/models.py:827
 #: src/themes/OLH/templates/press/press_journals.html:71
 #: src/themes/clean/templates/press/press_journals.html:42
 #: src/themes/material/templates/press/press_journals.html:46
 msgid "Current Issue"
 msgstr "Huidig nummer"
 
-#: src/journal/models.py:734
+#: src/journal/models.py:885
 #, fuzzy
 #| msgid "Pages"
 msgid "pages"
 msgstr "Pagina's"
 
-#: src/journal/models.py:736
+#: src/journal/models.py:887
 msgid "page"
 msgstr ""
 
-#: src/journal/views.py:751
+#: src/journal/views.py:771
 msgid "No file uploaded"
 msgstr "Geen bestand opgeladen"
 
-#: src/journal/views.py:1009
+#: src/journal/views.py:1097
 msgid "Issue not in this journal’s issue list."
 msgstr ""
 
-#: src/journal/views.py:1129
+#: src/journal/views.py:1143
+msgid ""
+"Publication date set to { article.date_published.strftime(\"%Y-%m-%d %H:%M "
+"%Z\") } "
+msgstr ""
+
+#: src/journal/views.py:1150
+#, fuzzy
+#| msgid "Publication Fees"
+msgid "Publication date unset"
+msgstr "Publicatiekosten"
+
+#: src/journal/views.py:1156
+msgid "Something went wrong when trying to save the form. "
+msgstr ""
+
+#: src/journal/views.py:1241
 msgid "Article set for publication."
 msgstr "Artikel klaar voor publicatie."
 
-#: src/journal/views.py:1401
+#: src/journal/views.py:1516
 msgid "You cannot move the first section up the order list"
 msgstr "U kunt de eerste sectie niet hoger in de lijst plaatsen"
 
-#: src/journal/views.py:1433
+#: src/journal/views.py:1548
 msgid "You cannot move the last section down the order list"
 msgstr "U kunt de laatste sectie niet lager in de lijst plaatsen"
 
-#: src/journal/views.py:1440
+#: src/journal/views.py:1555
 msgid "This page accepts post requests only."
 msgstr "Deze pagina aanvaardt enkel post requests."
 
-#: src/journal/views.py:1511
+#: src/journal/views.py:1626
 msgid "User is already a guest editor."
 msgstr "Gebruiker is al een gast editor."
 
-#: src/journal/views.py:1517
+#: src/journal/views.py:1632
 msgid "This user is not a member of this journal."
 msgstr "Deze gebruiker is niet ingeschreven voor dit tijdschrift."
 
-#: src/journal/views.py:1570
+#: src/journal/views.py:1685
 msgid "Editor removed from Issue."
 msgstr "Editor verwijderd van nummer"
 
-#: src/journal/views.py:1576
+#: src/journal/views.py:1691
 msgid "Issue Editor not found."
 msgstr "Editor van nummer niet gevonden."
 
-#: src/journal/views.py:1582
+#: src/journal/views.py:1697
 msgid "No Issue Editor ID supplied."
 msgstr "Geen editor ID van nummer geleverd."
 
-#: src/journal/views.py:1729
+#: src/journal/views.py:1851
 msgid "Uploaded file is not UTF-8 encoded"
 msgstr "Opgeladen bestand is niet UTF-8 gecodeerd"
 
-#: src/journal/views.py:1823
+#: src/journal/views.py:1945
 msgid ""
 "You must login before you can become a reviewer. Click the button below to "
 "login."
@@ -700,7 +733,7 @@ msgstr ""
 "U dient ingelogd te zijn om een reviewer te worden. Klik op de knop "
 "hieronder om in te loggen."
 
-#: src/journal/views.py:1828
+#: src/journal/views.py:1950
 msgid ""
 "You are not yet a reviewer for this journal. Click the button below to "
 "become a reviewer."
@@ -708,113 +741,104 @@ msgstr ""
 "U bent geen reviewer voor dit tijdschrift. Klik op de knop hieronder om "
 "reviewer te worden."
 
-#: src/journal/views.py:1833
+#: src/journal/views.py:1955
 msgid "You are already a reviewer."
 msgstr "U bent al een reviewer."
 
-#: src/journal/views.py:1840
+#: src/journal/views.py:1962
 msgid "You are now a reviewer"
 msgstr "U bent nu een reviewer"
 
-#: src/journal/views.py:1879
+#: src/journal/views.py:2001
 msgid "Your message has been sent."
 msgstr "Uw bericht is verzonden"
 
-#: src/journal/views.py:2313 src/journal/views.py:2330
-#: src/journal/views.py:2340
+#: src/journal/views.py:2478
+#, fuzzy
+#| msgid "Production file uploaded."
+msgid "Manuscript file uploaded."
+msgstr "Productiebestand opgeladen."
+
+#: src/journal/views.py:2495
+#, fuzzy
+#| msgid "Proofing file uploaded."
+msgid "Data/figure file uploaded."
+msgstr "Proefbestand opgeladen"
+
+#: src/journal/views.py:2506
 msgid "Production file uploaded."
 msgstr "Productiebestand opgeladen."
 
-#: src/journal/views.py:2350
+#: src/journal/views.py:2516
+#, fuzzy
+#| msgid "No file uploaded"
+msgid "Galley file uploaded."
+msgstr "Geen bestand opgeladen"
+
+#: src/journal/views.py:2552
 msgid "Proofing file uploaded."
 msgstr "Proefbestand opgeladen"
 
-#: src/journal/views.py:2603
+#: src/journal/views.py:2558
+#, fuzzy
+#| msgid "Upload files"
+msgid "Saved file."
+msgstr "Bestanden opladen"
+
+#: src/journal/views.py:2568
+#, fuzzy
+#| msgid "Supplementary Files"
+msgid "Supplementary file uploaded."
+msgstr "Aanvullende bestanden"
+
+#: src/journal/views.py:2578
+#, fuzzy
+#| msgid "Proofing file uploaded."
+msgid "Typesetting source file uploaded."
+msgstr "Proefbestand opgeladen"
+
+#: src/journal/views.py:2849
 #, fuzzy
 #| msgid "Published"
 msgid "Published after"
 msgstr "Gepubliceerd"
 
-#: src/journal/views.py:2607
+#: src/journal/views.py:2853
 #, fuzzy
 #| msgid "Published on"
 msgid "Published before"
 msgstr "Gepubliceerd op"
 
-#: src/journal/views.py:2612
-#: src/templates/admin/submission/submit_review.html:70
+#: src/journal/views.py:2858
+#: src/templates/admin/submission/submit_review.html:75
 msgid "Section"
 msgstr "Sectie"
 
-#: src/journal/views.py:2631 src/themes/OLH/templates/repository/list.html:77
+#: src/journal/views.py:2870 src/themes/OLH/templates/repository/list.html:77
 #: src/themes/material/templates/preprints/list.html:80
 #: src/themes/material/templates/repository/list.html:61
 msgid "Author Name"
 msgstr "Naam auteur"
 
-#: src/journal/views.py:2632
+#: src/journal/views.py:2871
 msgid "Volume"
 msgstr "Volume"
 
-#: src/plugins_bak/typesetting/forms.py:16
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to create a typesetting assignment?"
-msgstr "Geef uw wachtwoord twee keer in om het reset proces te voltooien"
-
-#: src/plugins_bak/typesetting/forms.py:90
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to create a proofreading assignment?"
-msgstr "Geef uw wachtwoord twee keer in om het reset proces te voltooien"
-
-#: src/plugins_bak/typesetting/forms.py:160
-#, fuzzy
-#| msgid "A set of controls for how things display on the article page"
-msgid "Text to show as the download link on the article page"
-msgstr "Instellingen voor de artikelpagina"
-
-#: src/plugins_bak/typesetting/forms.py:199
-#, fuzzy
-#| msgid "Enter your new password twice to complete the reset process"
-msgid "Are you sure you want to complete the proofreading task?"
-msgstr "Geef uw wachtwoord twee keer in om het reset proces te voltooien"
-
-#: src/plugins_bak/typesetting/forms.py:224
-msgid "You have not proofed some galleys:"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:164
-msgid "Article has no typeset files"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:165
-msgid "One or more typeset files are missing images"
-msgstr ""
-
-#: src/plugins_bak/typesetting/logic.py:167
-msgid "One or more typesetting or proofing tasks haven't been completed"
-msgstr ""
-
-#: src/plugins_bak/typesetting/templates/typesetting/typesetting_proofreading_assignment.html:116
-msgid "Mark Task as Complete"
-msgstr ""
-
-#: src/press/views.py:406
+#: src/press/views.py:405
 #, fuzzy
 #| msgid "Description"
 msgid "Description deleted."
 msgstr "Beschrijving"
 
-#: src/press/views.py:419
+#: src/press/views.py:418
 #, fuzzy
 #| msgid "Description"
 msgid "Description saved."
 msgstr "Beschrijving"
 
-#: src/repository/forms.py:44 src/submission/forms.py:75
+#: src/repository/forms.py:42 src/submission/forms.py:87
 #: src/templates/admin/core/manager/sections/section_articles.html:30
-#: src/templates/admin/submission/submit_review.html:46
+#: src/templates/admin/submission/submit_review.html:51
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:21
 #: src/themes/OLH/templates/repository/list.html:75
 #: src/themes/clean/templates/journal/articles.html:65
@@ -824,7 +848,7 @@ msgstr "Beschrijving"
 msgid "Title"
 msgstr "Titel"
 
-#: src/repository/forms.py:47 src/submission/forms.py:79
+#: src/repository/forms.py:45
 msgid "Enter your article's abstract here"
 msgstr "Geef hier de samenvatting van uw artikel in"
 
@@ -844,93 +868,82 @@ msgid ""
 "files."
 msgstr ""
 
-#: src/repository/models.py:350
+#: src/repository/models.py:375
 msgid ""
 "If this field is to be output as a dc metadata field you can addthe type "
 "here."
 msgstr ""
 
-#: src/repository/models.py:396 src/repository/models.py:983
-#: src/repository/models.py:1140 src/submission/models.py:632
+#: src/repository/models.py:421 src/repository/models.py:993
+#: src/repository/models.py:1144 src/submission/models.py:622
 msgid "Your article title"
 msgstr "Titel van uw artikel"
 
-#: src/repository/models.py:403 src/submission/models.py:645
-msgid "Copying and pasting from word processors is supported."
-msgstr ""
-
-#: src/repository/models.py:949
-#: src/templates/admin/submission/submit_review.html:101
+#: src/repository/models.py:959
+#: src/templates/admin/submission/submit_review.html:117
 msgid "ORCID"
 msgstr "ORCID"
 
-#: src/repository/models.py:990 src/repository/models.py:1146
-msgid ""
-"Please avoid pasting content from word processors as they can add unwanted "
-"styling to the abstract. You can retype the abstract here or copy and paste "
-"it into notepad/a plain text editor before pasting here."
-msgstr ""
-"Gelieve geen inhoud van tekstverwerkers te plakken, aangezien deze "
-"ongewenste opmaak aan de samenvatting kunnen toevoegen. U kunt de "
-"samenvatting hier opnieuw typen of eerst kopiëren en plakken in Kladblok of "
-"een andere eenvoudige text editor voordat u deze hier plakt."
-
-#: src/repository/models.py:1209
+#: src/repository/models.py:1206
 msgid "Approved"
 msgstr "Aanvaard"
 
-#: src/repository/models.py:1211
+#: src/repository/models.py:1208
 msgid "Under Review"
 msgstr "in Review"
 
-#: src/repository/models.py:1213 src/templates/admin/review/view_review.html:64
+#: src/repository/models.py:1210 src/templates/admin/review/view_review.html:64
 msgid "Declined"
 msgstr "Afgewezen"
 
-#: src/repository/views.py:1076
+#: src/repository/views.py:1097
 msgid "Author information saved"
 msgstr ""
 
-#: src/review/forms.py:237
+#: src/review/forms.py:242
 msgid "Are you sure you want to request revisions?"
 msgstr ""
 
-#: src/review/forms.py:281
+#: src/review/forms.py:292
 #, fuzzy
 #| msgid "Enter your new password twice to complete the reset process"
 msgid "Are you sure you want to complete the revision request?"
 msgstr "Geef uw wachtwoord twee keer in om het reset proces te voltooien"
 
-#: src/review/forms.py:406
+#: src/review/forms.py:415
 msgid "Author can access this review"
 msgstr ""
 
-#: src/review/forms.py:407
+#: src/review/forms.py:416
 msgid "Author can access review file"
 msgstr ""
 
-#: src/review/forms.py:427
+#: src/review/forms.py:436
 #, python-format
 msgid "Author can see ‘%(name)s’"
 msgstr ""
 
-#: src/review/models.py:195
+#: src/review/models.py:198
 msgid "Anonymity"
 msgstr ""
 
-#: src/review/models.py:331
+#: src/review/models.py:334
 msgid "available for the author to access"
 msgstr ""
 
-#: src/review/models.py:332
+#: src/review/models.py:335
 msgid "not available for the author to access"
 msgstr ""
 
-#: src/review/views.py:1605
+#: src/review/views.py:1664
 #, fuzzy
 #| msgid "This article has been peer reviewed."
 msgid "This article has already been accepted or declined."
 msgstr "Dit artikel heeft 'peer review' ondergaan."
+
+#: src/security/templatetags/securitytags.py:102
+msgid "[Anonymised data]"
+msgstr ""
 
 #: src/submission/decorators.py:22
 msgid "This page can only be accessed on Journals."
@@ -940,80 +953,84 @@ msgstr "Deze pagina kan enkel bezocht worden op Tijdschriften."
 msgid "Submission is disabled for this journal."
 msgstr "Inzendingen zijn uitgeschakeld voor dit tijdschrift."
 
-#: src/submission/forms.py:76
-#: src/templates/admin/submission/submit_review.html:48
+#: src/submission/forms.py:88
+#: src/templates/admin/submission/submit_review.html:53
 msgid "Subtitle"
 msgstr "Ondertitel"
 
-#: src/submission/forms.py:274
+#: src/submission/forms.py:289
 msgid "Enter biography here"
 msgstr ""
 
-#: src/submission/forms.py:277
+#: src/submission/forms.py:292
 #, fuzzy
 #| msgid "Twitter"
 msgid "Twitter handle"
 msgstr "Twitter"
 
-#: src/submission/forms.py:278
+#: src/submission/forms.py:293
 #, fuzzy
 #| msgid "View Profile"
 msgid "LinkedIn profile"
 msgstr "Bekijk profiel"
 
-#: src/submission/forms.py:279
+#: src/submission/forms.py:294
 msgid "ImpactStory profile"
 msgstr ""
 
-#: src/submission/forms.py:280
+#: src/submission/forms.py:295
 #, fuzzy
 #| msgid "ORCID"
 msgid "ORCID ID"
 msgstr "ORCID"
 
-#: src/submission/forms.py:281
+#: src/submission/forms.py:296
 #, fuzzy
 #| msgid "New Email Address"
 msgid "Email address"
 msgstr "Nieuw e-mailadres"
 
-#: src/submission/forms.py:338
+#: src/submission/forms.py:352
 #, python-format
 msgid "Currently linked to %s, leave blank to use this address"
 msgstr "Momenteel gekoppeld aan %s, laat leeg om dit adres te gebruiken"
 
-#: src/submission/forms.py:343
+#: src/submission/forms.py:357
 #, python-format
 msgid "If left blank, the account ORCiD will be used (%s)"
 msgstr "Indien leeg, zal het ORCiD account gebruikt worden (%s)"
 
-#: src/submission/logic.py:98
+#: src/submission/logic.py:99
 msgid "You must upload a file that is either a Doc, Docx, RTF or ODT."
 msgstr ""
 
-#: src/submission/models.py:639
+#: src/submission/models.py:347
+msgid "Additional information regarding this funding entry"
+msgstr ""
+
+#: src/submission/models.py:629
 msgid "Do not use--deprecated in version 1.4.1 and later."
 msgstr ""
 
-#: src/submission/models.py:654
+#: src/submission/models.py:644
 msgid "The primary language of the article"
 msgstr "De primaire taal van het artikel"
 
-#: src/submission/models.py:715
+#: src/submission/models.py:719
 msgid "Custom page range. e.g.: 'I-VII' or 1-3,4-8"
 msgstr "Pagina nummering, zoals ''I-VII' of 1-3,4-8."
 
-#: src/submission/models.py:738
+#: src/submission/models.py:742
 msgid "Add any comments you'd like the editor to consider here."
 msgstr ""
 
-#: src/submission/models.py:761
+#: src/submission/models.py:765
 msgid ""
 "Custom 'how to cite' text. To be used only if the block generated by Janeway "
 "is not suitable."
 msgstr ""
 
-#: src/submission/models.py:767 src/submission/models.py:774
+#: src/submission/models.py:771 src/submission/models.py:778
 msgid ""
 "Name of the publisher who published this article Only relevant to migrated "
 "articles from a different publisher"
@@ -1021,25 +1038,25 @@ msgstr ""
 "Naam van de uitgever die dit artikel publiceerde. Enkel relevant voor "
 "gemigreerde artikels van een andere uitgever"
 
-#: src/submission/models.py:780
+#: src/submission/models.py:784
 msgid ""
 "Original ISSN of this article's journal when published Only relevant for "
 "back content published under a different title"
 msgstr ""
 
-#: src/submission/models.py:1898
+#: src/submission/models.py:1948
 msgid "Optional name prefix (e.g: Prof or Dr)"
 msgstr "Optioneel naam prefix (bv.: Prof of Dr)"
 
-#: src/submission/models.py:1903
+#: src/submission/models.py:1954
 msgid "Optional name suffix (e.g.: Jr or III)"
 msgstr "Optioneel naam suffix (bv.: Jr or III)"
 
-#: src/submission/models.py:1914
+#: src/submission/models.py:1985
 msgid "Frozen Biography"
 msgstr ""
 
-#: src/submission/models.py:1915
+#: src/submission/models.py:1986
 msgid ""
 "The author's biography at the time they published the linked article. For "
 "this article only, it overrides any main biography attached to the author's "
@@ -1047,11 +1064,11 @@ msgid ""
 "account will be populated instead."
 msgstr ""
 
-#: src/submission/models.py:1939
+#: src/submission/models.py:2009
 msgid "Author Email"
 msgstr "E-mail auteur"
 
-#: src/submission/models.py:1944
+#: src/submission/models.py:2015
 msgid ""
 "ORCiD to be displayed when no account is associated with this author. It "
 "should be introduced in code format (e.g: 0000-0000-0000-000X)"
@@ -1059,7 +1076,7 @@ msgstr ""
 "ORCiD wordt weergegeven als er geen account aan deze auteur is gekoppeld. "
 "Het moet worden ingevoerd in codeformaat (bijvoorbeeld: 0000-0000-0000-000X)."
 
-#: src/submission/models.py:1951
+#: src/submission/models.py:2022
 msgid ""
 "If checked, this authors email address link will be displayed on the article "
 "page."
@@ -1067,88 +1084,88 @@ msgstr ""
 "Wanneer aangekruist, zal het e-mailadres van deze auteur getoond worden op "
 "de artikelpagina."
 
-#: src/submission/models.py:2311
-#: src/templates/admin/submission/submit_files.html:69
+#: src/submission/models.py:2387
+#: src/templates/admin/submission/submit_files.html:75
 msgid "Figures and Data Files"
 msgstr "Figuren en databestanden"
 
-#: src/submission/models.py:2318
+#: src/submission/models.py:2394
 msgid "The default license applied when no option is presented"
 msgstr ""
 "De standaard licentie die wordt toegepast wanneer er geen invuloptie wordt "
 "getoond"
 
-#: src/submission/models.py:2326
+#: src/submission/models.py:2402
 msgid "The default language of articles when lang is hidden"
 msgstr "De standaard taal van artikels wanneer taal verborgen is."
 
-#: src/submission/models.py:2332
+#: src/submission/models.py:2408
 msgid "The default section of articles when no option is presented"
 msgstr ""
 "De standaard sectie van artikels wanneer geen optie gepresenteerd wordt"
 
-#: src/submission/views.py:260 src/submission/views.py:295
-#: src/submission/views.py:320
+#: src/submission/views.py:284 src/submission/views.py:319
+#: src/submission/views.py:344
 #, python-brace-format
 msgid "{author_name} added to the article."
 msgstr "{author_name} toegevoegd aan het artikel."
 
-#: src/submission/views.py:288
+#: src/submission/views.py:312
 msgid "Errors found in the new author form"
 msgstr "Fouten gevonden in het formulier voor nieuwe auteur"
 
-#: src/submission/views.py:309
+#: src/submission/views.py:333
 msgid "An empty search is not allowed."
 msgstr "Een lege zoekopdracht is niet toegestaan."
 
-#: src/submission/views.py:327
+#: src/submission/views.py:351
 msgid "No author found with those details."
 msgstr "Geen auteur gevonden met die gegevens."
 
-#: src/submission/views.py:337
+#: src/submission/views.py:361
 msgid "You must select a main author."
 msgstr "U moet een hoofdauteur selecteren."
 
-#: src/submission/views.py:447
+#: src/submission/views.py:569
 msgid "File deleted"
 msgstr "Bestand verwijderd"
 
-#: src/submission/views.py:501
+#: src/submission/views.py:624
 msgid "You must upload a manuscript file."
 msgstr ""
 
-#: src/submission/views.py:564
+#: src/submission/views.py:692
 #, python-brace-format
 msgid "Article {title} submitted"
 msgstr "Artikel {title} ingezonden."
 
-#: src/submission/views.py:661
+#: src/submission/views.py:791
 msgid "Metadata updated."
 msgstr "Metadata aangepast"
 
-#: src/submission/views.py:673
+#: src/submission/views.py:803
 msgid "Primary author set."
 msgstr "Primaire auteur ingesteld."
 
-#: src/submission/views.py:690
+#: src/submission/views.py:820
 #, python-brace-format
 msgid "Author {author_name} updated."
 msgstr "Auteur {author_name} bijgewerkt"
 
-#: src/submission/views.py:708
+#: src/submission/views.py:838
 msgid "Frozen Author deleted."
 msgstr "Bevroren auteur verwijderd."
 
-#: src/submission/views.py:823
+#: src/submission/views.py:953
 msgid "License saved."
 msgstr "Licentie opgeslagen."
 
-#: src/submission/views.py:868
+#: src/submission/views.py:998
 #, python-brace-format
 msgid "License {license_name} deleted."
 msgstr "Licentie {license_name} verwijderd."
 
-#: src/submission/views.py:904
+#: src/submission/views.py:1034
 msgid "Configuration updated."
 msgstr "Configuratie aangepast."
 
@@ -1175,6 +1192,435 @@ msgstr ""
 #: src/templates/admin/copyediting/author_review.html:92
 msgid "Complete Copyedit Task"
 msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:5
+#: src/templates/admin/core/accounts/activate_account.html:10
+#: src/templates/admin/core/accounts/activate_account.html:15
+#: src/templates/admin/core/accounts/activate_account.html:29
+#: src/themes/OLH/templates/core/accounts/activate_account.html:9
+#: src/themes/OLH/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:30
+#: src/themes/clean/templates/core/accounts/activate_account.html:9
+#: src/themes/clean/templates/core/accounts/activate_account.html:17
+#: src/themes/clean/templates/core/accounts/activate_account.html:21
+#: src/themes/hourglass/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:9
+#: src/themes/material/templates/core/accounts/activate_account.html:18
+#: src/themes/material/templates/core/accounts/activate_account.html:23
+msgid "Activate Account"
+msgstr "Account activeren"
+
+#: src/templates/admin/core/accounts/activate_account.html:17
+#, fuzzy
+#| msgid "Account"
+msgid "No account to activate"
+msgstr "Account"
+
+#: src/templates/admin/core/accounts/activate_account.html:24
+#, fuzzy
+#| msgid ""
+#| "You can complete the activation process by clicking the button below."
+msgid ""
+"\n"
+"      You can complete the activation process by clicking the button\n"
+"      below.\n"
+"    "
+msgstr ""
+"U kunt het activeringsproces voltooien door op de onderstaande knop te "
+"klikken."
+
+#: src/templates/admin/core/accounts/activate_account.html:32
+msgid ""
+"\n"
+"      Sorry, we could not find an account to activate, or your account is "
+"active\n"
+"      already. You can check if it is active by attempting to log in.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/activate_account.html:38
+#: src/templates/admin/core/accounts/login.html:5
+#: src/templates/admin/core/accounts/login.html:13
+#: src/templates/admin/core/accounts/orcid_registration.html:38
+#: src/themes/OLH/templates/core/login.html:43
+#: src/themes/clean/templates/core/login.html:40
+msgid "Log in"
+msgstr "Inloggen"
+
+#: src/templates/admin/core/accounts/edit_profile.html:9
+#: src/templates/admin/core/accounts/edit_profile.html:17
+#: src/themes/OLH/templates/core/accounts/edit_profile.html:8
+#: src/themes/clean/templates/core/accounts/edit_profile.html:9
+#: src/themes/hourglass/templates/core/accounts/edit_profile.html:11
+#: src/themes/material/templates/core/accounts/edit_profile.html:8
+msgid "Edit Profile"
+msgstr "Profiel bewerken"
+
+#: src/templates/admin/core/accounts/edit_profile.html:26
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
+msgid "Change Your Email Address"
+msgstr "E-mailadres wijzigen"
+
+#: src/templates/admin/core/accounts/edit_profile.html:28
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                <p>If you want to change your email address you may do so "
+#| "below, however, you will be logged out and your\n"
+#| "                account will be marked as inactive until you follow the "
+#| "instructions in the verification email. <strong>Note: </strong>\n"
+#| "                Changing your email address will also change your "
+#| "username as these are one and the same.</p>\n"
+#| "                "
+msgid ""
+"\n"
+"          <p>If you want to change your email address you may do so below,\n"
+"          however, you will be logged out and your\n"
+"          account will be marked as inactive until you follow the\n"
+"          instructions in the verification email. <strong>Note: </strong>\n"
+"          Changing your email address will also change your username as "
+"these\n"
+"          are one and the same.</p>\n"
+"        "
+msgstr ""
+"\n"
+" <p>Als u uw e-mailadres wilt wijzigen, kunt u dat hieronder doen, maar u "
+"wordt dan uitgelogd en uw account wordt gemarkeerd als inactief totdat u de "
+"instructies in de verificatie-e-mail volgt. <strong>Opmerking: </strong> Als "
+"u uw e-mailadres wijzigt, verandert ook uw gebruikersnaam, aangezien deze "
+"één en dezelfde zijn.</p>"
+
+#: src/templates/admin/core/accounts/edit_profile.html:36
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
+msgid "Current Email Address"
+msgstr "Huidig e-mailadres"
+
+#: src/templates/admin/core/accounts/edit_profile.html:43
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
+msgid "New Email Address"
+msgstr "Nieuw e-mailadres"
+
+#: src/templates/admin/core/accounts/edit_profile.html:50
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
+msgid "Update Email Address"
+msgstr "Update e-mailadres"
+
+#: src/templates/admin/core/accounts/edit_profile.html:58
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
+#, fuzzy
+#| msgid "Register for an"
+msgid "Register for Article Notifications"
+msgstr "Registreer voor een"
+
+#: src/templates/admin/core/accounts/edit_profile.html:61
+msgid ""
+"\n"
+"              Use the button below to register to receive notifications of "
+"new articles\n"
+"              published in this journal.\n"
+"            "
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:68
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
+msgid "Unsubscribe from Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:72
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
+msgid "Subscribe to Article Notifications"
+msgstr ""
+
+#: src/templates/admin/core/accounts/edit_profile.html:80
+#: src/templates/admin/core/accounts/edit_profile.html:115
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
+msgid "Update Password"
+msgstr "Update wachtwoord"
+
+#: src/templates/admin/core/accounts/edit_profile.html:82
+#, fuzzy
+#| msgid ""
+#| "You can update your password by entering your existing password plus your "
+#| "new password."
+msgid ""
+"\n"
+"          You can update your password by entering your existing\n"
+"          password plus your new password.\n"
+"        "
+msgstr ""
+"U kunt uw wachtwoord bijwerken door uw bestaande wachtwoord en uw nieuwe "
+"wachtwoord in te voeren."
+
+#: src/templates/admin/core/accounts/edit_profile.html:91
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
+#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
+msgid "Current Password"
+msgstr "Huidig wachtwoord"
+
+#: src/templates/admin/core/accounts/edit_profile.html:98
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
+msgid "New Password"
+msgstr "Nieuw wachtwoord"
+
+#: src/templates/admin/core/accounts/edit_profile.html:105
+#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
+#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
+msgid "Enter Password Again"
+msgstr "Geef wachtwoord opnieuw in"
+
+#: src/templates/admin/core/accounts/edit_profile.html:122
+#, fuzzy
+#| msgid "Profile Image"
+msgid "Profile Details"
+msgstr "Profiel afbeelding"
+
+#: src/templates/admin/core/accounts/edit_profile.html:132
+#: src/templates/admin/core/accounts/reset_password.html:31
+#: src/templates/admin/press/edit_press_journal_description.html:24
+#: src/templates/admin/review/view_review.html:168
+#: src/templates/admin/review/view_review.html:189
+msgid "Save"
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:5
+#: src/templates/admin/core/accounts/get_reset_token.html:10
+#: src/templates/admin/core/accounts/get_reset_token.html:14
+#, fuzzy
+#| msgid "Reset Password"
+msgid "Reset password"
+msgstr "Wachtwoord opnieuw instellen"
+
+#: src/templates/admin/core/accounts/get_reset_token.html:20
+msgid ""
+"\n"
+"      Enter your email address and then follow the link sent to you by "
+"email.\n"
+"    "
+msgstr ""
+
+#: src/templates/admin/core/accounts/get_reset_token.html:27
+#, fuzzy
+#| msgid "Request Token"
+msgid "Request link"
+msgstr "Token aanvragen"
+
+#: src/templates/admin/core/accounts/login.html:24
+#: src/themes/OLH/templates/core/login.html:28
+#: src/themes/clean/templates/core/login.html:16
+#: src/themes/material/templates/core/login.html:18
+msgid "Log in with ORCiD"
+msgstr "Inloggen met ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:33
+#, fuzzy
+#| msgid "Login with ORCiD"
+msgid "Log in with"
+msgstr "Inloggen met ORCiD"
+
+#: src/templates/admin/core/accounts/login.html:45
+#: src/themes/OLH/templates/core/login.html:27
+#: src/themes/OLH/templates/press/core/login.html:25
+#: src/themes/clean/templates/core/login.html:14
+msgid "Log in with your account"
+msgstr "Inloggen met uw account"
+
+#: src/templates/admin/core/accounts/login.html:50
+#: src/templates/admin/core/accounts/orcid_registration.html:43
+#: src/themes/OLH/templates/core/login.html:44
+#: src/themes/clean/templates/core/login.html:44
+msgid "Forgotten your password?"
+msgstr "Wachtwoord vergeten?"
+
+#: src/templates/admin/core/accounts/login.html:55
+#: src/templates/admin/core/accounts/orcid_registration.html:48
+#: src/themes/OLH/templates/core/login.html:45
+#: src/themes/clean/templates/core/login.html:48
+msgid "Register a new account"
+msgstr "Nieuwe account registreren"
+
+#: src/templates/admin/core/accounts/orcid_registration.html:5
+#: src/templates/admin/core/accounts/orcid_registration.html:10
+#: src/templates/admin/core/accounts/orcid_registration.html:14
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:9
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:23
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:8
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:13
+msgid "Unregistered ORCiD"
+msgstr "Ongeregistreerde ORCiD"
+
+#: src/templates/admin/core/accounts/orcid_registration.html:19
+#, fuzzy
+#| msgid ""
+#| "The ORCiD you logged in with is not currently linked with an account in "
+#| "our system. You can either register a new account, or login with an "
+#| "existing account to link your ORCiD for future use."
+msgid ""
+"\n"
+"    The ORCiD you logged in with is not currently linked with an\n"
+"    account in our system. You can either register a new account, or login "
+"with\n"
+"    an existing account to link your ORCiD for future use.\n"
+"  "
+msgstr ""
+"De ORCiD waarmee u bent ingelogd, is momenteel niet gekoppeld aan een "
+"account in ons systeem. U kunt een nieuw account registreren of inloggen met "
+"een bestaand account om uw ORCiD te koppelen voor toekomstig gebruik."
+
+#: src/templates/admin/core/accounts/password_guide.html:11
+#: src/themes/OLH/templates/core/accounts/register.html:110
+#: src/themes/OLH/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/register.html:54
+#: src/themes/clean/templates/core/accounts/reset_password.html:47
+#: src/themes/material/templates/core/accounts/register.html:53
+#: src/themes/material/templates/core/accounts/reset_password.html:43
+msgid "Password Guide"
+msgstr "Wachtwoordgids"
+
+#: src/templates/admin/core/accounts/password_guide.html:15
+#, fuzzy
+#| msgid "When it comes to passwords, length is better than complexity."
+msgid ""
+"\n"
+"        When it comes to passwords, length is better than complexity.\n"
+"      "
+msgstr "Lengte is beter dan complexiteit voor wat betreft wachtwoorden."
+
+#: src/templates/admin/core/accounts/password_guide.html:18
+#, fuzzy
+#| msgid ""
+#| "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
+#| "secure than a long and uncomplicated password (our awesome moon base "
+#| "rocks)."
+msgid ""
+"\n"
+"        Its a common myth that a short and complex password\n"
+"        (Jfjfy&65^87) is more secure than a long and uncomplicated password\n"
+"        (our awesome moon base rocks).\n"
+"      "
+msgstr ""
+"Het is een mythe dat een kort en complex wachtwoord (Jfjfy&65^87) veiliger "
+"is dan een lang en eenvoudig wachtwoord (our awesome moon base rocks)."
+
+#: src/templates/admin/core/accounts/password_guide.html:23
+#, fuzzy
+#| msgid ""
+#| "We recommend selecting a long, but easy to remember password such as our "
+#| "awesome moon base rocks which would take an estimated septillion years to "
+#| "crack as opposed to a complex one like Jfjfy&65^87 which would take just "
+#| "over 600 years on a standard computer."
+msgid ""
+"\n"
+"        We recommend selecting a long, but easy to remember\n"
+"        password such as our awesome moon base rocks which would take an\n"
+"        estimated septillion years to crack as opposed to a complex one "
+"like\n"
+"        Jfjfy&65^87 which would take just over 600 years on a standard\n"
+"        computer.\n"
+"      "
+msgstr ""
+"We raden aan om een lang, maar makkelijk te onthouden wachtwoord te kiezen. "
+"Bijvoorbeeld om het wachtwoord 'our awesome moon base rocks' te kraken zijn "
+"heeft een standaard computer naar schatting een septiljoen jaren nodig ten "
+"opzichte van 600 jaar voor een complex wachtwoord als 'Jfjfy&65^87'. "
+
+#: src/templates/admin/core/accounts/register.html:5
+#: src/templates/admin/core/accounts/register.html:10
+#: src/templates/admin/core/accounts/register.html:14
+#, fuzzy
+#| msgid "Register for an account with"
+msgid "Register for an account"
+msgstr "Registreer voor een"
+
+#: src/templates/admin/core/accounts/register.html:39
+#: src/templates/admin/core/accounts/reset_password.html:19
+#: src/themes/OLH/templates/core/accounts/register.html:31
+#: src/themes/OLH/templates/core/accounts/reset_password.html:31
+#: src/themes/clean/templates/core/accounts/register.html:22
+#: src/themes/clean/templates/core/accounts/reset_password.html:21
+#: src/themes/material/templates/core/accounts/register.html:24
+#: src/themes/material/templates/core/accounts/reset_password.html:21
+msgid "Password Rules"
+msgstr "Wachtwoordgids"
+
+#: src/templates/admin/core/accounts/register.html:43
+#: src/templates/admin/core/accounts/reset_password.html:23
+#, fuzzy
+#| msgid ""
+#| "For more information read our <a href=\"#\" data-open=\"password-"
+#| "modal\">password guide</a>."
+msgid ""
+"\n"
+"    For more information read our <a href=\"#\"\n"
+"    data-open=\"password-modal\">password guide</a>.\n"
+"  "
+msgstr ""
+"Voor meer informatie lees onze <a href=\"#\" data-open=\"password-"
+"modal\">wachtwoord gids</a>."
+
+#: src/templates/admin/core/accounts/register.html:55
+#: src/themes/OLH/templates/core/accounts/register.html:91
+#: src/themes/clean/templates/core/accounts/register.html:31
+#: src/themes/hourglass/templates/custom/register.html:24
+#: src/themes/material/templates/core/accounts/register.html:37
+msgid "By registering an account you agree to our"
+msgstr "Als u een account registreert gaat u akkoord met onze"
+
+#: src/templates/admin/core/accounts/register.html:63
+#: src/templates/admin/journal/submissions.html:35
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:52
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:54
+#: src/themes/OLH/templates/core/accounts/register.html:9
+#: src/themes/OLH/templates/core/accounts/register.html:100
+#: src/themes/OLH/templates/core/base.html:142
+#: src/themes/OLH/templates/core/nav.html:76
+#: src/themes/OLH/templates/journal/submissions.html:30
+#: src/themes/OLH/templates/press/nav.html:58
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:45
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:47
+#: src/themes/clean/templates/core/accounts/register.html:9
+#: src/themes/clean/templates/core/accounts/register.html:39
+#: src/themes/clean/templates/core/nav.html:104
+#: src/themes/clean/templates/journal/submissions.html:17
+#: src/themes/clean/templates/press/nav.html:79
+#: src/themes/hourglass/templates/core/accounts/register.html:11
+#: src/themes/material/templates/core/accounts/register.html:10
+#: src/themes/material/templates/core/accounts/register.html:44
+#: src/themes/material/templates/core/nav.html:79
+#: src/themes/material/templates/core/nav.html:134
+#: src/themes/material/templates/journal/submissions.html:33
+#: src/themes/material/templates/press/nav.html:67
+#: src/themes/material/templates/press/nav.html:115
+#: src/themes/material/templates/repository/nav.html:60
+msgid "Register"
+msgstr "Registreren"
+
+#: src/templates/admin/core/accounts/reset_password.html:5
+#: src/templates/admin/core/accounts/reset_password.html:10
+#: src/templates/admin/core/accounts/reset_password.html:14
+#, fuzzy
+#| msgid "Enter New Password"
+msgid "Enter your new password"
+msgstr "Nieuw wachtwoord ingeven"
 
 #: src/templates/admin/core/manager/sections/manage_section.html:15
 #: src/templates/admin/core/manager/sections/manage_section.html:22
@@ -1310,6 +1756,30 @@ msgstr ""
 "Je kan geen sectie verwijderen die artikels bevat. Verwijder de artikels van "
 "de sectie vooraleer je ze wil verwijderen."
 
+#: src/templates/admin/core/manager/users/list.html:16
+#, fuzzy
+#| msgid "Journals"
+msgid "Journal Users"
+msgstr "Tijdschriften"
+
+#: src/templates/admin/core/manager/users/list.html:18
+#, fuzzy
+#| msgid "All Preprints"
+msgid "All Users"
+msgstr "Alle preprints"
+
+#: src/templates/admin/core/manager/users/list.html:40
+#, fuzzy
+#| msgid "Username"
+msgid "Users"
+msgstr "Gebruikersnaam"
+
+#: src/templates/admin/core/manager/users/list.html:70
+#, fuzzy
+#| msgid "No articles to display."
+msgid "No accounts to display."
+msgstr "Geen artikels om weer te geven."
+
 #: src/templates/admin/core/request_submission_access.html:14
 msgid "requires that you request permission to make a submission."
 msgstr ""
@@ -1325,44 +1795,64 @@ msgid "You have an active access request that was submitted on: "
 msgstr ""
 
 #: src/templates/admin/elements/accounts/user_form.html:4
-#: src/themes/OLH/templates/elements/accounts/user_form.html:5
-#: src/themes/clean/templates/elements/accounts/user_form.html:5
-#: src/themes/material/templates/elements/accounts/user_form.html:6
-msgid "Core Data"
-msgstr "Kerngegevens"
+#: src/templates/admin/repository/article.html:212
+#: src/templates/admin/repository/author_article.html:91
+#: src/templates/admin/repository/submit/authors.html:76
+#: src/templates/admin/submission/submit_authors.html:69
+#: src/templates/admin/submission/submit_funding.html:72
+#: src/templates/common/elements/funder_info_for_readers.html:4
+msgid "Name"
+msgstr "Naam"
 
-#: src/templates/admin/elements/accounts/user_form.html:61
+#: src/templates/admin/elements/accounts/user_form.html:13
+#, fuzzy
+#| msgid "Affiliation"
+msgid "Affiliations"
+msgstr "Affiliatie"
+
+#: src/templates/admin/elements/accounts/user_form.html:20
+#: src/themes/OLH/templates/elements/accounts/user_form.html:41
+#: src/themes/clean/templates/elements/accounts/user_form.html:38
+#: src/themes/material/templates/elements/accounts/user_form.html:39
+msgid "Social Media and Accounts"
+msgstr "Sociale media en accounts"
+
+#: src/templates/admin/elements/accounts/user_form.html:30
 #: src/themes/OLH/templates/elements/accounts/user_form.html:65
 #: src/themes/clean/templates/elements/accounts/user_form.html:62
 #: src/themes/material/templates/elements/accounts/user_form.html:63
 msgid "Biography and Signature"
 msgstr "Biografie en ondertekening"
 
-#: src/templates/admin/elements/accounts/user_form.html:70
+#: src/templates/admin/elements/accounts/user_form.html:40
+#: src/templates/admin/elements/accounts/user_form.html:43
 #: src/themes/OLH/templates/elements/accounts/user_form.html:74
 #: src/themes/clean/templates/elements/accounts/user_form.html:71
 #: src/themes/material/templates/elements/accounts/user_form.html:72
 msgid "Review Interests"
 msgstr "Review-interesses"
 
-#: src/templates/admin/elements/accounts/user_form.html:71
+#: src/templates/admin/elements/accounts/user_form.html:50
 #: src/themes/OLH/templates/elements/accounts/user_form.html:75
 #: src/themes/clean/templates/elements/accounts/user_form.html:72
 #: src/themes/material/templates/elements/accounts/user_form.html:73
 msgid "Hit Enter to add a new interest"
 msgstr "Druk op Enter om een ​​nieuwe interesse toe te voegen."
 
-#: src/templates/admin/elements/accounts/user_form.html:75
+#: src/templates/admin/elements/accounts/user_form.html:53
 #: src/themes/OLH/templates/elements/accounts/user_form.html:79
 #: src/themes/clean/templates/elements/accounts/user_form.html:76
 #: src/themes/material/templates/elements/accounts/user_form.html:77
 msgid "Profile Image"
 msgstr "Profiel afbeelding"
 
-#: src/templates/admin/elements/accounts/user_form.html:91
-#, fuzzy
-#| msgid "Options"
-msgid "Email Options"
+#: src/templates/admin/elements/accounts/user_form.html:69
+#: src/themes/OLH/templates/elements/accounts/user_form.html:95
+#: src/themes/OLH/templates/journal/article.html:107
+#: src/themes/OLH/templates/journal/article.html:108
+#: src/themes/clean/templates/elements/accounts/user_form.html:92
+#: src/themes/material/templates/elements/accounts/user_form.html:93
+msgid "Options"
 msgstr "Opties"
 
 #: src/templates/admin/elements/confirm_modal.html:7
@@ -1386,7 +1876,7 @@ msgstr ""
 msgid "No, go back"
 msgstr ""
 
-#: src/templates/admin/elements/forms/field.html:7
+#: src/templates/admin/elements/forms/field.html:13
 msgid "translatable"
 msgstr "Vertaalbaar"
 
@@ -1406,6 +1896,10 @@ msgid ""
 msgstr ""
 "Als je geen metrics wil tonen, kan je ze allemaal uitschakelen, of je kan "
 "hieronder de citation metrics uitschakelen."
+
+#: src/templates/admin/elements/forms/group_article.html:37
+msgid "Enable the display of the dates an article was submitted and accepted."
+msgstr ""
 
 #: src/templates/admin/elements/forms/group_journal.html:32
 msgid ""
@@ -1443,7 +1937,7 @@ msgstr ""
 msgid "How should editors and staff members get help with Janeway?"
 msgstr ""
 
-#: src/templates/admin/elements/forms/group_journal_images.html:10
+#: src/templates/admin/elements/forms/group_journal_images.html:11
 msgid ""
 "For details about where each image appears, see the Janeway documentation: "
 msgstr ""
@@ -1466,17 +1960,17 @@ msgstr ""
 msgid "Review Form manager"
 msgstr "Review formulier manager"
 
-#: src/templates/admin/elements/forms/group_review.html:29
+#: src/templates/admin/elements/forms/group_review.html:28
 msgid "Settings here determine the review form experience."
 msgstr "Instellingen hier bepalen de ervaring met het reviewformulier."
 
-#: src/templates/admin/elements/forms/group_review.html:41
+#: src/templates/admin/elements/forms/group_review.html:40
 #, fuzzy
 #| msgid "Settings here determine the review experience for authors."
 msgid "Settings here determine the review experience for editors."
 msgstr "De instellingen hier bepalen de review ervaring voor auteurs."
 
-#: src/templates/admin/elements/forms/group_review.html:49
+#: src/templates/admin/elements/forms/group_review.html:48
 msgid "Settings here determine the review experience for authors."
 msgstr "De instellingen hier bepalen de review ervaring voor auteurs."
 
@@ -1492,15 +1986,31 @@ msgstr ""
 "Onderstaande tekst vormt de inzendingenpagina en de inzendingsovereenkomst "
 "die de auteurs aanvaarden."
 
-#: src/templates/admin/elements/fundref/fundref.html:24
+#: src/templates/admin/elements/forms/messages_in_callout.html:11
+msgid "Problems processing the form"
+msgstr ""
+
+#: src/templates/admin/elements/fundref/fundref.html:22
 msgid "Funder"
 msgstr "Financier"
 
-#: src/templates/admin/elements/fundref/fundref.html:61
-#: src/templates/admin/elements/fundref/fundref.html:82
-#: src/templates/admin/elements/fundref/fundref.html:166
-#: src/templates/admin/submission/submit_funding.html:85
-#: src/templates/admin/submission/submit_funding.html:108
+#: src/templates/admin/elements/fundref/fundref.html:23
+#: src/templates/admin/submission/submit_funding.html:73
+#: src/templates/common/elements/funder_info_for_readers.html:5
+#, fuzzy
+#| msgid "Funder DOI"
+msgid "FundRef ID"
+msgstr "DOI financier"
+
+#: src/templates/admin/elements/fundref/fundref.html:24
+#, fuzzy
+#| msgid "Add funder"
+msgid "Add Funder"
+msgstr "Financier toevoegen"
+
+#: src/templates/admin/elements/fundref/fundref.html:39
+#: src/templates/admin/submission/submit_funding.html:121
+#: src/templates/admin/submission/submit_funding.html:128
 msgid "Add funder"
 msgstr "Financier toevoegen"
 
@@ -1520,6 +2030,34 @@ msgstr ""
 #| msgid "Sort articles by"
 msgid "Sort Articles"
 msgstr "Sorteer artikels op"
+
+#: src/templates/admin/elements/list_filters.html:7
+#, fuzzy
+#| msgid "Sort and Filter"
+msgid "Search and filter"
+msgstr "Sorteren en filteren"
+
+#: src/templates/admin/elements/list_filters.html:28
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
+msgid "Apply"
+msgstr ""
+
+#: src/templates/admin/elements/list_filters.html:32
+#: src/themes/OLH/templates/elements/journal/article_list_filters.html:10
+#: src/themes/clean/templates/elements/journal/article_list_filters.html:11
+#: src/themes/material/templates/elements/journal/article_list_filters.html:15
+#, fuzzy
+#| msgid "Clear Filters"
+msgid "Clear all"
+msgstr "Verwijder filters"
+
+#: src/templates/admin/elements/metadata.html:143
+#: src/templates/admin/submission/edit/metadata.html:244
+#: src/templates/admin/submission/submit_funding.html:75
+#: src/templates/common/elements/funder_info_for_readers.html:7
+msgid "Funding Statement"
+msgstr ""
 
 #: src/templates/admin/elements/move_to_next_modal.html:7
 msgid "Workflow Info"
@@ -1556,7 +2094,7 @@ msgid "Save Publisher Note"
 msgstr "Uitgeversnotitie opslaan"
 
 #: src/templates/admin/elements/repository/metadata_form.html:39
-#: src/templates/admin/repository/submit/start.html:73 src/utils/forms.py:55
+#: src/templates/admin/repository/submit/start.html:71 src/utils/forms.py:60
 msgid "Hit Enter to add a new keyword."
 msgstr "Druk op Enter om een ​​nieuw trefwoord toe te voegen."
 
@@ -1566,10 +2104,10 @@ msgid "Additional Fields"
 msgstr "Bijkomende velden"
 
 #: src/templates/admin/elements/submit/author.html:8
-#: src/templates/admin/repository/submit/authors.html:65
-#: src/templates/admin/repository/submit/authors.html:116
-#: src/templates/admin/repository/submit/authors.html:123
-#: src/templates/admin/submission/submit_authors.html:49
+#: src/templates/admin/repository/submit/authors.html:62
+#: src/templates/admin/repository/submit/authors.html:113
+#: src/templates/admin/repository/submit/authors.html:120
+#: src/templates/admin/submission/submit_authors.html:54
 #: src/themes/OLH/templates/elements/submit/author.html:8
 msgid "Add New Author"
 msgstr "Nieuwe auteur toevoegen"
@@ -1579,14 +2117,13 @@ msgstr "Nieuwe auteur toevoegen"
 msgid "Add Author"
 msgstr "Auteur toevoegen"
 
-#: src/templates/admin/elements/submit/file.html:7
+#: src/templates/admin/elements/submit/file.html:9
 #: src/themes/OLH/templates/elements/submit/file.html:6
 #: src/themes/OLH/templates/elements/submit/preprint_file.html:6
 msgid "Add New File"
 msgstr "Nieuw bestand toevoegen"
 
-#: src/templates/admin/elements/submit/file.html:35
-#: src/templates/admin/elements/submit/file.html:51
+#: src/templates/admin/elements/submit/file.html:33
 #: src/themes/OLH/templates/elements/submit/file.html:25
 #: src/themes/OLH/templates/elements/submit/preprint_file.html:25
 msgid "Add File"
@@ -1638,6 +2175,7 @@ msgstr "Contact informatie"
 #: src/themes/clean/templates/journal/contact.html:5
 #: src/themes/clean/templates/journal/contact.html:21
 #: src/themes/clean/templates/press/nav.html:53
+#: src/themes/hourglass/templates/press/contact.html:4
 #: src/themes/material/templates/core/nav.html:42
 #: src/themes/material/templates/core/nav.html:103
 #: src/themes/material/templates/journal/contact.html:5
@@ -1647,14 +2185,6 @@ msgstr "Contact informatie"
 msgid "Contact"
 msgstr "Contacteer"
 
-#: src/core/models.py:1492
-#: src/templates/admin/journal/contact.html:38
-#: src/themes/OLH/templates/journal/contact.html:30
-#: src/themes/OLH/templates/press/journal/contact.html:22
-#: src/themes/clean/templates/journal/contact.html:27
-msgid "Who would you like to contact?"
-msgstr "Wie wilt u contacteren?"
-
 #: src/templates/admin/journal/contact.html:52
 #: src/themes/OLH/templates/journal/contact.html:39
 #: src/themes/OLH/templates/press/journal/contact.html:30
@@ -1663,39 +2193,39 @@ msgstr "Wie wilt u contacteren?"
 msgid "Send Message"
 msgstr "Bericht versturen"
 
-#: src/templates/admin/journal/manage/archive_article.html:24
+#: src/templates/admin/journal/manage/archive_article.html:25
 #, fuzzy
 #| msgid "Edit Article"
 msgid "Edit Article Images"
 msgstr "Artikel bewerken"
 
-#: src/templates/admin/journal/manage/archive_article.html:26
+#: src/templates/admin/journal/manage/archive_article.html:27
 #, fuzzy
 #| msgid "Publication"
 msgid "Edit Publication Info"
 msgstr "Publicatie"
 
-#: src/templates/admin/journal/manage/archive_article.html:28
+#: src/templates/admin/journal/manage/archive_article.html:29
 #, fuzzy
 #| msgid "Latest Articles & News"
 msgid "Remote Article View"
 msgstr "Laatste artikels en nieuws"
 
-#: src/templates/admin/journal/manage/archive_article.html:178
+#: src/templates/admin/journal/manage/archive_article.html:179
 msgid "Undo Article Rejection"
 msgstr ""
 
-#: src/templates/admin/journal/manage/archive_article.html:182
+#: src/templates/admin/journal/manage/archive_article.html:183
 msgid "Review"
 msgstr "Review"
 
-#: src/templates/admin/journal/manage/archive_article.html:184
+#: src/templates/admin/journal/manage/archive_article.html:185
 #, fuzzy
 #| msgid "Assign"
 msgid "Unassigned"
 msgstr "Toewijzen"
 
-#: src/templates/admin/journal/manage/archive_article.html:186
+#: src/templates/admin/journal/manage/archive_article.html:187
 #, python-format
 msgid ""
 "You will have the opportunity to send an email to the author, and then the "
@@ -1720,52 +2250,26 @@ msgid ""
 "                 "
 msgstr ""
 
-#: src/templates/admin/journal/submissions.html:35
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:48
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:50
-#: src/themes/OLH/templates/core/accounts/register.html:5
-#: src/themes/OLH/templates/core/accounts/register.html:96
-#: src/themes/OLH/templates/core/base.html:141
-#: src/themes/OLH/templates/core/nav.html:77
-#: src/themes/OLH/templates/journal/submissions.html:30
-#: src/themes/OLH/templates/press/nav.html:58
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:41
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:43
-#: src/themes/clean/templates/core/accounts/register.html:5
-#: src/themes/clean/templates/core/accounts/register.html:39
-#: src/themes/clean/templates/core/nav.html:104
-#: src/themes/clean/templates/journal/submissions.html:17
-#: src/themes/clean/templates/press/nav.html:79
-#: src/themes/material/templates/core/accounts/register.html:6
-#: src/themes/material/templates/core/accounts/register.html:44
-#: src/themes/material/templates/core/nav.html:79
-#: src/themes/material/templates/core/nav.html:134
-#: src/themes/material/templates/journal/submissions.html:33
-#: src/themes/material/templates/press/nav.html:67
-#: src/themes/material/templates/press/nav.html:115
-#: src/themes/material/templates/repository/nav.html:60
-msgid "Register"
-msgstr "Registreren"
-
 #: src/templates/admin/journal/submissions.html:36
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:28
-#: src/themes/OLH/templates/core/base.html:141
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:32
+#: src/themes/OLH/templates/core/base.html:142
 #: src/themes/OLH/templates/core/login.html:6
-#: src/themes/OLH/templates/core/nav.html:76
+#: src/themes/OLH/templates/core/nav.html:75
 #: src/themes/OLH/templates/elements/journal_footer.html:30
 #: src/themes/OLH/templates/journal/become_reviewer.html:16
 #: src/themes/OLH/templates/journal/submissions.html:31
 #: src/themes/OLH/templates/press/core/login.html:5
 #: src/themes/OLH/templates/press/elements/press_footer.html:15
 #: src/themes/OLH/templates/press/nav.html:57
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:19
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:23
 #: src/themes/clean/templates/core/login.html:5
 #: src/themes/clean/templates/core/nav.html:103
-#: src/themes/clean/templates/elements/journal_footer.html:41
+#: src/themes/clean/templates/elements/journal_footer.html:43
 #: src/themes/clean/templates/elements/press_footer.html:19
 #: src/themes/clean/templates/journal/become_reviewer.html:13
 #: src/themes/clean/templates/journal/submissions.html:18
 #: src/themes/clean/templates/press/nav.html:77
+#: src/themes/hourglass/templates/core/accounts/login.html:11
 #: src/themes/material/templates/core/login.html:5
 #: src/themes/material/templates/core/login.html:42
 #: src/themes/material/templates/core/nav.html:78
@@ -1779,7 +2283,7 @@ msgid "Login"
 msgstr "Inloggen"
 
 #: src/templates/admin/journal/submissions.html:38
-#: src/templates/admin/submission/start.html:72
+#: src/templates/admin/submission/start.html:77
 #: src/themes/OLH/templates/core/nav.html:43
 #: src/themes/OLH/templates/journal/submissions.html:32
 #: src/themes/clean/templates/core/nav.html:71
@@ -1800,10 +2304,13 @@ msgid "Licences"
 msgstr "Licenties"
 
 #: src/templates/admin/journal/submissions.html:48
+#: src/templates/admin/submission/submit_info.html:109
 #: src/themes/OLH/templates/journal/submissions.html:40
 #: src/themes/clean/templates/journal/submissions.html:27
 #: src/themes/material/templates/journal/submissions.html:46
-msgid "allows the following licences for submission"
+#, fuzzy
+#| msgid "allows the following licences for submission"
+msgid "The following licences are allowed:"
 msgstr "laat de volgende licenties toe bij inzendingen"
 
 #: src/templates/admin/press/edit_press_journal_description.html:5
@@ -1814,8 +2321,9 @@ msgstr ""
 #: src/templates/admin/press/edit_press_journal_description.html:11
 #: src/templates/admin/press/edit_press_journal_description.html:17
 #: src/templates/admin/repository/article.html:215
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 #: src/templates/admin/review/view_review.html:112
+#: src/templates/admin/submission/submit_funding.html:76
 #: src/themes/OLH/templates/elements/edit_author.html:4
 msgid "Edit"
 msgstr "Bewerken"
@@ -1832,12 +2340,6 @@ msgid ""
 "description is used."
 msgstr ""
 
-#: src/templates/admin/press/edit_press_journal_description.html:24
-#: src/templates/admin/review/view_review.html:168
-#: src/templates/admin/review/view_review.html:189
-msgid "Save"
-msgstr ""
-
 #: src/templates/admin/press/edit_press_journal_description.html:25
 #, fuzzy
 #| msgid "Description"
@@ -1852,31 +2354,24 @@ msgstr "Elke proefleesronde is beperkt tot"
 msgid "proofreaders"
 msgstr "proeflezers"
 
-#: src/templates/admin/repository/article.html:212
-#: src/templates/admin/repository/author_article.html:91
-#: src/templates/admin/repository/submit/authors.html:79
-#: src/templates/admin/submission/submit_authors.html:64
-#: src/templates/admin/submission/submit_funding.html:49
-msgid "Name"
-msgstr "Naam"
-
 #: src/templates/admin/repository/article.html:214
 #: src/templates/admin/repository/author_article.html:93
-#: src/templates/admin/repository/submit/authors.html:81
-#: src/templates/admin/submission/submit_review.html:102
-#: src/themes/OLH/templates/core/accounts/public_profile.html:14
-#: src/themes/clean/templates/core/accounts/public_profile.html:14
-#: src/themes/material/templates/core/accounts/public_profile.html:14
+#: src/templates/admin/repository/submit/authors.html:78
+#: src/templates/admin/submission/submit_review.html:118
+#: src/themes/OLH/templates/core/accounts/public_profile.html:42
+#: src/themes/clean/templates/core/accounts/public_profile.html:18
+#: src/themes/material/templates/core/accounts/public_profile.html:18
 msgid "Affiliation"
 msgstr "Affiliatie"
 
 #: src/templates/admin/repository/article.html:216
-#: src/templates/admin/repository/submit/authors.html:82
+#: src/templates/admin/repository/submit/authors.html:79
+#: src/templates/admin/submission/submit_funding.html:77
 msgid "Delete"
 msgstr ""
 
 #: src/templates/admin/repository/article.html:239
-#: src/templates/admin/repository/submit/authors.html:97
+#: src/templates/admin/repository/submit/authors.html:94
 msgid "No authors added."
 msgstr ""
 
@@ -1894,37 +2389,37 @@ msgstr ""
 msgid "Add Authors to"
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:23
-#: src/themes/clean/templates/journal/article.html:217
+#: src/templates/admin/repository/submit/authors.html:20
+#: src/themes/clean/templates/journal/article.html:219
 msgid "Information"
 msgstr "Informatie"
 
-#: src/templates/admin/repository/submit/authors.html:27
+#: src/templates/admin/repository/submit/authors.html:24
 msgid ""
 "You can add yourself as an author using the button below. This will copy "
 "metadata from your profile to create a"
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:27
+#: src/templates/admin/repository/submit/authors.html:24
 msgid "author record."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:28
+#: src/templates/admin/repository/submit/authors.html:25
 msgid ""
 "You can search the database of existing authors and add them as authors."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:29
+#: src/templates/admin/repository/submit/authors.html:26
 msgid "You can create a new record for an author using the form below."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:34
-#: src/templates/admin/submission/submit_authors.html:46
+#: src/templates/admin/repository/submit/authors.html:31
+#: src/templates/admin/submission/submit_authors.html:51
 msgid "Add Self as Author"
 msgstr "Uzelf toevoegen als auteur"
 
-#: src/templates/admin/repository/submit/authors.html:37
-#: src/templates/admin/submission/submit_authors.html:44
+#: src/templates/admin/repository/submit/authors.html:34
+#: src/templates/admin/submission/submit_authors.html:49
 msgid ""
 "By default, your account is the owner of this submission, but is not an "
 "Author on record. You can add yourself using the button below."
@@ -1932,22 +2427,22 @@ msgstr ""
 "Standaard is je account eigenaar van deze inzending, maar niet de auteur. Je "
 "kan jezelf toevoegen als auteur door op onderstaand knop te klikken."
 
-#: src/templates/admin/repository/submit/authors.html:45
+#: src/templates/admin/repository/submit/authors.html:42
 msgid "Search for an Author"
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:48
+#: src/templates/admin/repository/submit/authors.html:45
 msgid ""
 "You can search by email or ORCiD. eg. person@example.com or "
 "0000-0003-2126-266X."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/repository/submit/authors.html:58
 msgid "Add an Author"
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:64
-#: src/templates/admin/submission/submit_authors.html:48
+#: src/templates/admin/repository/submit/authors.html:61
+#: src/templates/admin/submission/submit_authors.html:53
 msgid ""
 "If you cannot find the author record by searching, and you are not the only "
 "author, you can add one by clicking the button below. This will open a popup "
@@ -1957,97 +2452,93 @@ msgstr ""
 "dan kan je een auteur toevoegen door op onderstaande knop te klikken. In het "
 "popup venster dat dan verschijnt, kan je de gegevens van de auteur ingeven."
 
-#: src/templates/admin/repository/submit/authors.html:70
+#: src/templates/admin/repository/submit/authors.html:67
 #: src/themes/OLH/templates/journal/article.html:27
 #: src/themes/OLH/templates/journal/article.html:63
-#: src/themes/OLH/templates/journal/article.html:158
-#: src/themes/OLH/templates/journal/article.html:332
+#: src/themes/OLH/templates/journal/article.html:161
+#: src/themes/OLH/templates/journal/article.html:313
 #: src/themes/OLH/templates/journal/authors.html:4
 #: src/themes/OLH/templates/journal/authors.html:5
 #: src/themes/OLH/templates/journal/authors.html:11
 #: src/themes/OLH/templates/journal/print.html:15
 #: src/themes/OLH/templates/repository/preprint.html:33
 #: src/themes/clean/templates/journal/article.html:37
-#: src/themes/clean/templates/journal/article.html:167
+#: src/themes/clean/templates/journal/article.html:153
 #: src/themes/clean/templates/journal/authors.html:9
 #: src/themes/clean/templates/journal/print.html:15
-#: src/themes/material/templates/journal/article.html:269
+#: src/themes/material/templates/journal/article.html:250
 #: src/themes/material/templates/journal/authors.html:5
 #: src/themes/material/templates/journal/authors.html:6
 #: src/themes/material/templates/journal/authors.html:10
 #: src/themes/material/templates/preprints/article.html:28
-#: src/themes/material/templates/repository/preprint.html:149
+#: src/themes/material/templates/repository/preprint.html:147
 msgid "Authors"
 msgstr "Auteurs"
 
-#: src/templates/admin/repository/submit/authors.html:73
+#: src/templates/admin/repository/submit/authors.html:70
 msgid ""
 "You can reorder the authors by dragging and dropping rows in the table below."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:103
+#: src/templates/admin/repository/submit/authors.html:100
 msgid "Once you have added all of your authors you can complete this stage."
 msgstr ""
 
-#: src/templates/admin/repository/submit/authors.html:106
-msgid "Complete Step 2 of 3"
+#: src/templates/admin/repository/submit/authors.html:103
+msgid "Complete Step 2 of 4"
 msgstr ""
 
 #: src/templates/admin/repository/submit/files.html:8
 msgid "Upload Files for"
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:29
+#: src/templates/admin/repository/submit/files.html:25
 msgid "You can use the form below to select and upload your manuscript file."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:43
 msgid "Supplementary files"
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:50
+#: src/templates/admin/repository/submit/files.html:46
 msgid "Optional links to externaly hosted supplementary files."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:51
-#: src/templates/admin/repository/submit/files.html:101
-#: src/templates/admin/repository/submit/files.html:108
+#: src/templates/admin/repository/submit/files.html:47
+#: src/templates/admin/repository/submit/files.html:97
+#: src/templates/admin/repository/submit/files.html:104
 #: src/templates/admin/repository/supp_files_body.html:53
 msgid "Add New Supplementary File"
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:60
+#: src/templates/admin/repository/submit/files.html:56
 msgid ""
 "If you want to change this file you can upload a new one and it will be "
 "overwritten."
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:93
-msgid "Complete Step 3 of 3"
+#: src/templates/admin/repository/submit/files.html:89
+msgid "Complete Step 3 of 4"
 msgstr ""
 
-#: src/templates/admin/repository/submit/files.html:120
+#: src/templates/admin/repository/submit/files.html:116
 #, fuzzy
 #| msgid "Sections submission information"
 msgid "Submission Information"
 msgstr "Informatie over secties bij de inzending"
 
-#: src/templates/admin/repository/submit/review.html:8
-msgid "Submission Complete"
-msgstr ""
-
-#: src/templates/admin/repository/submit/start.html:26
+#: src/templates/admin/repository/submit/start.html:24
 msgid "Submission Agreement"
 msgstr ""
 
-#: src/templates/admin/repository/submit/start.html:38
+#: src/templates/admin/repository/submit/start.html:36
 #: src/themes/OLH/templates/repository/preprint.html:122
 #: src/themes/material/templates/preprints/article.html:121
 msgid "Metadata"
 msgstr "Metadata"
 
-#: src/templates/admin/repository/submit/start.html:94
-msgid "Complete Step 1 of 3"
+#: src/templates/admin/repository/submit/start.html:92
+msgid "Complete Step 1 of 4"
 msgstr ""
 
 #: src/templates/admin/repository/version_queue.html:19
@@ -2057,16 +2548,35 @@ msgid ""
 msgstr ""
 
 #: src/templates/admin/review/add_review_assignment.html:27
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                        You can select a reviewer using the radio buttons "
+#| "in the first column and complete the section under \"Set Options\".\n"
+#| "                        If you cannot find the reviewer you want in this "
+#| "list you can use \"Enroll Existing User\" to search the database and give "
+#| "users the Reviewer role, or \"Add New Reviewer\" to create a new account "
+#| "for a reviewer (this process is silent, they will not receive an account "
+#| "creation email).\n"
+#| "                        "
 msgid ""
 "\n"
-"                        You can select a reviewer using the radio buttons in "
-"the first column and complete the section under \"Set Options\".\n"
-"                        If you cannot find the reviewer you want in this "
-"list you can use \"Enroll Existing User\" to search the database and give "
-"users the Reviewer role, or \"Add New Reviewer\" to create a new account for "
-"a reviewer (this process is silent, they will not receive an account "
-"creation email).\n"
-"                        "
+"                                You can select a reviewer using the radio\n"
+"                                buttons in the first column and complete "
+"the\n"
+"                                section under 'Set Options'.\n"
+"                                If you cannot find the reviewer you want in\n"
+"                                this list you can use 'Enroll Existing User' "
+"to\n"
+"                                search the database and give users the "
+"Reviewer\n"
+"                                role, or 'Add New Reviewer' to create a new\n"
+"                                account for a reviewer (this process is "
+"silent,\n"
+"                                so they will not receive an account "
+"creation\n"
+"                                email).\n"
+"                            "
 msgstr ""
 "\n"
 " Je kan een reviewer selecteren met behulp van de keuzerondjes in de eerste "
@@ -2077,7 +2587,7 @@ msgstr ""
 "om een ​​nieuw account voor een reviewer aan te maken (dit proces is stil, ze "
 "ontvangen geen e-mail voor het aanmaken van een account)."
 
-#: src/templates/admin/review/decision.html:44
+#: src/templates/admin/review/decision.html:57
 msgid ""
 "Note: This article has completed reviews that have not been made available "
 "to the author:"
@@ -2098,20 +2608,20 @@ msgstr ""
 msgid "No"
 msgstr "Opmerking"
 
-#: src/templates/admin/review/in_review.html:25
+#: src/templates/admin/review/in_review.html:23
 msgid "This article is not yet in the review stage"
 msgstr "Dit artikel zit nog niet in de review fase"
 
-#: src/templates/admin/review/in_review.html:27
+#: src/templates/admin/review/in_review.html:25
 msgid "Before you can move this paper into review you need to"
 msgstr "Vooraleer je deze paper naar review zendt, moet je"
 
-#: src/templates/admin/review/in_review.html:28
+#: src/templates/admin/review/in_review.html:26
 msgid "assign an editor"
 msgstr "Editor toewijzen"
 
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
 msgid ""
 "This paper has not had an automatic plagiarism check. If you wish to do so "
 "you can run a"
@@ -2119,12 +2629,12 @@ msgstr ""
 "Deze paper heeft geen automatische plagiaatcontrole gehad. Als je dat wilt, "
 "kun je een"
 
-#: src/templates/admin/review/in_review.html:41
-#: src/templates/admin/review/unassigned_article.html:288
+#: src/templates/admin/review/in_review.html:39
+#: src/templates/admin/review/unassigned_article.html:295
 msgid "Similarity Check via iThenticate"
 msgstr "Similarity Check via iThenticate"
 
-#: src/templates/admin/review/in_review.html:68
+#: src/templates/admin/review/in_review.html:66
 #, python-format
 msgid ""
 "\n"
@@ -2133,7 +2643,7 @@ msgid ""
 "                                            "
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:217
+#: src/templates/admin/review/in_review.html:215
 msgid ""
 "\n"
 "                                The latest manuscript and figure files for "
@@ -2142,19 +2652,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: src/templates/admin/review/in_review.html:287
+#: src/templates/admin/review/in_review.html:285
 msgid "Move to Next Stage"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:20
+#: src/templates/admin/review/projected_issue.html:27
 msgid "Save Projected Issue"
 msgstr "Geplande nummer opslaan"
 
-#: src/templates/admin/review/projected_issue.html:30
+#: src/templates/admin/review/projected_issue.html:37
 msgid "What is this for?"
 msgstr "Waar dient dit voor?"
 
-#: src/templates/admin/review/projected_issue.html:31
+#: src/templates/admin/review/projected_issue.html:38
 msgid ""
 "The projected issue field can be used internally to keep track of plans and "
 "communicate with typesetters, without affecting issue assignment or "
@@ -2162,21 +2672,21 @@ msgid ""
 "to issues on a rolling basis and publish them individually."
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:32
+#: src/templates/admin/review/projected_issue.html:39
 msgid ""
 "You can assign articles directly to issues in the prepublication stage or "
 "through "
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:32
+#: src/templates/admin/review/projected_issue.html:39
 msgid "issue management"
 msgstr ""
 
-#: src/templates/admin/review/projected_issue.html:33
+#: src/templates/admin/review/projected_issue.html:40
 msgid "How does it work?"
 msgstr "Hoe werkt het?"
 
-#: src/templates/admin/review/projected_issue.html:34
+#: src/templates/admin/review/projected_issue.html:41
 #, fuzzy
 #| msgid ""
 #| "Select an issue from the drop down on the left and press save, this "
@@ -2188,11 +2698,11 @@ msgstr ""
 "Selecteer een nummer in de drop down links en klik op opslaan, om het "
 "geplande nummer voor dit artikel te registreren."
 
-#: src/templates/admin/review/projected_issue.html:35
+#: src/templates/admin/review/projected_issue.html:42
 msgid "Can I unset a projected issue?"
 msgstr "Kan ik een gepland nummer ongedaan maken?"
 
-#: src/templates/admin/review/projected_issue.html:36
+#: src/templates/admin/review/projected_issue.html:43
 #, fuzzy
 #| msgid "Yes, simply select the blank option (-------) from the drop down."
 msgid "Yes, you can select the blank option (-------) from the dropdown."
@@ -2206,23 +2716,23 @@ msgid ""
 "revisions once you click 'Submit Revisions'"
 msgstr ""
 
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 msgid "Assign"
 msgstr "Toewijzen"
 
-#: src/templates/admin/review/unassigned_article.html:117
+#: src/templates/admin/review/unassigned_article.html:120
 msgid "Projected Issue"
 msgstr "Gepland nummer"
 
-#: src/templates/admin/review/unassigned_article.html:122
+#: src/templates/admin/review/unassigned_article.html:125
 msgid "This article is projected to be published as part of"
 msgstr "Dit artikel is gepland om gepubliceerd te worden als deel van"
 
-#: src/templates/admin/review/unassigned_article.html:124
+#: src/templates/admin/review/unassigned_article.html:127
 msgid "This article is not projected to be published as part of any issue."
 msgstr "Dit artikel is niet gepland om gepubliceerd te worden in een nummer"
 
-#: src/templates/admin/review/unassigned_article.html:137
+#: src/templates/admin/review/unassigned_article.html:140
 msgid ""
 "To check an article for possible plagiarism, you can send an article for an "
 "automated Similarity Check via iThenticate by clicking Send below. The "
@@ -2312,7 +2822,6 @@ msgid "Withdrawn"
 msgstr ""
 
 #: src/templates/admin/review/view_review.html:63
-#: src/themes/material/templates/journal/article.html:394
 msgid "Accepted"
 msgstr "Geaccepteerd"
 
@@ -2392,7 +2901,7 @@ msgstr ""
 msgid "Suggested Reviewers"
 msgstr "Peer reviewed"
 
-#: src/templates/admin/submission/edit/metadata.html:178
+#: src/templates/admin/submission/edit/metadata.html:195
 msgid ""
 "\n"
 "                            You can search the <a href=\"https://www."
@@ -2402,7 +2911,7 @@ msgid ""
 "                        "
 msgstr ""
 
-#: src/templates/admin/submission/manager/delete_license.html:26
+#: src/templates/admin/submission/manager/delete_license.html:25
 msgid ""
 "This license is currently used by the following articles. If you delete it "
 "these articles will no longer have a license listed."
@@ -2410,9 +2919,13 @@ msgstr ""
 "Deze licentie wordt momenteel gebruikt door de volgende artikels. Als u deze "
 "licentie verwijderd hebben deze artikels geen licentie meer."
 
-#: src/templates/admin/submission/manager/delete_license.html:27
+#: src/templates/admin/submission/manager/delete_license.html:26
+#, fuzzy
+#| msgid ""
+#| "You should only delete this license if you are absolutley sure you want "
+#| "to remove it."
 msgid ""
-"You should only delete this license if you are absolutley sure you want to "
+"You should only delete this license if you are absolutely sure you want to "
 "remove it."
 msgstr "Verwijder deze licentie enkel wanneer u er heel zeker van bent."
 
@@ -2431,46 +2944,48 @@ msgstr ""
 "Gelieve de onderstaande verklaringen zorgvuldig door te lezen voordat u "
 "items controleert"
 
-#: src/templates/admin/submission/start.html:24
+#: src/templates/admin/submission/start.html:29
 msgid ""
 "All authors must agree to the below statements in order to submit an article "
 "to"
-msgstr "Alle auteurs moeten zich akkoord verklaren met onderstaande stellingen "
-"om een artikel te publiceren in"
+msgstr ""
+"Alle auteurs moeten zich akkoord verklaren met onderstaande stellingen om "
+"een artikel te publiceren in"
 
-#: src/templates/admin/submission/start.html:24
+#: src/templates/admin/submission/start.html:29
 msgid ""
 "If you do not agree with these terms you will be unable to proceed with your "
 "submission."
-msgstr "Als je je niet akkoord verklaart met deze voorwaarden "
-"kan je niet verdergaan met deze inzending."
+msgstr ""
+"Als je je niet akkoord verklaart met deze voorwaarden kan je niet verdergaan "
+"met deze inzending."
 
-#: src/templates/admin/submission/start.html:29
+#: src/templates/admin/submission/start.html:34
 msgid "Publication Fees"
 msgstr "Publicatiekosten"
 
-#: src/templates/admin/submission/start.html:36
+#: src/templates/admin/submission/start.html:41
 msgid "Author(s) agrees to the above statement"
 msgstr "Auteur(s) gaat / gaan akkoord met de bovenstaande verklaring."
 
-#: src/templates/admin/submission/start.html:42
+#: src/templates/admin/submission/start.html:47
 msgid "Submission Checklist"
 msgstr "Checklist voor inzending"
 
-#: src/templates/admin/submission/start.html:48
+#: src/templates/admin/submission/start.html:53
 msgid "Author(s) confirms that this article adheres to the above requirements"
 msgstr ""
 "Auteur(s) bevestigt / bevestigen dat dit artikel voldoet aan de bovenstaande "
 "vereisten"
 
-#: src/templates/admin/submission/start.html:54
+#: src/templates/admin/submission/start.html:59
 msgid "Copyright Notice"
 msgstr "Copyright verklaring"
 
-#: src/templates/admin/submission/start.html:66
-#: src/themes/OLH/templates/journal/article.html:428
-#: src/themes/clean/templates/journal/article.html:255
-#: src/themes/material/templates/journal/article.html:424
+#: src/templates/admin/submission/start.html:71
+#: src/themes/OLH/templates/journal/article.html:419
+#: src/themes/clean/templates/journal/article.html:265
+#: src/themes/material/templates/journal/article.html:400
 msgid "Competing Interests"
 msgstr "Strijdige belangen"
 
@@ -2480,11 +2995,11 @@ msgstr "Strijdige belangen"
 msgid "Author Information"
 msgstr "Auteur informatie"
 
-#: src/templates/admin/submission/submit_authors.html:18
+#: src/templates/admin/submission/submit_authors.html:23
 msgid "Search for Existing Authors"
 msgstr "Naar bestaande auteurs zoeken"
 
-#: src/templates/admin/submission/submit_authors.html:25
+#: src/templates/admin/submission/submit_authors.html:30
 msgid ""
 "Search for a user using email address or ORCiD. If a user is matched, they "
 "will be automatically added as an author. This search only returns exact "
@@ -2494,12 +3009,12 @@ msgstr ""
 "gebruiker overeenkomt, wordt deze automatisch als auteur toegevoegd. Deze "
 "zoekopdracht levert alleen exacte overeenkomsten op."
 
-#: src/templates/admin/submission/submit_authors.html:31
+#: src/templates/admin/submission/submit_authors.html:36
 msgid "Search by email address or ORCiD"
 msgstr "Zoek op e-mailadres of ORCiD"
 
-#: src/templates/admin/submission/submit_authors.html:35
-#: src/themes/OLH/templates/core/base.html:153
+#: src/templates/admin/submission/submit_authors.html:40
+#: src/themes/OLH/templates/core/base.html:154
 #: src/themes/OLH/templates/journal/full-text-search.html:8
 #: src/themes/OLH/templates/journal/full-text-search.html:10
 #: src/themes/OLH/templates/journal/full-text-search.html:70
@@ -2522,23 +3037,23 @@ msgstr "Zoek op e-mailadres of ORCiD"
 msgid "Search"
 msgstr "Zoeken"
 
-#: src/templates/admin/submission/submit_authors.html:40
+#: src/templates/admin/submission/submit_authors.html:45
 msgid "Add Authors"
 msgstr "Auteurs toevoegen"
 
-#: src/templates/admin/submission/submit_authors.html:55
+#: src/templates/admin/submission/submit_authors.html:60
 msgid "Current Authors"
 msgstr "Huidige auteurs"
 
-#: src/templates/admin/submission/submit_authors.html:57
+#: src/templates/admin/submission/submit_authors.html:62
 msgid "Drag and drop an author to re-order them."
 msgstr "Versleep een auteur om de volgorde te wijzigen."
 
-#: src/templates/admin/submission/submit_authors.html:81
+#: src/templates/admin/submission/submit_authors.html:86
 msgid "No authors yet, add one!"
 msgstr "Nog geen auteurs, voeg er één toe!"
 
-#: src/templates/admin/submission/submit_authors.html:88
+#: src/templates/admin/submission/submit_authors.html:93
 msgid ""
 "You are required to select a main author, this author will receive the "
 "communications regarding your articles process through our systems. This "
@@ -2548,14 +3063,14 @@ msgstr ""
 "betrekking tot de voortgang van uw artikel in ons systeem. Dit hoeft u niet "
 "te zijn."
 
-#: src/templates/admin/submission/submit_authors.html:89
+#: src/templates/admin/submission/submit_authors.html:94
 msgid "Select main author"
 msgstr "Hoofdauteur selecteren"
 
-#: src/templates/admin/submission/submit_authors.html:99
-#: src/templates/admin/submission/submit_files.html:112
-#: src/templates/admin/submission/submit_funding.html:75
-#: src/templates/admin/submission/submit_info.html:83
+#: src/templates/admin/submission/submit_authors.html:104
+#: src/templates/admin/submission/submit_files.html:118
+#: src/templates/admin/submission/submit_funding.html:111
+#: src/templates/admin/submission/submit_info.html:93
 msgid "Save and Continue"
 msgstr "Opslaan en doorgaan"
 
@@ -2563,77 +3078,90 @@ msgstr "Opslaan en doorgaan"
 msgid "Upload files"
 msgstr "Bestanden opladen"
 
-#: src/templates/admin/submission/submit_files.html:33
-#: src/templates/admin/submission/submit_files.html:74
+#: src/templates/admin/submission/submit_files.html:39
+#: src/templates/admin/submission/submit_files.html:80
 msgid "Upload"
 msgstr "Opladen"
 
-#: src/templates/admin/submission/submit_files.html:41
-#: src/templates/admin/submission/submit_files.html:81
-#: src/templates/admin/submission/submit_review.html:121
+#: src/templates/admin/submission/submit_files.html:47
+#: src/templates/admin/submission/submit_files.html:87
+#: src/templates/admin/submission/submit_review.html:137
 msgid "File Name"
 msgstr "Bestandsnaam"
 
-#: src/templates/admin/submission/submit_files.html:59
-#: src/templates/admin/submission/submit_files.html:97
+#: src/templates/admin/submission/submit_files.html:65
+#: src/templates/admin/submission/submit_files.html:103
 msgid "No files uploaded"
 msgstr "Geen bestanden opgeladen"
 
 #: src/templates/admin/submission/submit_funding.html:7
-#: src/templates/admin/submission/submit_info.html:6
-#: src/templates/admin/submission/submit_review.html:43
-msgid "Article Info"
-msgstr "Artikel info"
+#, fuzzy
+#| msgid "License Information"
+msgid "Funding Information"
+msgstr "Licentie informatie"
 
-#: src/templates/admin/submission/submit_funding.html:16
+#: src/templates/admin/submission/submit_funding.html:25
 #: src/templates/admin/submission/timeline.html:36
 #: src/templates/admin/submission/timeline.html:37
-#: src/themes/OLH/templates/journal/article.html:229
-#: src/themes/clean/templates/journal/article.html:123
-#: src/themes/material/templates/journal/article.html:151
+#: src/templates/common/elements/funder_info_for_readers.html:3
 msgid "Funding"
 msgstr "Financiering"
 
-#: src/templates/admin/submission/submit_funding.html:20
+#: src/templates/admin/submission/submit_funding.html:30
+msgid ""
+"\n"
+"                         Here you can search the FundRef database to add "
+"grant IDs to your article's metadata. If you can't find a specific funder, "
+"you can manually enter the details. You can also edit or delete entries as "
+"necessary.\n"
+"                    "
+msgstr ""
+
+#: src/templates/admin/submission/submit_funding.html:36
 msgid "Add Funding Source"
 msgstr "Financieringsbron toevoegen"
 
-#: src/templates/admin/submission/submit_funding.html:27
+#: src/templates/admin/submission/submit_funding.html:47
 msgid "Search for funder"
 msgstr "Financier zoeken"
 
-#: src/templates/admin/submission/submit_funding.html:31
+#: src/templates/admin/submission/submit_funding.html:53
 msgid "Add funder manually"
 msgstr "Financier handmatig toevoegen"
 
-#: src/templates/admin/submission/submit_funding.html:41
+#: src/templates/admin/submission/submit_funding.html:64
 msgid "Current Funders"
 msgstr "Huidige financiers"
 
-#: src/templates/admin/submission/submit_funding.html:50
+#: src/templates/admin/submission/submit_funding.html:74
 msgid "Grant Number"
 msgstr "Beurs nummer"
 
-#: src/templates/admin/submission/submit_funding.html:65
+#: src/templates/admin/submission/submit_funding.html:100
 msgid "No funders added."
 msgstr "Geen financiers toegevoegd"
 
-#: src/templates/admin/submission/submit_info.html:16
+#: src/templates/admin/submission/submit_info.html:6
+#: src/templates/admin/submission/submit_review.html:48
+msgid "Article Info"
+msgstr "Artikel info"
+
+#: src/templates/admin/submission/submit_info.html:26
 msgid "This article is a preprint"
 msgstr "Dit artikel is een preprint"
 
-#: src/templates/admin/submission/submit_info.html:21
+#: src/templates/admin/submission/submit_info.html:31
 #, fuzzy
 #| msgid "Information"
 msgid "Basic Information"
 msgstr "Informatie"
 
-#: src/templates/admin/submission/submit_info.html:58
+#: src/templates/admin/submission/submit_info.html:68
 msgid "View license information"
 msgstr "Licentie informatie bekijken"
 
-#: src/templates/admin/submission/submit_info.html:67
-#: src/themes/OLH/templates/journal/article.html:178
+#: src/templates/admin/submission/submit_info.html:77
+#: src/themes/OLH/templates/journal/article.html:181
 #: src/themes/OLH/templates/journal/keywords.html:6
 #: src/themes/OLH/templates/journal/keywords.html:12
 #: src/themes/OLH/templates/journal/print.html:33
@@ -2653,17 +3181,13 @@ msgstr "Licentie informatie bekijken"
 #: src/themes/material/templates/journal/search.html:50
 #: src/themes/material/templates/preprints/list.html:79
 #: src/themes/material/templates/repository/list.html:60
-#: src/themes/material/templates/repository/preprint.html:172
+#: src/themes/material/templates/repository/preprint.html:170
 msgid "Keywords"
 msgstr "Trefwoorden"
 
-#: src/templates/admin/submission/submit_info.html:96
+#: src/templates/admin/submission/submit_info.html:106
 msgid "License Information"
 msgstr "Licentie informatie"
-
-#: src/templates/admin/submission/submit_info.html:99
-msgid "allows the following licenses for submission"
-msgstr "laat de volgende licenties toe bij inzendingen"
 
 #: src/templates/admin/submission/submit_review.html:7
 #: src/templates/admin/submission/timeline.html:43
@@ -2675,7 +3199,7 @@ msgstr "laat de volgende licenties toe bij inzendingen"
 msgid "Review your submission"
 msgstr "Preprint inzending reviewen"
 
-#: src/templates/admin/submission/submit_review.html:21
+#: src/templates/admin/submission/submit_review.html:26
 msgid ""
 "Please review your submission use the details below. If you need to make "
 "changes use the links above to move back along the submission steps. You "
@@ -2684,120 +3208,120 @@ msgid ""
 "receipt email. "
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:25
+#: src/templates/admin/submission/submit_review.html:30
 #, fuzzy
 #| msgid "Author Agreement"
 msgid "Agreements"
 msgstr "Auteur overeenkomst"
 
-#: src/templates/admin/submission/submit_review.html:29
+#: src/templates/admin/submission/submit_review.html:34
 #, fuzzy
 #| msgid "Publication Fees"
 msgid "Agreed to Publication Fees statement"
 msgstr "Publicatiekosten"
 
-#: src/templates/admin/submission/submit_review.html:33
+#: src/templates/admin/submission/submit_review.html:38
 #, fuzzy
 #| msgid "Submission Checklist"
 msgid "Agreed to Submission Checklist"
 msgstr "Checklist voor inzending"
 
-#: src/templates/admin/submission/submit_review.html:37
+#: src/templates/admin/submission/submit_review.html:42
 msgid "Agreed to Copyright statement"
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:59
-#: src/themes/OLH/templates/journal/article.html:175
+#: src/templates/admin/submission/submit_review.html:64
+#: src/themes/OLH/templates/journal/article.html:178
 #: src/themes/OLH/templates/journal/print.html:30
 #: src/themes/OLH/templates/repository/preprint.html:45
 #: src/themes/clean/templates/journal/article.html:78
 #: src/themes/clean/templates/journal/print.html:30
 #: src/themes/material/templates/journal/article.html:73
 #: src/themes/material/templates/preprints/article.html:43
-#: src/themes/material/templates/repository/preprint.html:157
+#: src/themes/material/templates/repository/preprint.html:155
 msgid "Abstract"
 msgstr "Samenvatting"
 
-#: src/templates/admin/submission/submit_review.html:68
+#: src/templates/admin/submission/submit_review.html:73
 msgid "Language"
 msgstr "Taal"
 
-#: src/templates/admin/submission/submit_review.html:72
-#: src/themes/material/templates/journal/article.html:413
+#: src/templates/admin/submission/submit_review.html:77
+#: src/themes/material/templates/journal/article.html:389
 msgid "Licence"
 msgstr "Licentie"
 
-#: src/templates/admin/submission/submit_review.html:94
+#: src/templates/admin/submission/submit_review.html:110
 msgid "Author Info"
 msgstr "Auteur info"
 
-#: src/templates/admin/submission/submit_review.html:97
+#: src/templates/admin/submission/submit_review.html:113
 #, fuzzy
 #| msgid "First name"
 msgid "First Name"
 msgstr "Voornaam"
 
-#: src/templates/admin/submission/submit_review.html:98
+#: src/templates/admin/submission/submit_review.html:114
 #, fuzzy
 #| msgid "Middle name"
 msgid "Middle Name"
 msgstr "Tweede naam"
 
-#: src/templates/admin/submission/submit_review.html:99
+#: src/templates/admin/submission/submit_review.html:115
 #, fuzzy
 #| msgid "Last name"
 msgid "Last Name"
 msgstr "Familienaam"
 
-#: src/templates/admin/submission/submit_review.html:100
+#: src/templates/admin/submission/submit_review.html:116
 #, fuzzy
 #| msgid "New Email Address"
 msgid "Email Address"
 msgstr "Nieuw e-mailadres"
 
-#: src/templates/admin/submission/submit_review.html:110
+#: src/templates/admin/submission/submit_review.html:126
 #, fuzzy
 #| msgid "No Issue Editor ID supplied."
 msgid "No ORCID supplied"
 msgstr "Geen editor ID van nummer geleverd."
 
-#: src/templates/admin/submission/submit_review.html:117
+#: src/templates/admin/submission/submit_review.html:133
 #: src/templates/admin/submission/timeline.html:28
 #: src/templates/admin/submission/timeline.html:29
 msgid "Article Files"
 msgstr "Artikel bestanden"
 
-#: src/templates/admin/submission/submit_review.html:122
+#: src/templates/admin/submission/submit_review.html:138
 #, fuzzy
 #| msgid "File Name"
 msgid "File Type"
 msgstr "Bestandsnaam"
 
-#: src/templates/admin/submission/submit_review.html:128
+#: src/templates/admin/submission/submit_review.html:144
 #, fuzzy
 #| msgid "Manuscript File"
 msgid "Manuscript"
 msgstr "Manuscript-bestand"
 
-#: src/templates/admin/submission/submit_review.html:136
+#: src/templates/admin/submission/submit_review.html:152
 msgid "Figure/Data"
 msgstr "Figuren/Data"
 
-#: src/templates/admin/submission/submit_review.html:146
+#: src/templates/admin/submission/submit_review.html:162
 msgid "Comments to the Editor"
 msgstr "Opmerkingen voor de editor"
 
-#: src/templates/admin/submission/submit_review.html:149
+#: src/templates/admin/submission/submit_review.html:165
 msgid ""
 "Before submitting you have the option to add additional comments for the "
 "editor using the field below. Only the editor will see anything you add here."
 msgstr ""
 
-#: src/templates/admin/submission/submit_review.html:155
+#: src/templates/admin/submission/submit_review.html:171
 msgid "Complete"
 msgstr "Voltooien"
 
-#: src/templates/admin/submission/submit_review.html:155
+#: src/templates/admin/submission/submit_review.html:171
 #: src/themes/OLH/templates/core/nav.html:40
 #: src/themes/clean/templates/core/nav.html:47
 #: src/themes/material/templates/core/nav.html:39
@@ -2814,15 +3338,38 @@ msgstr "Inzending gestart"
 msgid "Article Information"
 msgstr "Artikel informatie"
 
+#: src/templates/common/accounts/register_privacy_policy.html:3
+#: src/templates/common/accounts/register_privacy_policy.html:7
+#: src/templates/common/accounts/register_privacy_policy.html:11
+#: src/themes/OLH/templates/elements/journal_footer.html:25
+#: src/themes/OLH/templates/elements/journal_footer.html:27
+#: src/themes/OLH/templates/press/elements/press_footer.html:9
+#: src/themes/OLH/templates/press/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/journal_footer.html:33
+#: src/themes/clean/templates/elements/journal_footer.html:37
+#: src/themes/clean/templates/elements/press_footer.html:11
+#: src/themes/clean/templates/elements/press_footer.html:14
+#: src/themes/hourglass/templates/custom/register.html:29
+#: src/themes/hourglass/templates/custom/register.html:35
+#: src/themes/material/templates/elements/journal_footer.html:28
+msgid "Privacy Policy"
+msgstr "Privacybeleid"
+
+#: src/templates/common/elements/funder_info_for_readers.html:6
+#, fuzzy
+#| msgid "Funding"
+msgid "Funding ID"
+msgstr "Financiering"
+
 #: src/templates/common/elements/journal/article_issue_list.html:4
 #: src/themes/OLH/templates/core/nav.html:25
+#: src/themes/OLH/templates/journal/issues.html:5
 #: src/themes/OLH/templates/journal/issues.html:7
-#: src/themes/OLH/templates/journal/issues.html:9
 #: src/themes/clean/templates/core/nav.html:24
 #: src/themes/clean/templates/journal/issues.html:6
 #: src/themes/material/templates/core/nav.html:33
 #: src/themes/material/templates/core/nav.html:94
-#: src/themes/material/templates/journal/issues.html:6
+#: src/themes/material/templates/journal/issues.html:5
 msgid "Issues"
 msgstr "Nummers"
 
@@ -2842,6 +3389,30 @@ msgstr ""
 #: src/templates/common/elements/journal/article_issue_list.html:21
 msgid "This article is not a part of any issues"
 msgstr "Dit artikel maakt geen deel uit van een nummer"
+
+#: src/templates/common/elements/orcid_registration.html:16
+#, fuzzy
+#| msgid "Login with ORCiD"
+msgid "Register with ORCiD"
+msgstr "Inloggen met ORCiD"
+
+#: src/templates/common/elements/password_rules.html:2
+#, python-format
+msgid "Your password should be %(password_length)s characters long."
+msgstr "Uw wachtwoord moet %(password_length)s karakters lang zijn"
+
+#: src/templates/common/elements/password_rules.html:6
+msgid "Your password should contain at least one upper case letter."
+msgstr "Uw wachtwoord moet minstens één hoofdletter bevatten."
+
+#: src/templates/common/elements/password_rules.html:11
+msgid "Your password should contain at least one number."
+msgstr "Uw wachtwoord moet minstens één nummer bevatten."
+
+#: src/templates/common/elements/skip_to_main_content.html:3
+#: src/themes/clean/templates/500.html:21
+msgid "Skip to main content"
+msgstr ""
 
 #: src/templates/common/elements/sorting.html:7
 #: src/themes/clean/templates/elements/sorting.html:7
@@ -2889,33 +3460,30 @@ msgstr "Serverfout"
 msgid "A server error has occurred"
 msgstr ""
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:5
-#: src/themes/OLH/templates/core/accounts/activate_account.html:22
-#: src/themes/OLH/templates/core/accounts/activate_account.html:26
-#: src/themes/clean/templates/core/accounts/activate_account.html:5
-#: src/themes/clean/templates/core/accounts/activate_account.html:13
-#: src/themes/clean/templates/core/accounts/activate_account.html:17
-#: src/themes/material/templates/core/accounts/activate_account.html:5
-#: src/themes/material/templates/core/accounts/activate_account.html:14
-#: src/themes/material/templates/core/accounts/activate_account.html:19
-msgid "Activate Account"
-msgstr "Account activeren"
+#: src/themes/OLH/templates/cms/page.html:22
+#: src/themes/clean/templates/cms/page.html:19
+#: src/themes/clean/templates/journal/article.html:340
+#: src/themes/material/templates/cms/page.html:25
+#: src/themes/material/templates/journal/article.html:484
+#: src/themes/material/templates/journal/submissions.html:72
+msgid "Table of Contents"
+msgstr "Inhoudstafel"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:25
-#: src/themes/clean/templates/core/accounts/activate_account.html:16
-#: src/themes/material/templates/core/accounts/activate_account.html:17
+#: src/themes/OLH/templates/core/accounts/activate_account.html:29
+#: src/themes/clean/templates/core/accounts/activate_account.html:20
+#: src/themes/material/templates/core/accounts/activate_account.html:21
 msgid "You can complete the activation process by clicking the button below."
 msgstr ""
 "U kunt het activeringsproces voltooien door op de onderstaande knop te "
 "klikken."
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:29
-#: src/themes/clean/templates/core/accounts/activate_account.html:20
-#: src/themes/material/templates/core/accounts/activate_account.html:23
+#: src/themes/OLH/templates/core/accounts/activate_account.html:33
+#: src/themes/clean/templates/core/accounts/activate_account.html:24
+#: src/themes/material/templates/core/accounts/activate_account.html:27
 msgid "Error"
 msgstr "Fout"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:31
+#: src/themes/OLH/templates/core/accounts/activate_account.html:35
 msgid ""
 "There was no inactive account with this activation code found. It is "
 "possible that your account is already active, you can check by attempting to"
@@ -2923,49 +3491,32 @@ msgstr ""
 "Er is geen inactief account met deze activeringscode gevonden. Het is "
 "mogelijk dat uw account al actief is, u kunt dit controleren door te proberen"
 
-#: src/themes/OLH/templates/core/accounts/activate_account.html:32
-#: src/themes/clean/templates/core/accounts/activate_account.html:22
-#: src/themes/material/templates/core/accounts/activate_account.html:26
+#: src/themes/OLH/templates/core/accounts/activate_account.html:36
+#: src/themes/clean/templates/core/accounts/activate_account.html:26
+#: src/themes/material/templates/core/accounts/activate_account.html:30
 msgid "login"
 msgstr "Inloggen"
 
-#: src/themes/OLH/templates/core/accounts/edit_profile.html:4
-#: src/themes/clean/templates/core/accounts/edit_profile.html:5
-#: src/themes/material/templates/core/accounts/edit_profile.html:4
-msgid "Edit Profile"
-msgstr "Profiel bewerken"
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:5
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:9
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:86
 #: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:105
 #: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:100
 msgid "Update"
 msgstr "Update"
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:25
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:15
-#: src/themes/material/templates/core/accounts/get_reset_token.html:14
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:20
+#: src/themes/material/templates/core/accounts/get_reset_token.html:20
 msgid "Enter your email address to begin the reset process"
 msgstr "Geef uw e-mailadres in om het reset proces te beginnen"
 
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:27
-msgid "somebody"
-msgstr "iemand"
-
-#: src/themes/OLH/templates/core/accounts/get_reset_token.html:29
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:21
-#: src/themes/material/templates/core/accounts/get_reset_token.html:21
+#: src/themes/OLH/templates/core/accounts/get_reset_token.html:31
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:24
+#: src/themes/material/templates/core/accounts/get_reset_token.html:25
 msgid "Request Token"
 msgstr "Token aanvragen"
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:5
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:19
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:4
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:9
-msgid "Unregistered ORCiD"
-msgstr "Ongeregistreerde ORCiD"
-
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:20
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:24
 msgid ""
 "The ORCiD you logged in with is not currently linked with an account in our "
 "system. You can either register a new account, or login with an existing "
@@ -2975,27 +3526,27 @@ msgstr ""
 "account in ons systeem. U kunt een nieuw account registreren of inloggen met "
 "een bestaand account om uw ORCiD te koppelen voor toekomstig gebruik."
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:36
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:40
 #: src/themes/OLH/templates/press/core/login.html:36
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:29
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:33
 msgid "Log In"
 msgstr "Inloggen"
 
-#: src/themes/OLH/templates/core/accounts/orcid_registration.html:37
+#: src/themes/OLH/templates/core/accounts/orcid_registration.html:41
 #: src/themes/OLH/templates/press/core/login.html:37
 msgid "Forgot your password?"
 msgstr "Wachtwoord vergeten?"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:5
-#: src/themes/OLH/templates/core/nav.html:73
+#: src/themes/OLH/templates/core/accounts/public_profile.html:9
+#: src/themes/OLH/templates/core/nav.html:72
 #: src/themes/OLH/templates/elements/right_hand_menu.html:38
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:12
 #: src/themes/OLH/templates/press/nav.html:54
 #: src/themes/OLH/templates/repository/elements/right_hand_menu.html:10
-#: src/themes/clean/templates/core/accounts/public_profile.html:4
+#: src/themes/clean/templates/core/accounts/public_profile.html:8
 #: src/themes/clean/templates/core/nav.html:98
 #: src/themes/clean/templates/press/nav.html:71
-#: src/themes/material/templates/core/accounts/public_profile.html:5
+#: src/themes/material/templates/core/accounts/public_profile.html:9
 #: src/themes/material/templates/core/nav.html:165
 #: src/themes/material/templates/core/nav.html:200
 #: src/themes/material/templates/press/nav.html:135
@@ -3003,118 +3554,55 @@ msgstr "Wachtwoord vergeten?"
 msgid "Profile"
 msgstr "Profiel"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:13
-#: src/themes/clean/templates/core/accounts/public_profile.html:13
-#: src/themes/material/templates/core/accounts/public_profile.html:13
+#: src/themes/OLH/templates/core/accounts/public_profile.html:19
+#: src/themes/clean/templates/core/accounts/public_profile.html:17
+#: src/themes/material/templates/core/accounts/public_profile.html:17
 msgid "Roles"
 msgstr "Rollen"
 
-#: src/themes/OLH/templates/core/accounts/public_profile.html:25
-#: src/themes/clean/templates/core/accounts/public_profile.html:25
-#: src/themes/material/templates/core/accounts/public_profile.html:25
+#: src/themes/OLH/templates/core/accounts/public_profile.html:27
+#, fuzzy
+#| msgid "Editorial Team"
+msgid "Editorial groups"
+msgstr "Redactie"
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:35
+msgid "Staff roles"
+msgstr ""
+
+#: src/themes/OLH/templates/core/accounts/public_profile.html:56
+#: src/themes/clean/templates/core/accounts/public_profile.html:29
+#: src/themes/material/templates/core/accounts/public_profile.html:29
 msgid "Publications"
 msgstr "Publicaties"
 
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
+#: src/themes/OLH/templates/core/accounts/register.html:29
+#: src/themes/clean/templates/core/accounts/register.html:21
+#: src/themes/material/templates/core/accounts/register.html:19
 msgid "Register for an account with"
 msgstr "Registreer voor een"
 
-#: src/themes/OLH/templates/core/accounts/register.html:25
-#: src/themes/clean/templates/core/accounts/register.html:17
-#: src/themes/material/templates/core/accounts/register.html:15
-msgid "account"
-msgstr "account"
-
-#: src/themes/OLH/templates/core/accounts/register.html:26
-#: src/themes/OLH/templates/core/accounts/reset_password.html:27
-#: src/themes/clean/templates/core/accounts/register.html:18
-#: src/themes/clean/templates/core/accounts/reset_password.html:17
-#: src/themes/material/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/reset_password.html:17
-msgid "Password Rules"
-msgstr "Wachtwoordgids"
-
-#: src/themes/OLH/templates/core/accounts/register.html:28
-#: src/themes/clean/templates/core/accounts/register.html:20
-#: src/themes/material/templates/core/accounts/register.html:22
-#: src/themes/material/templates/core/accounts/reset_password.html:19
-#: src/templates/common/elements/password_rules.html:2
-msgid "Your password should be %(password_length)s characters long."
-msgstr "Uw wachtwoord moet %(password_length)s karakters lang zijn"
-
-#: src/themes/OLH/templates/core/accounts/register.html:29
-#: src/themes/OLH/templates/core/accounts/reset_password.html:30
-#: src/themes/clean/templates/core/accounts/register.html:21
-#: src/themes/clean/templates/core/accounts/reset_password.html:20
-#: src/themes/material/templates/core/accounts/register.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:20
-#: src/templates/common/elements/password_rules.html:2
-msgid "Your password should contain at least one upper case letter."
-msgstr "Uw wachtwoord moet minstens één hoofdletter bevatten."
-
-#: src/themes/OLH/templates/core/accounts/register.html:30
-#: src/themes/OLH/templates/core/accounts/reset_password.html:31
-#: src/themes/clean/templates/core/accounts/register.html:22
-#: src/themes/clean/templates/core/accounts/reset_password.html:21
-#: src/themes/material/templates/core/accounts/register.html:24
-#: src/themes/material/templates/core/accounts/reset_password.html:21
-#: src/templates/common/elements/password_rules.html:2
-msgid "Your password should contain at least one number."
-msgstr "Uw wachtwoord moet minstens één nummer bevatten."
-
-#: src/themes/OLH/templates/core/accounts/register.html:33
+#: src/themes/OLH/templates/core/accounts/register.html:35
+#: src/themes/OLH/templates/core/accounts/reset_password.html:36
 msgid ""
-"For more information read our <a href=\"#\" data-open=\"password-modal\">password guide</a>."
+"For more information read our <a href=\"#\" data-open=\"password-"
+"modal\">password guide</a>."
 msgstr ""
-"Voor meer informatie lees onze <a href=\"#\" data-open=\"password-modal\">wachtwoord gids</a>."
+"Voor meer informatie lees onze <a href=\"#\" data-open=\"password-"
+"modal\">wachtwoord gids</a>."
 
-#: src/themes/OLH/templates/core/accounts/register.html:83
-#: src/themes/clean/templates/core/accounts/register.html:27
-#: src/themes/material/templates/core/accounts/register.html:33
-msgid "By registering an account you agree to our"
-msgstr "Als u een account registreert gaat u akkoord met onze"
-
-#: src/themes/OLH/templates/core/accounts/register.html:85
-#: src/themes/OLH/templates/core/accounts/register.html:87
-#: src/themes/OLH/templates/elements/journal_footer.html:25
-#: src/themes/OLH/templates/elements/journal_footer.html:27
-#: src/themes/OLH/templates/press/elements/press_footer.html:9
-#: src/themes/OLH/templates/press/elements/press_footer.html:11
-#: src/themes/clean/templates/core/accounts/register.html:29
-#: src/themes/clean/templates/core/accounts/register.html:31
-#: src/themes/clean/templates/elements/journal_footer.html:33
-#: src/themes/clean/templates/elements/journal_footer.html:37
-#: src/themes/clean/templates/elements/press_footer.html:11
-#: src/themes/clean/templates/elements/press_footer.html:14
-#: src/themes/material/templates/core/accounts/register.html:35
-#: src/themes/material/templates/core/accounts/register.html:37
-#: src/themes/material/templates/elements/journal_footer.html:28
-msgid "Privacy Policy"
-msgstr "Privacybeleid"
-
-#: src/themes/OLH/templates/core/accounts/register.html:106
-#: src/themes/OLH/templates/core/accounts/reset_password.html:48
-#: src/themes/clean/templates/core/accounts/register.html:54
-#: src/themes/clean/templates/core/accounts/reset_password.html:43
-#: src/themes/material/templates/core/accounts/register.html:53
-#: src/themes/material/templates/core/accounts/reset_password.html:41
-msgid "Password Guide"
-msgstr "Wachtwoordgids"
-
-#: src/themes/OLH/templates/core/accounts/register.html:107
-#: src/themes/OLH/templates/core/accounts/reset_password.html:49
-#: src/themes/clean/templates/core/accounts/reset_password.html:49
+#: src/themes/OLH/templates/core/accounts/register.html:111
+#: src/themes/OLH/templates/core/accounts/reset_password.html:53
+#: src/themes/clean/templates/core/accounts/reset_password.html:53
 #: src/themes/material/templates/core/accounts/register.html:54
-#: src/themes/material/templates/core/accounts/reset_password.html:42
+#: src/themes/material/templates/core/accounts/reset_password.html:44
 msgid "When it comes to passwords, length is better than complexity."
 msgstr "Lengte is beter dan complexiteit voor wat betreft wachtwoorden."
 
-#: src/themes/OLH/templates/core/accounts/register.html:108
-#: src/themes/OLH/templates/core/accounts/reset_password.html:50
+#: src/themes/OLH/templates/core/accounts/register.html:112
+#: src/themes/OLH/templates/core/accounts/reset_password.html:54
 #: src/themes/material/templates/core/accounts/register.html:55
-#: src/themes/material/templates/core/accounts/reset_password.html:43
+#: src/themes/material/templates/core/accounts/reset_password.html:45
 msgid ""
 "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
 "secure than a long and uncomplicated password (our awesome moon base rocks)."
@@ -3122,8 +3610,8 @@ msgstr ""
 "Het is een mythe dat een kort en complex wachtwoord (Jfjfy&65^87) veiliger "
 "is dan een lang en eenvoudig wachtwoord (our awesome moon base rocks)."
 
-#: src/themes/OLH/templates/core/accounts/register.html:109
-#: src/themes/OLH/templates/core/accounts/reset_password.html:51
+#: src/themes/OLH/templates/core/accounts/register.html:113
+#: src/themes/OLH/templates/core/accounts/reset_password.html:55
 msgid ""
 "We recommend selecting a long, but easy to remember password such as our "
 "awesome moon base rocks which would take an estimated septillion years to "
@@ -3135,43 +3623,26 @@ msgstr ""
 "heeft een standaard computer naar schatting een septiljoen jaren nodig ten "
 "opzichte van 600 jaar voor een complex wachtwoord als 'Jfjfy&65^87'. "
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:6
-#: src/themes/OLH/templates/core/accounts/reset_password.html:38
-#: src/themes/clean/templates/core/accounts/get_reset_token.html:4
-#: src/themes/clean/templates/core/accounts/reset_password.html:5
-#: src/themes/clean/templates/core/accounts/reset_password.html:29
-#: src/themes/material/templates/core/accounts/get_reset_token.html:4
-#: src/themes/material/templates/core/accounts/reset_password.html:5
-#: src/themes/material/templates/core/accounts/reset_password.html:29
+#: src/themes/OLH/templates/core/accounts/reset_password.html:10
+#: src/themes/OLH/templates/core/accounts/reset_password.html:42
+#: src/themes/clean/templates/core/accounts/get_reset_token.html:8
+#: src/themes/clean/templates/core/accounts/reset_password.html:9
+#: src/themes/clean/templates/core/accounts/reset_password.html:33
+#: src/themes/hourglass/templates/core/accounts/get_reset_token.html:9
+#: src/themes/hourglass/templates/core/accounts/reset_password.html:10
+#: src/themes/material/templates/core/accounts/get_reset_token.html:8
+#: src/themes/material/templates/core/accounts/reset_password.html:9
+#: src/themes/material/templates/core/accounts/reset_password.html:31
 msgid "Reset Password"
 msgstr "Wachtwoord opnieuw instellen"
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:26
-#: src/themes/clean/templates/core/accounts/reset_password.html:16
-#: src/themes/material/templates/core/accounts/reset_password.html:16
+#: src/themes/OLH/templates/core/accounts/reset_password.html:30
+#: src/themes/clean/templates/core/accounts/reset_password.html:20
+#: src/themes/material/templates/core/accounts/reset_password.html:20
 msgid "Enter your new password twice to complete the reset process"
 msgstr "Geef uw wachtwoord twee keer in om het reset proces te voltooien"
 
-#: src/themes/OLH/templates/core/accounts/reset_password.html:29
-#: src/themes/clean/templates/core/accounts/reset_password.html:19
-#, fuzzy, python-format
-#| msgid "Your password must be {} characters long"
-msgid ""
-"Your password should be %(request.press.password_length)s characters long."
-msgstr "Uw wachtwoord moet {} karakters lang zijn"
-
-#: src/themes/OLH/templates/core/accounts/reset_password.html:33
-#: src/themes/material/templates/core/accounts/register.html:26
-msgid ""
-"For more information read our\n"
-"                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-"\">password guide</a>\n"
-"                        ."
-msgstr ""
-"Voor meer informatie, lees onze <a href=\"#passwordmodal\" class=\"modal-"
-"trigger\">wachtwoordgids</a>."
-
-#: src/themes/OLH/templates/core/base.html:60
+#: src/themes/OLH/templates/core/base.html:61
 #: src/themes/OLH/templates/core/nav.html:7
 #: src/themes/OLH/templates/press/nav.html:6
 #: src/themes/OLH/templates/press/press_index.html:5
@@ -3187,18 +3658,6 @@ msgstr ""
 msgid "Home"
 msgstr "Home"
 
-#: src/themes/OLH/templates/core/login.html:27
-#: src/themes/OLH/templates/press/core/login.html:25
-#: src/themes/clean/templates/core/login.html:14
-msgid "Log in with your account"
-msgstr "Inloggen met uw account"
-
-#: src/themes/OLH/templates/core/login.html:28
-#: src/themes/clean/templates/core/login.html:16
-#: src/themes/material/templates/core/login.html:18
-msgid "Log in with ORCiD"
-msgstr "Inloggen met ORCiD"
-
 #: src/themes/OLH/templates/core/login.html:31
 #: src/themes/OLH/templates/press/core/login.html:28
 #: src/themes/clean/templates/core/login.html:20
@@ -3207,38 +3666,6 @@ msgstr "Inloggen met ORCiD"
 #| msgid "Login with ORCiD"
 msgid "Login with"
 msgstr "Inloggen met ORCiD"
-
-#: src/themes/OLH/templates/core/login.html:43
-#: src/themes/clean/templates/core/login.html:40
-msgid "Log in"
-msgstr "Inloggen"
-
-#: src/themes/OLH/templates/core/login.html:44
-#: src/themes/clean/templates/core/login.html:44
-msgid "Forgotten your password?"
-msgstr "Wachtwoord vergeten?"
-
-#: src/themes/OLH/templates/core/login.html:45
-#: src/themes/clean/templates/core/login.html:48
-msgid "Register a new account"
-msgstr "Nieuwe account registreren"
-
-#: src/themes/OLH/templates/core/nav.html:29
-#: src/themes/OLH/templates/core/nav.html:37
-#: src/themes/OLH/templates/journal/editorial_team.html:10
-#: src/themes/OLH/templates/journal/editorial_team.html:20
-#: src/themes/OLH/templates/press/nav.html:39
-#: src/themes/clean/templates/core/nav.html:32
-#: src/themes/clean/templates/core/nav.html:41
-#: src/themes/clean/templates/journal/editorial_team.html:4
-#: src/themes/clean/templates/journal/editorial_team.html:9
-#: src/themes/material/templates/core/nav.html:36
-#: src/themes/material/templates/core/nav.html:97
-#: src/themes/material/templates/journal/editorial_team.html:11
-#: src/themes/material/templates/preprints/editors.html:5
-#: src/themes/material/templates/preprints/editors.html:6
-msgid "Editorial Team"
-msgstr "Redactie"
 
 #: src/themes/OLH/templates/core/nav.html:44
 #: src/themes/OLH/templates/journal/become_reviewer.html:5
@@ -3317,13 +3744,13 @@ msgstr "Artikel bewerken"
 msgid "Edit Issue"
 msgstr "Nummer bewerken"
 
-#: src/themes/OLH/templates/core/nav.html:66
+#: src/themes/OLH/templates/core/nav.html:65
 #: src/themes/OLH/templates/elements/right_hand_menu.html:31
 #: src/themes/material/templates/core/nav.html:194
 msgid "Edit News Item"
 msgstr "Nieuwsitem bewerken"
 
-#: src/themes/OLH/templates/core/nav.html:70
+#: src/themes/OLH/templates/core/nav.html:69
 #: src/themes/OLH/templates/elements/right_hand_menu.html:35
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:8
 #: src/themes/OLH/templates/press/nav.html:51
@@ -3339,7 +3766,7 @@ msgstr "Nieuwsitem bewerken"
 msgid "Admin"
 msgstr "Admin"
 
-#: src/themes/OLH/templates/core/nav.html:74
+#: src/themes/OLH/templates/core/nav.html:73
 #: src/themes/OLH/templates/elements/right_hand_menu.html:39
 #: src/themes/OLH/templates/press/elements/right_hand_menu.html:13
 #: src/themes/OLH/templates/press/nav.html:55
@@ -3355,42 +3782,43 @@ msgstr "Admin"
 msgid "Logout"
 msgstr "Uitloggen"
 
-#: src/themes/OLH/templates/core/news/index.html:11
-#: src/themes/material/templates/core/news/index.html:11
+#: src/themes/OLH/templates/core/news/index.html:12
+#: src/themes/material/templates/core/news/index.html:12
 #: src/themes/material/templates/press/core/news/index.html:11
 msgid "Filtering tag"
 msgstr "Filter tag"
 
-#: src/themes/OLH/templates/core/news/index.html:24
-#: src/themes/OLH/templates/core/news/item.html:24
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:27
-#: src/themes/OLH/templates/press/core/news/index.html:22
-#: src/themes/OLH/templates/press/core/news/item.html:24
-#: src/themes/OLH/templates/press/core/news/item.html:33
-#: src/themes/material/templates/core/news/index.html:30
-#: src/themes/material/templates/core/news/item.html:30
+#: src/themes/OLH/templates/core/news/index.html:25
+#: src/themes/OLH/templates/core/news/item.html:25
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:28
+#: src/themes/OLH/templates/press/core/news/index.html:23
+#: src/themes/OLH/templates/press/core/news/item.html:25
+#: src/themes/OLH/templates/press/core/news/item.html:34
+#: src/themes/hourglass/templates/custom/news-item.html:16
+#: src/themes/material/templates/core/news/index.html:31
+#: src/themes/material/templates/core/news/item.html:31
 #: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
+#: src/themes/material/templates/press/core/news/item.html:18
 msgid "on"
 msgstr "aan"
 
-#: src/themes/OLH/templates/core/news/index.html:26
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:29
-#: src/themes/OLH/templates/press/core/news/index.html:24
+#: src/themes/OLH/templates/core/news/index.html:27
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:30
+#: src/themes/OLH/templates/press/core/news/index.html:25
 #: src/themes/clean/templates/core/news/index.html:17
 #: src/themes/clean/templates/press/core/news/index.html:17
-#: src/themes/material/templates/core/news/index.html:34
-#: src/themes/material/templates/journal/homepage_elements/news.html:36
+#: src/themes/material/templates/core/news/index.html:35
+#: src/themes/material/templates/journal/homepage_elements/news.html:37
 #: src/themes/material/templates/press/core/news/index.html:25
 msgid "Read More"
 msgstr "Lees meer"
 
-#: src/themes/OLH/templates/core/news/index.html:33
+#: src/themes/OLH/templates/core/news/index.html:34
 #: src/themes/material/templates/press/core/news/index.html:30
 msgid "This journal currently has no news items to display."
 msgstr "Dit tijdschrift heeft momenteel geen nieuws items om weer te geven"
 
-#: src/themes/OLH/templates/core/news/item.html:40
+#: src/themes/OLH/templates/core/news/item.html:41
 #: src/themes/clean/templates/core/news/item.html:20
 #: src/themes/clean/templates/press/core/news/item.html:16
 #, fuzzy
@@ -3398,23 +3826,17 @@ msgstr "Dit tijdschrift heeft momenteel geen nieuws items om weer te geven"
 msgid "Tags "
 msgstr "Tags"
 
-#: src/themes/OLH/templates/core/news/item.html:47
+#: src/themes/OLH/templates/core/news/item.html:48
 #: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
+#: src/themes/material/templates/core/news/item.html:44
 msgid "Back to"
 msgstr "Terug naar"
 
-#: src/themes/OLH/templates/core/news/item.html:47
+#: src/themes/OLH/templates/core/news/item.html:48
 #: src/themes/clean/templates/core/news/item.html:22
-#: src/themes/material/templates/core/news/item.html:43
+#: src/themes/material/templates/core/news/item.html:44
 msgid "List"
 msgstr "Lijst"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:7
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:8
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:8
-msgid "Change Your Email Address"
-msgstr "E-mailadres wijzigen"
 
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:8
 msgid ""
@@ -3434,58 +3856,12 @@ msgstr ""
 "u uw e-mailadres wijzigt, verandert ook uw gebruikersnaam, aangezien deze "
 "één en dezelfde zijn.</p>"
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:13
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:14
-msgid "Current Email Address"
-msgstr "Huidig e-mailadres"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:16
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:20
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:18
-msgid "New Email Address"
-msgstr "Nieuw e-mailadres"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:18
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:27
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:20
-msgid "Update Email Address"
-msgstr "Update e-mailadres"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:28
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:40
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:29
-#, fuzzy
-#| msgid "Register for an"
-msgid "Register for Article Notifications"
-msgstr "Registreer voor een"
-
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:31
 #: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:43
 msgid ""
 "Use the button below to register to receive notifications of new articles\n"
 "                            published in this journal "
 msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:37
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:49
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:39
-msgid "Unsubscribe from Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:41
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:53
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:43
-msgid "Subscribe to Article Notifications"
-msgstr ""
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:52
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:70
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:67
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:87
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:65
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:84
-msgid "Update Password"
-msgstr "Update wachtwoord"
 
 #: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:53
 #: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:66
@@ -3496,34 +3872,11 @@ msgstr ""
 "U kunt uw wachtwoord bijwerken door uw bestaande wachtwoord en uw nieuwe "
 "wachtwoord in te voeren."
 
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:58
-#: src/themes/clean/templates/elements/accounts/edit_profile_body_block.html:73
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:72
-msgid "Current Password"
-msgstr "Huidig wachtwoord"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:62
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:76
-msgid "New Password"
-msgstr "Nieuw wachtwoord"
-
-#: src/themes/OLH/templates/elements/accounts/edit_profile_body_block.html:66
-#: src/themes/material/templates/elements/accounts/edit_profile_body_block.html:80
-msgid "Enter Password Again"
-msgstr "Geef wachtwoord opnieuw in"
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:41
-#: src/themes/clean/templates/elements/accounts/user_form.html:38
-#: src/themes/material/templates/elements/accounts/user_form.html:39
-msgid "Social Media and Accounts"
-msgstr "Sociale media en accounts"
-
-#: src/themes/OLH/templates/elements/accounts/user_form.html:95
-#: src/themes/OLH/templates/journal/article.html:108
-#: src/themes/clean/templates/elements/accounts/user_form.html:92
-#: src/themes/material/templates/elements/accounts/user_form.html:93
-msgid "Options"
-msgstr "Opties"
+#: src/themes/OLH/templates/elements/accounts/user_form.html:5
+#: src/themes/clean/templates/elements/accounts/user_form.html:5
+#: src/themes/material/templates/elements/accounts/user_form.html:6
+msgid "Core Data"
+msgstr "Kerngegevens"
 
 #: src/themes/OLH/templates/elements/edit_author.html:5
 msgid "NB."
@@ -3571,13 +3924,13 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/themes/OLH/templates/elements/journal/article_filter_form.html:26
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:34
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:35
 #: src/themes/OLH/templates/elements/journal/article_list_filters.html:6
 #: src/themes/OLH/templates/elements/journal/search_form.html:19
 #: src/themes/OLH/templates/press/press_journals.html:93
 #: src/themes/OLH/templates/press/press_journals.html:94
 #: src/themes/clean/templates/elements/journal/article_list_filters.html:7
-#: src/themes/clean/templates/journal/articles.html:81
+#: src/themes/clean/templates/journal/articles.html:82
 #: src/themes/clean/templates/journal/full-text-search.html:54
 #: src/themes/clean/templates/press/press_journals.html:56
 #: src/themes/material/templates/journal/articles.html:95
@@ -3587,18 +3940,14 @@ msgstr "Datum"
 msgid "Filter"
 msgstr "Filter"
 
-#: src/themes/OLH/templates/elements/journal/article_filter_form.html:36
-#: src/themes/clean/templates/journal/articles.html:84
+#: src/themes/OLH/templates/elements/journal/article_filter_form.html:37
+#: src/themes/clean/templates/journal/articles.html:85
 #: src/themes/material/templates/journal/articles.html:109
 msgid "Clear Filters"
 msgstr "Verwijder filters"
 
-#: src/themes/OLH/templates/elements/journal/article_list_filters.html:9
-#: src/themes/clean/templates/elements/journal/article_list_filters.html:10
-msgid "Apply"
-msgstr ""
-
 #: src/themes/OLH/templates/elements/journal/authors_block.html:4
+#: src/themes/clean/templates/elements/article_listing.html:27
 #: src/themes/clean/templates/elements/journal/authors_block.html:4
 #: src/themes/material/templates/elements/article_listing.html:25
 msgid "and"
@@ -3612,7 +3961,7 @@ msgstr "Ook onderdeel van:"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:5
 #: src/themes/clean/templates/elements/journal/citation_modals.html:6
-#: src/themes/clean/templates/journal/article.html:294
+#: src/themes/clean/templates/journal/article.html:304
 msgid "Harvard-style Citation"
 msgstr "Harvard-stijl citatie"
 
@@ -3625,37 +3974,37 @@ msgid "Preprints"
 msgstr "Preprints"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:19
-#: src/themes/OLH/templates/journal/article.html:135
+#: src/themes/OLH/templates/journal/article.html:137
 msgid "Vancouver Citation Style"
 msgstr "Vancouver citatie stijl"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:19
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:40
-#: src/themes/OLH/templates/journal/article.html:136
+#: src/themes/OLH/templates/journal/article.html:138
 msgid "APA Citation Style"
 msgstr "APA citatie stijl"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:27
 #: src/themes/clean/templates/elements/journal/citation_modals.html:28
-#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/clean/templates/journal/article.html:305
 msgid "Vancouver-style Citation"
 msgstr "Vancouver-stijl citatie"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:40
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:63
-#: src/themes/OLH/templates/journal/article.html:134
+#: src/themes/OLH/templates/journal/article.html:136
 msgid "Harvard Citation Style"
 msgstr "Harvard citatie stijl"
 
 #: src/themes/OLH/templates/elements/journal/citation_modals.html:49
 #: src/themes/clean/templates/elements/journal/citation_modals.html:49
-#: src/themes/clean/templates/journal/article.html:296
+#: src/themes/clean/templates/journal/article.html:306
 msgid "APA-style Citation"
 msgstr "APA-stijl citatie"
 
 #: src/themes/OLH/templates/elements/journal/editorial_social_content.html:4
 #: src/themes/clean/templates/elements/journal/editorial_social_content.html:4
-#: src/themes/clean/templates/journal/article.html:283
+#: src/themes/clean/templates/journal/article.html:293
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -3674,17 +4023,45 @@ msgstr "Github"
 msgid "Linkedin"
 msgstr "Linkedin"
 
+#: src/themes/OLH/templates/elements/journal/issue_list.html:16
+#: src/themes/clean/templates/elements/journal/issue_list.html:5
+#: src/themes/clean/templates/journal/issues.html:14
+#: src/themes/material/templates/elements/journal/issue_list.html:16
+#: src/themes/material/templates/elements/journal/issue_list.html:20
+msgid "items"
+msgstr "Items"
+
+#: src/themes/OLH/templates/elements/journal/issue_list.html:24
+msgid "There are no issues published in this journal yet."
+msgstr "Dit tijdschrift heeft nog geen nummers gepubliceerd"
+
+#: src/themes/OLH/templates/elements/journal/issue_list_by_decade.html:3
+#: src/themes/material/templates/elements/journal/issue_list_by_decade.html:3
+msgid ""
+"\n"
+"            Issues are grouped by decade. Select a decade to view the "
+"issues\n"
+"            published during that decade.\n"
+"        "
+msgstr ""
+
 #: src/themes/OLH/templates/elements/journal/issue_sidebar.html:7
-#: src/themes/OLH/templates/journal/article.html:208
-#: src/themes/OLH/templates/journal/article.html:263
+#: src/themes/OLH/templates/journal/article.html:210
+#: src/themes/OLH/templates/journal/article.html:246
+#: src/themes/OLH/templates/journal/article.html:334
 #: src/themes/OLH/templates/repository/preprint.html:114
+#: src/themes/OLH/templates/repository/preprint.html:152
 #: src/themes/clean/templates/elements/journal/issue_sidebar.html:6
-#: src/themes/clean/templates/journal/article.html:102
-#: src/themes/clean/templates/journal/article.html:281
+#: src/themes/clean/templates/journal/article.html:101
+#: src/themes/clean/templates/journal/article.html:184
+#: src/themes/clean/templates/journal/article.html:291
 #: src/themes/material/templates/elements/journal/issue_sidebar.html:5
-#: src/themes/material/templates/journal/article.html:188
+#: src/themes/material/templates/journal/article.html:123
+#: src/themes/material/templates/journal/article.html:169
+#: src/themes/material/templates/journal/article.html:273
 #: src/themes/material/templates/preprints/article.html:133
-#: src/themes/material/templates/repository/preprint.html:132
+#: src/themes/material/templates/repository/preprint.html:130
+#: src/themes/material/templates/repository/preprint.html:203
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -3739,11 +4116,11 @@ msgid "Sort articles by"
 msgstr "Sorteer artikels op"
 
 #: src/themes/OLH/templates/elements/journal/summary_modal.html:3
-#: src/themes/OLH/templates/journal/article.html:437
+#: src/themes/OLH/templates/journal/article.html:428
 #: src/themes/clean/templates/elements/journal/summary_modal.html:6
-#: src/themes/clean/templates/journal/article.html:250
+#: src/themes/clean/templates/journal/article.html:260
 #: src/themes/material/templates/elements/summary_modal.html:5
-#: src/themes/material/templates/journal/article.html:380
+#: src/themes/material/templates/journal/article.html:382
 msgid "Non Specialist Summary"
 msgstr "Niet-gespecialiseerde samenvatting"
 
@@ -3808,9 +4185,9 @@ msgid "Public Submissions"
 msgstr "Publieke inzendingen"
 
 #: src/themes/OLH/templates/elements/section_block.html:12
-#: src/themes/OLH/templates/journal/article.html:298
+#: src/themes/OLH/templates/journal/article.html:279
 #: src/themes/clean/templates/elements/sections_block.html:9
-#: src/themes/clean/templates/journal/article.html:242
+#: src/themes/clean/templates/journal/article.html:252
 #: src/themes/material/templates/elements/sections_display.html:11
 msgid "Peer Reviewed"
 msgstr "Peer reviewed"
@@ -3898,7 +4275,7 @@ msgstr "Artikel"
 
 #: src/themes/OLH/templates/journal/article.html:28
 #: src/themes/OLH/templates/journal/article.html:64
-#: src/themes/OLH/templates/journal/article.html:159
+#: src/themes/OLH/templates/journal/article.html:162
 #: src/themes/OLH/templates/journal/print.html:15
 #: src/themes/clean/templates/journal/article.html:38
 #: src/themes/clean/templates/journal/print.html:15
@@ -3906,41 +4283,86 @@ msgid "Author"
 msgstr "Auteur"
 
 #: src/themes/OLH/templates/journal/article.html:115
-#: src/themes/material/templates/journal/article.html:250
+#: src/themes/clean/templates/journal/article.html:172
+#: src/themes/material/templates/journal/article.html:231
 msgid "Share"
 msgstr "Delen"
 
+#: src/themes/OLH/templates/journal/article.html:116
+#: src/themes/clean/templates/journal/article.html:176
+#: src/themes/material/templates/journal/article.html:236
+#, fuzzy
+#| msgid "Facebook"
+msgid "Share on Facebook"
+msgstr "Facebook"
+
+#: src/themes/OLH/templates/journal/article.html:118
+#: src/themes/clean/templates/journal/article.html:179
+#: src/themes/material/templates/journal/article.html:239
+#, fuzzy
+#| msgid "Share"
+msgid "Share on X"
+msgstr "Delen"
+
+#: src/themes/OLH/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:182
+#: src/themes/material/templates/journal/article.html:242
+msgid "Share on LinkedIn"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:128
+#, fuzzy
+#| msgid "Edit Article"
+msgid "print article"
+msgstr "Artikel bewerken"
+
+#: src/themes/OLH/templates/journal/article.html:129
+msgid "decrease text size"
+msgstr ""
+
 #: src/themes/OLH/templates/journal/article.html:130
+msgid "increase text size"
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:132
+#, fuzzy
+#| msgid "Dyslexia"
+msgid "Dyslexia mode"
+msgstr "Dyslexie"
+
+#: src/themes/OLH/templates/journal/article.html:132
 msgid "Dyslexia"
 msgstr "Dyslexie"
 
-#: src/themes/OLH/templates/journal/article.html:137
-#: src/themes/OLH/templates/journal/article.html:210
-#: src/themes/OLH/templates/journal/article.html:353
-#: src/themes/OLH/templates/journal/article.html:357
+#: src/themes/OLH/templates/journal/article.html:134
+#, fuzzy
+#| msgid "Edit Article"
+msgid "Cite article"
+msgstr "Artikel bewerken"
+
+#: src/themes/OLH/templates/journal/article.html:139
+#: src/themes/OLH/templates/journal/article.html:213
+#: src/themes/OLH/templates/journal/article.html:339
 #: src/themes/clean/templates/journal/article.html:104
-#: src/themes/clean/templates/journal/article.html:186
-#: src/themes/clean/templates/journal/article.html:191
-#: src/themes/clean/templates/journal/article.html:298
-#: src/themes/clean/templates/journal/article.html:301
+#: src/themes/clean/templates/journal/article.html:190
+#: src/themes/clean/templates/journal/article.html:308
+#: src/themes/clean/templates/journal/article.html:311
 #: src/themes/material/templates/elements/journal/issue_sidebar.html:8
-#: src/themes/material/templates/journal/article.html:124
 #: src/themes/material/templates/journal/article.html:127
-#: src/themes/material/templates/journal/article.html:293
-#: src/themes/material/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:279
 #: src/themes/material/templates/preprints/article.html:113
 #: src/themes/material/templates/preprints/article.html:117
 #: src/themes/material/templates/preprints/article.html:139
 msgid "Download"
 msgstr "Download"
 
-#: src/themes/OLH/templates/journal/article.html:138
+#: src/themes/OLH/templates/journal/article.html:140
 #, fuzzy
 #| msgid "Download"
 msgid " Download"
 msgstr "Download"
 
-#: src/themes/OLH/templates/journal/article.html:183
+#: src/themes/OLH/templates/journal/article.html:186
 #: src/themes/OLH/templates/journal/print.html:35
 #: src/themes/clean/templates/journal/article.html:89
 #: src/themes/clean/templates/journal/print.html:35
@@ -3948,131 +4370,150 @@ msgstr "Download"
 msgid "How to Cite"
 msgstr "Hoe citeren"
 
-#: src/themes/OLH/templates/journal/article.html:190
+#: src/themes/OLH/templates/journal/article.html:193
 #: src/themes/clean/templates/journal/article.html:95
 #: src/themes/material/templates/journal/article.html:101
 msgid "Rights"
 msgstr "Rechten"
 
-#: src/themes/OLH/templates/journal/article.html:195
-#: src/themes/clean/templates/journal/article.html:143
+#: src/themes/OLH/templates/journal/article.html:198
+#: src/themes/clean/templates/journal/article.html:129
 #: src/themes/material/templates/journal/article.html:110
 msgid "Publisher Notes"
 msgstr "Uitgeversnotities"
 
-#: src/themes/OLH/templates/journal/article.html:213
-#: src/themes/OLH/templates/journal/article.html:361
+#: src/themes/OLH/templates/journal/article.html:216
+#: src/themes/OLH/templates/journal/article.html:343
 #, fuzzy
 #| msgid "View"
 msgid "View PDF"
 msgstr "Bekijken"
 
-#: src/themes/OLH/templates/journal/article.html:239
-#, python-format
-msgid ""
-"\n"
-"                                                        (grant %(id)s)\n"
-"                                                    "
+#: src/themes/OLH/templates/journal/article.html:227
+#: src/themes/OLH/templates/journal/article.html:356
+#: src/themes/clean/templates/journal/article.html:119
+#: src/themes/clean/templates/journal/article.html:207
+#: src/themes/material/templates/journal/article.html:143
+#: src/themes/material/templates/journal/article.html:298
+msgid "Downloads are not available for this article."
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:257
-#: src/themes/clean/templates/journal/article.html:280
-#: src/themes/material/templates/journal/article.html:182
+#: src/themes/OLH/templates/journal/article.html:240
+#: src/themes/OLH/templates/repository/preprint.html:151
+#: src/themes/clean/templates/journal/article.html:290
+#: src/themes/material/templates/journal/article.html:163
 #: src/themes/material/templates/preprints/article.html:132
+#: src/themes/material/templates/repository/preprint.html:202
 msgid "Views"
 msgstr "Views"
 
-#: src/themes/OLH/templates/journal/article.html:269
-#: src/themes/clean/templates/journal/article.html:289
-#: src/themes/material/templates/journal/article.html:220
+#: src/themes/OLH/templates/journal/article.html:253
+#: src/themes/clean/templates/journal/article.html:299
+#: src/themes/material/templates/journal/article.html:201
 msgid "Citations"
 msgstr "Citaties"
 
-#: src/themes/OLH/templates/journal/article.html:283
-#: src/themes/clean/templates/journal/article.html:221
+#: src/themes/OLH/templates/journal/article.html:267
+#: src/themes/clean/templates/journal/article.html:233
+#: src/themes/material/templates/journal/article.html:354
 #: src/themes/material/templates/preprints/article.html:123
 msgid "Published on"
 msgstr "Gepubliceerd op"
 
 #: src/themes/OLH/templates/journal/article.html:287
-#: src/themes/clean/templates/journal/article.html:224
-msgid "Accepted on"
-msgstr "Geaccepteerd op"
-
-#: src/themes/OLH/templates/journal/article.html:306
-#: src/themes/OLH/templates/repository/preprint.html:126
-#: src/themes/clean/templates/journal/article.html:245
+#: src/themes/OLH/templates/repository/preprint.html:127
+#: src/themes/clean/templates/journal/article.html:255
 #: src/themes/material/templates/preprints/article.html:124
-#: src/themes/material/templates/repository/preprint.html:190
+#: src/themes/material/templates/repository/preprint.html:189
 msgid "License"
 msgstr "Licentie"
 
-#: src/themes/OLH/templates/journal/article.html:374
+#: src/themes/OLH/templates/journal/article.html:359
 msgid "Downloads are not available until this article is published "
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:383
-#: src/themes/material/templates/journal/article.html:434
+#: src/themes/OLH/templates/journal/article.html:368
+#: src/themes/material/templates/journal/article.html:410
 msgid "Identifiers"
 msgstr "Identifiers"
 
-#: src/themes/OLH/templates/journal/article.html:393
-#: src/themes/material/templates/journal/article.html:326
+#: src/themes/OLH/templates/journal/article.html:378
+#: src/themes/material/templates/journal/article.html:308
 msgid "Publication details"
 msgstr "Publicatie gegevens"
 
-#: src/themes/OLH/templates/journal/article.html:396
-#: src/themes/clean/templates/journal/article.html:227
-#: src/themes/material/templates/journal/article.html:330
+#: src/themes/OLH/templates/journal/article.html:381
+#: src/themes/clean/templates/journal/article.html:237
+#: src/themes/material/templates/journal/article.html:312
 msgid "Pages"
 msgstr "Pagina's"
 
-#: src/themes/OLH/templates/journal/article.html:399
-#: src/themes/clean/templates/journal/article.html:230
+#: src/themes/OLH/templates/journal/article.html:384
+#: src/themes/clean/templates/journal/article.html:240
 msgid "Article Number"
 msgstr "Artikelnummer"
 
-#: src/themes/OLH/templates/journal/article.html:402
-#: src/themes/clean/templates/journal/article.html:233
-#: src/themes/material/templates/journal/article.html:342
+#: src/themes/OLH/templates/journal/article.html:387
+#: src/themes/clean/templates/journal/article.html:243
+#: src/themes/material/templates/journal/article.html:324
 msgid "Publisher"
 msgstr "Uitgever"
 
-#: src/themes/OLH/templates/journal/article.html:405
-#: src/themes/clean/templates/journal/article.html:236
+#: src/themes/OLH/templates/journal/article.html:390
+#: src/themes/clean/templates/journal/article.html:246
 msgid "Original Publication"
 msgstr "Originele publicatie"
 
-#: src/themes/OLH/templates/journal/article.html:408
-#: src/themes/clean/templates/journal/article.html:239
-#: src/themes/material/templates/journal/article.html:354
+#: src/themes/OLH/templates/journal/article.html:393
+#: src/themes/clean/templates/journal/article.html:249
+#: src/themes/material/templates/journal/article.html:336
 msgid "Original ISSN"
 msgstr ""
 
-#: src/themes/OLH/templates/journal/article.html:416
-#: src/themes/clean/templates/journal/article.html:209
-#: src/themes/material/templates/journal/article.html:366
-#: src/themes/material/templates/repository/preprint.html:140
+#: src/themes/OLH/templates/journal/article.html:396
+#: src/themes/clean/templates/journal/article.html:223
+#: src/themes/material/templates/journal/article.html:342
+#, fuzzy
+#| msgid "D/T Submitted"
+msgid "Submitted on"
+msgstr "Datum/Tijd ingezonden"
+
+#: src/themes/OLH/templates/journal/article.html:399
+#: src/themes/clean/templates/journal/article.html:228
+#: src/themes/material/templates/journal/article.html:348
+msgid "Accepted on"
+msgstr "Geaccepteerd op"
+
+#: src/themes/OLH/templates/journal/article.html:407
+#: src/themes/clean/templates/journal/article.html:211
+#: src/themes/material/templates/journal/article.html:368
+#: src/themes/material/templates/repository/preprint.html:138
 msgid "Supplementary Files"
 msgstr "Aanvullende bestanden"
 
-#: src/themes/OLH/templates/journal/article.html:439
-#: src/themes/material/templates/journal/article.html:381
+#: src/themes/OLH/templates/journal/article.html:430
+#: src/themes/material/templates/journal/article.html:383
 msgid "View Summary"
 msgstr "Samenvatting bekijken"
 
-#: src/themes/OLH/templates/journal/article.html:446
+#: src/themes/OLH/templates/journal/article.html:437
 msgid "Jump to"
 msgstr "Spring naar"
 
-#: src/themes/OLH/templates/journal/article.html:472
-#: src/themes/clean/templates/journal/article.html:305
-#: src/themes/material/templates/journal/article.html:478
+#: src/themes/OLH/templates/journal/article.html:463
+#: src/themes/clean/templates/journal/article.html:324
+#: src/themes/material/templates/journal/article.html:464
 msgid "File Checksums"
 msgstr "Checksums van bestanden"
 
-#: src/themes/OLH/templates/journal/article.html:485
-#: src/themes/material/templates/journal/article.html:446
+#: src/themes/OLH/templates/journal/article.html:473
+#: src/themes/clean/templates/journal/article.html:334
+#: src/themes/material/templates/journal/article.html:475
+msgid "File Checksums are not available for this article."
+msgstr ""
+
+#: src/themes/OLH/templates/journal/article.html:480
+#: src/themes/material/templates/journal/article.html:422
 msgid "Peer Review"
 msgstr "Peer review"
 
@@ -4108,7 +4549,6 @@ msgstr "Collectie"
 
 #: src/themes/OLH/templates/journal/collections.html:29
 #: src/themes/OLH/templates/repository/preprint.html:124
-#: src/themes/material/templates/journal/article.html:400
 msgid "Published"
 msgstr "Gepubliceerd"
 
@@ -4143,19 +4583,19 @@ msgstr "Uitgelichte tijdschriften"
 msgid "Unnamed Journal"
 msgstr "Naamloos tijdschrift"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
 #: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
 msgid "Latest"
 msgstr "Laatste"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:9
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:10
 #: src/themes/clean/templates/journal/homepage_elements/news.html:8
-#: src/themes/material/templates/journal/homepage_elements/news.html:11
+#: src/themes/material/templates/journal/homepage_elements/news.html:12
 msgid "Posts"
 msgstr "Berichten"
 
-#: src/themes/OLH/templates/journal/homepage_elements/news.html:35
+#: src/themes/OLH/templates/journal/homepage_elements/news.html:36
 #: src/themes/clean/templates/press/core/news/index.html:21
 msgid "This journal currently has no news items to display"
 msgstr "Dit tijdschrift heeft momenteel geen nieuwsitems om weer te geven"
@@ -4170,18 +4610,6 @@ msgstr "Meest populaire artikels"
 #: src/themes/clean/templates/journal/homepage_elements/preprints.html:6
 msgid "Featured Preprints"
 msgstr "Uitgelichte preprints"
-
-#: src/themes/OLH/templates/journal/issues.html:31
-#: src/themes/clean/templates/journal/issues.html:19
-#: src/themes/clean/templates/journal/issues.html:28
-#: src/themes/material/templates/journal/issues.html:29
-#: src/themes/material/templates/journal/issues.html:31
-msgid "items"
-msgstr "Items"
-
-#: src/themes/OLH/templates/journal/issues.html:39
-msgid "There are no issues published in this journal yet."
-msgstr "Dit tijdschrift heeft nog geen nummers gepubliceerd"
 
 #: src/themes/OLH/templates/journal/keyword.html:6
 #: src/themes/OLH/templates/journal/keyword.html:12
@@ -4227,37 +4655,38 @@ msgstr "Inzendingen"
 msgid "Login with ORCiD"
 msgstr "Inloggen met ORCiD"
 
-#: src/themes/OLH/templates/press/core/news/index.html:5
-#: src/themes/OLH/templates/press/core/news/index.html:10
-#: src/themes/OLH/templates/press/core/news/item.html:5
+#: src/themes/OLH/templates/press/core/news/index.html:6
+#: src/themes/OLH/templates/press/core/news/index.html:11
+#: src/themes/OLH/templates/press/core/news/item.html:6
 #: src/themes/clean/templates/press/core/news/index.html:9
 #: src/themes/clean/templates/press/nav.html:16
+#: src/themes/hourglass/templates/press/news/index.html:4
 #: src/themes/material/templates/core/nav.html:88
 #: src/themes/material/templates/press/core/news/index.html:5
 #: src/themes/material/templates/press/core/news/index.html:10
-#: src/themes/material/templates/press/core/news/item.html:5
+#: src/themes/material/templates/press/core/news/item.html:6
 msgid "News"
 msgstr "Nieuws"
 
-#: src/themes/OLH/templates/press/core/news/index.html:31
+#: src/themes/OLH/templates/press/core/news/index.html:32
 msgid "This press currently has no news items to display."
 msgstr "Momenteel zijn er geen nieuwsitems."
 
-#: src/themes/OLH/templates/press/core/news/item.html:33
+#: src/themes/OLH/templates/press/core/news/item.html:34
 #: src/themes/material/templates/press/core/news/index.html:21
-#: src/themes/material/templates/press/core/news/item.html:17
+#: src/themes/material/templates/press/core/news/item.html:18
 msgid "Posted by"
 msgstr "Geplaatst door"
 
-#: src/themes/OLH/templates/press/core/news/item.html:40
-#: src/themes/material/templates/core/news/item.html:35
-#: src/themes/material/templates/press/core/news/item.html:22
+#: src/themes/OLH/templates/press/core/news/item.html:41
+#: src/themes/material/templates/core/news/item.html:36
+#: src/themes/material/templates/press/core/news/item.html:23
 msgid "Tags"
 msgstr "Tags"
 
-#: src/themes/OLH/templates/press/core/news/item.html:45
+#: src/themes/OLH/templates/press/core/news/item.html:46
 #: src/themes/clean/templates/press/core/news/item.html:18
-#: src/themes/material/templates/press/core/news/item.html:30
+#: src/themes/material/templates/press/core/news/item.html:31
 msgid "Back to News List"
 msgstr "Terug naar de nieuws lijst"
 
@@ -4270,6 +4699,7 @@ msgstr "Sitemap"
 #: src/themes/OLH/templates/press/press_journals.html:5
 #: src/themes/clean/templates/press/nav.html:37
 #: src/themes/clean/templates/press/press_journals.html:10
+#: src/themes/hourglass/templates/press/press_journals.html:9
 #: src/themes/material/templates/press/press_journals.html:9
 msgid "Journals"
 msgstr "Tijdschriften"
@@ -4285,16 +4715,22 @@ msgstr "Conferenties"
 msgid "Repositories"
 msgstr ""
 
+#: src/themes/OLH/templates/press/nav.html:39
+#: src/themes/material/templates/preprints/editors.html:5
+#: src/themes/material/templates/preprints/editors.html:6
+msgid "Editorial Team"
+msgstr "Redactie"
+
 #: src/themes/OLH/templates/press/press_journals.html:48
 msgid "Disciplines"
 msgstr "Disciplines"
 
 #: src/themes/OLH/templates/press/press_journals.html:61
 #: src/themes/OLH/templates/press/press_journals.html:68
-#: src/themes/clean/templates/journal/article.html:195
+#: src/themes/clean/templates/journal/article.html:194
 #: src/themes/clean/templates/press/press_journals.html:32
 #: src/themes/clean/templates/press/press_journals.html:39
-#: src/themes/material/templates/journal/article.html:303
+#: src/themes/material/templates/journal/article.html:283
 #: src/themes/material/templates/press/press_journals.html:36
 #: src/themes/material/templates/press/press_journals.html:43
 msgid "View"
@@ -4350,7 +4786,7 @@ msgstr "Affiliatie auteur"
 #: src/themes/OLH/templates/repository/nav.html:6
 #: src/themes/material/templates/repository/nav.html:21
 #: src/themes/material/templates/repository/nav.html:45
-#: src/themes/material/templates/repository/preprint.html:168
+#: src/themes/material/templates/repository/preprint.html:166
 msgid "Subjects"
 msgstr ""
 
@@ -4361,7 +4797,7 @@ msgstr "Preprint Body"
 
 #: src/themes/OLH/templates/repository/preprint.html:60
 #: src/themes/material/templates/preprints/article.html:63
-#: src/themes/material/templates/repository/preprint.html:87
+#: src/themes/material/templates/repository/preprint.html:85
 msgid "Comments"
 msgstr "Opmerkingen"
 
@@ -4381,16 +4817,23 @@ msgstr "Er zijn geen opmerkingen of ze zijn niet publiek gemaakt"
 msgid "Last Updated"
 msgstr "Update"
 
-#: src/themes/OLH/templates/repository/preprint.html:134
+#: src/themes/OLH/templates/repository/preprint.html:138
 #: src/themes/material/templates/preprints/article.html:135
 msgid "Versions"
 msgstr "Versies"
 
-#: src/themes/OLH/templates/repository/preprint.html:139
+#: src/themes/OLH/templates/repository/preprint.html:143
 msgid "This is the only version of the preprint."
 msgstr "Dit is de enige versie van de preprint"
 
-#: src/themes/OLH/templates/repository/preprint.html:143
+#: src/themes/OLH/templates/repository/preprint.html:149
+#: src/themes/clean/templates/journal/article.html:288
+#: src/themes/material/templates/preprints/article.html:130
+#: src/themes/material/templates/repository/preprint.html:201
+msgid "Metrics"
+msgstr "Metrieken"
+
+#: src/themes/OLH/templates/repository/preprint.html:156
 #: src/themes/material/templates/preprints/article.html:152
 #: src/themes/material/templates/preprints/list.html:6
 #: src/themes/material/templates/preprints/list.html:14
@@ -4401,16 +4844,11 @@ msgstr "Alle preprints"
 msgid "You do not have permission to view this page"
 msgstr ""
 
-#: src/themes/clean/templates/500.html:21
-#: src/themes/clean/templates/core/base.html:37
-msgid "Skip to main content"
-msgstr ""
-
 #: src/themes/clean/templates/500.html:27
 msgid "A server error has occurred."
 msgstr ""
 
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:10
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:14
 msgid ""
 "The ORCiD you logged in with is not currently linked with an account in our "
 "system. You can either\n"
@@ -4421,15 +4859,12 @@ msgstr ""
 "account in ons systeem. U kunt een nieuw account registreren of inloggen met "
 "een bestaand account om uw ORCiD te koppelen voor toekomstig gebruik."
 
-#: src/themes/clean/templates/core/accounts/orcid_registration.html:30
+#: src/themes/clean/templates/core/accounts/orcid_registration.html:34
 msgid "Forgot your password"
 msgstr "Wachtwoord vergeten"
 
-#: src/themes/clean/templates/core/accounts/public_profile.html:10
-msgid "profile photo"
-msgstr "profielfoto"
-
-#: src/themes/clean/templates/core/accounts/register.html:24
+#: src/themes/clean/templates/core/accounts/register.html:26
+#: src/themes/clean/templates/core/accounts/reset_password.html:26
 msgid ""
 "For more information read our <a href=\"#\" data-toggle=\"modal\" data-"
 "target=\"#passwordmodal\">password guide</a>."
@@ -4468,12 +4903,7 @@ msgstr ""
 "kraken, ten opzicht van ongeveer 600 jaar voor een complex wachtwoord zoals "
 "<i>Jfjfy&65^87</i>."
 
-#: src/themes/clean/templates/core/accounts/reset_password.html:23
-#: src/themes/material/templates/core/accounts/reset_password.html:23
-msgid "For more information read our <a href=\"#\" data-target=\"passwordmodal\" class=\"modal-trigger\">password guide</a>."
-msgstr "Voor meer informatie, lees onze <a href=\"#\" data-target=\"passwordmodal\" class=\"modal-trigger\">wachtwoordgids</a>."
-
-#: src/themes/clean/templates/core/accounts/reset_password.html:50
+#: src/themes/clean/templates/core/accounts/reset_password.html:54
 msgid ""
 "Its a common myth that a short and complex password (Jfjfy&65^87) is more "
 "secure than a long and\n"
@@ -4482,7 +4912,7 @@ msgstr ""
 "Het is een mythe dat een kort en complex wachtwoord (Jfjfy&65^87) veiliger "
 "is dan een lang en eenvoudig wachtwoord (our awesome moon base rocks)."
 
-#: src/themes/clean/templates/core/accounts/reset_password.html:52
+#: src/themes/clean/templates/core/accounts/reset_password.html:56
 msgid ""
 "We recommend selecting a long, but easy to remember password such as <em>our "
 "awesome moon base\n"
@@ -4547,10 +4977,22 @@ msgstr "Nieuw wachtwoord ingeven"
 msgid "Enter New Password Again"
 msgstr "Nieuw wachtwoord nogmaals ingeven"
 
+#: src/themes/clean/templates/elements/journal/issue_list.html:8
+msgid "This journal has no issues"
+msgstr "Dit tijdschrift heeft geen nummers"
+
+#: src/themes/clean/templates/elements/journal/issue_list_by_decade.html:2
+msgid ""
+"\n"
+"        Issues are grouped by decade. Select a decade to view the issues\n"
+"        published during that decade.\n"
+"    "
+msgstr ""
+
 #: src/themes/clean/templates/elements/journal/table_modal.html:12
 #: src/themes/clean/templates/elements/public_reviews.html:35
 #: src/themes/material/templates/core/accounts/register.html:61
-#: src/themes/material/templates/core/accounts/reset_password.html:49
+#: src/themes/material/templates/core/accounts/reset_password.html:51
 #: src/themes/material/templates/elements/summary_modal.html:13
 msgid "Close"
 msgstr "Sluiten"
@@ -4580,54 +5022,28 @@ msgstr ""
 msgid "Sections submission information"
 msgstr "Informatie over secties bij de inzending"
 
-#: src/themes/clean/templates/journal/article.html:133
-#, fuzzy, python-format
-#| msgid ""
-#| "For more information read our\n"
-#| "                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-#| "\">password guide</a>\n"
-#| "                        ."
-msgid ""
-"\n"
-"                                        (grant %(id)s)\n"
-"                                    "
-msgstr ""
-"Voor meer informatie, lees onze <a href=\"#passwordmodal\" class=\"modal-"
-"trigger\">wachtwoordgids</a>."
-
-#: src/themes/clean/templates/journal/article.html:268
+#: src/themes/clean/templates/journal/article.html:278
 #, fuzzy
 #| msgid "Peer Review"
 msgid "Open Peer Reviews"
 msgstr "Peer review"
 
-#: src/themes/clean/templates/journal/article.html:278
-#: src/themes/material/templates/preprints/article.html:130
-msgid "Metrics"
-msgstr "Metrieken"
-
-#: src/themes/clean/templates/journal/article.html:285
-#: src/themes/material/templates/journal/article.html:203
+#: src/themes/clean/templates/journal/article.html:295
+#: src/themes/material/templates/journal/article.html:184
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: src/themes/clean/templates/journal/article.html:287
-#: src/themes/material/templates/journal/article.html:211
+#: src/themes/clean/templates/journal/article.html:297
+#: src/themes/material/templates/journal/article.html:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/themes/clean/templates/journal/article.html:292
+#: src/themes/clean/templates/journal/article.html:302
 #: src/themes/material/templates/preprints/article.html:145
 msgid "Citation"
 msgstr "Citatie"
 
-#: src/themes/clean/templates/journal/article.html:317
-#: src/themes/material/templates/journal/article.html:494
-#: src/themes/material/templates/journal/submissions.html:72
-msgid "Table of Contents"
-msgstr "Inhoudstafel"
-
-#: src/themes/clean/templates/journal/article.html:343
+#: src/themes/clean/templates/journal/article.html:366
 msgid "View Larger Table"
 msgstr ""
 
@@ -4643,7 +5059,7 @@ msgstr "Secties"
 
 #: src/themes/clean/templates/journal/authors.html:26
 #: src/themes/material/templates/journal/authors.html:31
-#: src/themes/material/templates/journal/editorial_team.html:36
+#: src/themes/material/templates/journal/editorial_team.html:34
 msgid "View Profile"
 msgstr "Bekijk profiel"
 
@@ -4673,13 +5089,9 @@ msgstr "Volgende"
 msgid "Play"
 msgstr "Speel"
 
-#: src/themes/clean/templates/journal/issues.html:16
+#: src/themes/clean/templates/journal/issues.html:14
 msgid "The current issue is"
 msgstr "Het huidige nummer is"
-
-#: src/themes/clean/templates/journal/issues.html:30
-msgid "This journal has no issues"
-msgstr "Dit tijdschrift heeft geen nummers"
 
 #: src/themes/clean/templates/press/press_journals.html:52
 #, fuzzy
@@ -4692,7 +5104,64 @@ msgstr "Dit tijdschrift heeft geen nummers"
 msgid "Start typing to filter."
 msgstr ""
 
-#: src/themes/material/templates/core/accounts/activate_account.html:25
+#: src/themes/hourglass/templates/core/accounts/orcid_registration.html:10
+#, fuzzy
+#| msgid "Unregistered ORCiD"
+msgid "Unregistered ORCID"
+msgstr "Ongeregistreerde ORCiD"
+
+#: src/themes/hourglass/templates/custom/get-reset-token.html:27
+#, fuzzy
+#| msgid "Enter your email address to begin the reset process"
+msgid ""
+"\n"
+"                  Enter your email address to begin the reset process\n"
+"                "
+msgstr "Geef uw e-mailadres in om het reset proces te beginnen"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:19
+#, fuzzy
+#| msgid ""
+#| "The ORCiD you logged in with is not currently linked with an account in "
+#| "our system. You can either register a new account, or login with an "
+#| "existing account to link your ORCiD for future use."
+msgid ""
+"\n"
+"          <p>The ORCiD you logged in with is not currently linked with\n"
+"          an account in our system. You can either register a new account, "
+"or\n"
+"          login with an existing account to link your ORCiD for future use.</"
+"p>\n"
+"        "
+msgstr ""
+"De ORCiD waarmee u bent ingelogd, is momenteel niet gekoppeld aan een "
+"account in ons systeem. U kunt een nieuw account registreren of inloggen met "
+"een bestaand account om uw ORCiD te koppelen voor toekomstig gebruik."
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:43
+#, fuzzy
+#| msgid "Register an Account"
+msgid "Register an account"
+msgstr "Een account registreren"
+
+#: src/themes/hourglass/templates/custom/orcid-registration.html:46
+#, fuzzy
+#| msgid "Reset Your Password"
+msgid "Reset your password"
+msgstr "Uw wachtwoord opnieuw instellen"
+
+#: src/themes/hourglass/templates/custom/profile.html:40
+msgid ""
+"\n"
+"                    Please note: If you update your email,\n"
+"                    You will be logged out, and you won't be\n"
+"                    able to log in again until you follow\n"
+"                    the verification link in an email\n"
+"                    sent to your new email address.\n"
+"                  "
+msgstr ""
+
+#: src/themes/material/templates/core/accounts/activate_account.html:29
 msgid ""
 "There was no inactive account with this activation code found. It is "
 "possible that your account is already active, you can check by attempting to "
@@ -4701,8 +5170,17 @@ msgstr ""
 "mogelijk dat uw account al actief is, u kunt dit controleren door te "
 "proberen "
 
+#: src/themes/material/templates/core/accounts/register.html:29
+#: src/themes/material/templates/core/accounts/reset_password.html:26
+msgid ""
+"For more information read our <a href=\"#\" data-target=\"passwordmodal\" "
+"class=\"modal-trigger\">password guide</a>."
+msgstr ""
+"Voor meer informatie, lees onze <a href=\"#\" data-target=\"passwordmodal\" "
+"class=\"modal-trigger\">wachtwoordgids</a>."
+
 #: src/themes/material/templates/core/accounts/register.html:56
-#: src/themes/material/templates/core/accounts/reset_password.html:44
+#: src/themes/material/templates/core/accounts/reset_password.html:46
 msgid ""
 "We recommend selecting a long, but easy to remember password such as <i>our "
 "awesome moon base\n"
@@ -4731,7 +5209,7 @@ msgstr "Een account registreren"
 msgid "Reset Your Password"
 msgstr "Uw wachtwoord opnieuw instellen"
 
-#: src/themes/material/templates/core/news/index.html:39
+#: src/themes/material/templates/core/news/index.html:40
 msgid "This journal currently has no items to display."
 msgstr "Dit tijdschrift heeft momenteel geen items om te tonen."
 
@@ -4775,56 +5253,37 @@ msgstr "U kan uw data exporteren in JSON formaat voor hergebruik."
 msgid "Export"
 msgstr "Exporteren"
 
+#: src/themes/material/templates/elements/journal/issue_list.html:26
+msgid "close"
+msgstr "sluiten"
+
+#: src/themes/material/templates/elements/journal/issue_list.html:30
+msgid "View Issue"
+msgstr "Nummer bekijken"
+
 #: src/themes/material/templates/elements/license_block.html:4
 msgid "More Information "
 msgstr "Meer informatie "
 
-#: src/themes/material/templates/journal/article.html:161
-#, fuzzy, python-format
-#| msgid ""
-#| "For more information read our\n"
-#| "                        <a href=\"#passwordmodal\" class=\"modal-trigger"
-#| "\">password guide</a>\n"
-#| "                        ."
-msgid ""
-"\n"
-"                                                (grant %(id)s)\n"
-"                                            "
-msgstr ""
-"Voor meer informatie, lees onze <a href=\"#passwordmodal\" class=\"modal-"
-"trigger\">wachtwoordgids</a>."
-
-#: src/themes/material/templates/journal/article.html:195
+#: src/themes/material/templates/journal/article.html:176
 msgid "Tweets"
 msgstr "Tweets"
 
-#: src/themes/material/templates/journal/article.html:336
+#: src/themes/material/templates/journal/article.html:318
 msgid "Article No."
 msgstr "Artikel nr."
 
-#: src/themes/material/templates/journal/article.html:348
+#: src/themes/material/templates/journal/article.html:330
 msgid "Publication"
 msgstr "Publicatie"
 
-#: src/themes/material/templates/journal/article.html:389
-msgid "Dates"
-msgstr "Data"
-
-#: src/themes/material/templates/journal/article.html:450
+#: src/themes/material/templates/journal/article.html:426
 msgid "This article has been peer reviewed."
 msgstr "Dit artikel heeft 'peer review' ondergaan."
 
 #: src/themes/material/templates/journal/collections.html:33
 msgid "View Collection"
 msgstr "Collectie bekijken"
-
-#: src/themes/material/templates/journal/issues.html:35
-msgid "close"
-msgstr "sluiten"
-
-#: src/themes/material/templates/journal/issues.html:39
-msgid "View Issue"
-msgstr "Nummer bekijken"
 
 #: src/themes/material/templates/journal/new_search.html:26
 #: src/themes/material/templates/journal/search.html:28
@@ -4881,26 +5340,129 @@ msgstr "Instelling auteur"
 msgid "Start New Submission"
 msgstr ""
 
-#: src/themes/material/templates/repository/preprint.html:70
+#: src/themes/material/templates/repository/preprint.html:68
 msgid "Add a Comment"
 msgstr ""
 
-#: src/utils/forms.py:102
+#: src/utils/forms.py:107
 #, python-format
 msgid "What is %(num1)i %(operator)s %(num2)i? "
 msgstr "Wat is %(num1)i %(operator)s %(num2)i? "
 
-#: src/utils/forms.py:103
+#: src/utils/forms.py:108
 msgid "Answer this question: "
 msgstr "Beantwoord deze vraag: "
 
-#: src/utils/transactional_emails.py:370
+#: src/utils/forms.py:153
+msgid "HTML is not allowed in this field"
+msgstr ""
+
+#: src/utils/transactional_emails.py:385
 msgid "accepted"
 msgstr "aanvaard"
 
-#: src/utils/transactional_emails.py:380
+#: src/utils/transactional_emails.py:395
 msgid "declined"
 msgstr "geweigerd"
+
+#~ msgid "Password 1"
+#~ msgstr "Wachtwoord 1"
+
+#~ msgid "Password 2"
+#~ msgstr "Wachtwoord 2"
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to create a typesetting assignment?"
+#~ msgstr "Geef uw wachtwoord twee keer in om het reset proces te voltooien"
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to create a proofreading assignment?"
+#~ msgstr "Geef uw wachtwoord twee keer in om het reset proces te voltooien"
+
+#, fuzzy
+#~| msgid "A set of controls for how things display on the article page"
+#~ msgid "Text to show as the download link on the article page"
+#~ msgstr "Instellingen voor de artikelpagina"
+
+#, fuzzy
+#~| msgid "Enter your new password twice to complete the reset process"
+#~ msgid "Are you sure you want to complete the proofreading task?"
+#~ msgstr "Geef uw wachtwoord twee keer in om het reset proces te voltooien"
+
+#~ msgid ""
+#~ "Please avoid pasting content from word processors as they can add "
+#~ "unwanted styling to the abstract. You can retype the abstract here or "
+#~ "copy and paste it into notepad/a plain text editor before pasting here."
+#~ msgstr ""
+#~ "Gelieve geen inhoud van tekstverwerkers te plakken, aangezien deze "
+#~ "ongewenste opmaak aan de samenvatting kunnen toevoegen. U kunt de "
+#~ "samenvatting hier opnieuw typen of eerst kopiëren en plakken in Kladblok "
+#~ "of een andere eenvoudige text editor voordat u deze hier plakt."
+
+#, fuzzy
+#~| msgid "Options"
+#~ msgid "Email Options"
+#~ msgstr "Opties"
+
+#~ msgid "allows the following licenses for submission"
+#~ msgstr "laat de volgende licenties toe bij inzendingen"
+
+#~ msgid "somebody"
+#~ msgstr "iemand"
+
+#~ msgid "account"
+#~ msgstr "account"
+
+#, fuzzy, python-format
+#~| msgid "Your password must be {} characters long"
+#~ msgid ""
+#~ "Your password should be %(request.press.password_length)s characters long."
+#~ msgstr "Uw wachtwoord moet {} karakters lang zijn"
+
+#~ msgid ""
+#~ "For more information read our\n"
+#~ "                        <a href=\"#passwordmodal\" class=\"modal-"
+#~ "trigger\">password guide</a>\n"
+#~ "                        ."
+#~ msgstr ""
+#~ "Voor meer informatie, lees onze <a href=\"#passwordmodal\" class=\"modal-"
+#~ "trigger\">wachtwoordgids</a>."
+
+#~ msgid "profile photo"
+#~ msgstr "profielfoto"
+
+#, fuzzy, python-format
+#~| msgid ""
+#~| "For more information read our\n"
+#~| "                        <a href=\"#passwordmodal\" class=\"modal-"
+#~| "trigger\">password guide</a>\n"
+#~| "                        ."
+#~ msgid ""
+#~ "\n"
+#~ "                                        (grant %(id)s)\n"
+#~ "                                    "
+#~ msgstr ""
+#~ "Voor meer informatie, lees onze <a href=\"#passwordmodal\" class=\"modal-"
+#~ "trigger\">wachtwoordgids</a>."
+
+#, fuzzy, python-format
+#~| msgid ""
+#~| "For more information read our\n"
+#~| "                        <a href=\"#passwordmodal\" class=\"modal-"
+#~| "trigger\">password guide</a>\n"
+#~| "                        ."
+#~ msgid ""
+#~ "\n"
+#~ "                                                (grant %(id)s)\n"
+#~ "                                            "
+#~ msgstr ""
+#~ "Voor meer informatie, lees onze <a href=\"#passwordmodal\" class=\"modal-"
+#~ "trigger\">wachtwoordgids</a>."
+
+#~ msgid "Dates"
+#~ msgstr "Data"
 
 #~ msgid "File Checksums (MD5)"
 #~ msgstr "Checksums (MD5) van bestanden"
@@ -5000,9 +5562,6 @@ msgstr "geweigerd"
 #~ msgid "Completed"
 #~ msgstr "Voltooien"
 
-#~ msgid "Funder DOI"
-#~ msgstr "DOI financier"
-
 #~ msgid "(optional)"
 #~ msgstr "(optioneel)"
 
@@ -5042,8 +5601,8 @@ msgstr "geweigerd"
 #~ "                            contain specific\n"
 #~ "                            characters but you should make it as long as "
 #~ "possible. For more information read our\n"
-#~ "                            <a href=\"#\" data-open=\"password-modal"
-#~ "\">password guide</a>"
+#~ "                            <a href=\"#\" data-open=\"password-"
+#~ "modal\">password guide</a>"
 #~ msgstr ""
 #~ "Uw wachtwoord moet minstens 12 karakters lang zijn. Het hoeft geen "
 #~ "speciale karakters te bevatten, maar u moet het zo lang mogelijk maken. "


### PR DESCRIPTION
These changes were generated by running the following command on f47441b.

```sh
❯ python src/manage.py makemessages --all --ignore venv --ignore plugins
invalid locale en-us, did you mean en_US?
processing locale it
processing locale cy
invalid locale en_us, did you mean en_US?
processing locale nl
processing locale fr
processing locale es
processing locale de
```

This has resulted in 12000 lines of changes, which seems like too many.

Note also the error messages about invalid locales, "en-us" and "en_US". See https://github.com/openlibhums/janeway/issues/4157.