### PR TITLE
[TGDK] Fix access button functionality to properly disable review stage link

### DIFF
--- a/src/templates/admin/elements/article_jump.html
+++ b/src/templates/admin/elements/article_jump.html
@@ -8,7 +8,8 @@
         <a class="button" href="{% url 'review_unassigned_article' article.pk %}">Editor Assignment</a>
         {% for element in article.distinct_workflow_elements %}
             <a class="button{% if element.element_name == 'review' and article.stage == 'Unassigned' %} disabled{% endif %}"
-               href="{% url element.jump_url article.pk %}">{{ element.element_name|capfirst }}</a>
+            {% if element.element_name != 'review' or article.stage != 'Unassigned' %}href="{% url element.jump_url article.pk %}"{% endif %}
+            >{{ element.element_name|capfirst }}</a>
         {% endfor %}
         <button class="button" type="button" data-toggle="more-dropdown">Logs, Documents and More</button>
 


### PR DESCRIPTION
>[!IMPORTANT]
> This implementation is part of a set of features and fixes developed within the context of a project for the TGDK academic journal, with the goal of customizing Janeway to meet the journal's specific needs, which may also be extended to other contexts.

## Problem / Objective
This PR addresses a bug where the access button for the review stage of an article appeared visually disabled but remained functional when clicked.

![image](https://github.com/user-attachments/assets/fec36624-7758-48c6-8e68-c2cf4f46bf92)

This happened when using the Google Chrome browser.

## Solution
The fix ensures that the link is completely disabled and cannot be accessed when the button is in a disabled state.

Following the most direct recommendation, the href is disabled so that it does not redirect anywhere