### PR TITLE
[TGDK][Fix] Ensure articles transition to 'Accepted' stage when review is the final workflow step 

### DIFF
--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -483,7 +483,7 @@ def handle_decision_action(article, draft, request):
     }
 
     if draft.decision == ED.ACCEPT.value:
-        article.accept_article(stage=submission_models.STAGE_EDITOR_COPYEDITING)
+        article.accept_article(stage=submission_models.STAGE_ACCEPTED)
         event_logic.Events.raise_event(
             event_logic.Events.ON_ARTICLE_ACCEPTED,
             task_object=article,


### PR DESCRIPTION
>[!IMPORTANT]
> This implementation is part of a set of features and fixes developed within the context of a project for the TGDK academic journal, with the goal of customizing Janeway to meet the journal's specific needs, which may also be extended to other contexts.

## Problem / Objective
When the `draft_decisions` option is enabled and the editorial workflow is limited to the review stage, accepting a draft decision that approves an article should transition its stage to `Accepted`. However, it incorrectly transitions to `Editor Copyediting`.  

This issue becomes particularly problematic when the workflow is restricted to the review stage, as articles appear in the `Copyediting` stage instead of being marked as `Accepted`. This discrepancy leads to logistical issues within the platform.  

## Solution
The problem was identified in the `manage_draft` function, where the stage is directly set to `STAGE_EDITOR_COPYEDITING`:  
```python
article.accept_article(stage=submission_models.STAGE_EDITOR_COPYEDITING)
```  
The fix ensures that the initial stage after approval is set to `STAGE_ACCEPTED`. If subsequent workflow stages exist (e.g., Copyediting), the article will transition to those automatically, but the primary stage must always begin as `Accepted`.  
