### PR TITLE
[TGDK][Feature] Add 'Accepted Articles' panel to Back Content for better accessibility in Review-only workflows

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -455,7 +455,7 @@ def get_settings_to_edit(display_group, journal, user):
             'use_ga_four', 'display_login_page_notice', 'login_page_notice', 
             'display_register_page_notice', 'register_page_notice',
             'support_email', 'support_contact_message_for_staff',
-            'from_address', 'replyto_address',
+            'from_address', 'replyto_address', 'show_accepted_articles_archive',
         ]
 
         group_of_settings = process_setting_list(journal_settings, 'general', journal)

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -686,6 +686,27 @@ class Journal(AbstractSiteModel):
             '-date_declined'
         )
 
+    def accepted_articles(self):
+        return submission_models.Article.objects.filter(
+            journal=self,
+            stage=submission_models.STAGE_ACCEPTED,
+        ).annotate(
+            frozen_authors=ExpressionWrapper(
+                db_functions.GroupConcat(
+                    Concat(
+                        Coalesce(F('frozenauthor__first_name'), Value('')),
+                        Value(' '),
+                        Coalesce(F('frozenauthor__middle_name'), Value('')),
+                        Value(' '),
+                        Coalesce(F('frozenauthor__last_name'), Value(''))
+                    ),
+                ),
+                output_field=TextField()
+            )
+        ).order_by(
+            '-date_accepted'
+        )
+
 class PinnedArticle(models.Model):
     journal = models.ForeignKey(
         Journal,

--- a/src/journal/urls.py
+++ b/src/journal/urls.py
@@ -170,6 +170,11 @@ urlpatterns = [
         views.rejected_archived_article_archive,
         name='manage_rejected_archived_archive',
     ),
+    re_path(
+        r'^manage/archive/accepted/$',
+        views.accepted_article_archive,
+        name='manage_accepted_archive',
+    ),
     re_path(r'^manage/archive/article/(?P<article_id>\d+)/$',
         views.manage_archive_article, name='manage_archive_article'),
 

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -1807,6 +1807,23 @@ def rejected_archived_article_archive(request):
         context,
     )
 
+@editor_user_required
+def accepted_article_archive(request):
+    """
+    Allows the editor to view information about an article that has been accepted already in peer review process.
+    :param request: request object
+    :return: contextualised django template
+    """
+    template = 'journal/manage/accepted_article_archive.html'
+    context = {
+        'accepted_articles': request.journal.accepted_articles(),
+    }
+
+    return render(
+        request,
+        template,
+        context,
+    )
 
 @editor_user_required
 def manage_archive_article(request, article_id):

--- a/src/templates/admin/core/nav.html
+++ b/src/templates/admin/core/nav.html
@@ -105,6 +105,13 @@
                     <i class="fa fa-file">&nbsp;</i> Published Articles
                 </a>
             </li>
+            {% if journal_settings.general.show_accepted_articles_archive %}
+            <li>
+                <a href="{% url 'manage_accepted_archive' %}">
+                    <i class="fa fa-archive">&nbsp;</i> Accepted Articles
+                </a>
+            </li>
+            {% endif %}
             <li>
                 <a href="{% url 'manage_rejected_archived_archive' %}">
                     <i class="fa fa-archive">&nbsp;</i> Archived Articles

--- a/src/templates/admin/core/nav.html
+++ b/src/templates/admin/core/nav.html
@@ -108,7 +108,7 @@
             {% if journal_settings.general.show_accepted_articles_archive %}
             <li>
                 <a href="{% url 'manage_accepted_archive' %}">
-                    <i class="fa fa-archive">&nbsp;</i> Accepted Articles
+                    <i class="fa fa-check">&nbsp;</i> Accepted Articles
                 </a>
             </li>
             {% endif %}

--- a/src/templates/admin/elements/forms/group_journal.html
+++ b/src/templates/admin/elements/forms/group_journal.html
@@ -80,6 +80,9 @@
     <p>You can use this setting to stop this journal being list on the Press' journals page.</p>
     {% include "admin/elements/forms/field.html" with field=attr_form.hide_from_press %}
 
+    <p>If you want to allow the editor to view information about peer review accepted articles:</p>
+    {% include "admin/elements/forms/field.html" with field=edit_form.show_accepted_articles_archive %}
+
     <p>If you want to display a special message on the login page you can add it here.</p>
     {% include "admin/elements/forms/field.html" with field=edit_form.display_login_page_notice %}
     {% include "admin/elements/forms/field.html" with field=edit_form.login_page_notice %}

--- a/src/templates/admin/journal/manage/accepted_article_archive.html
+++ b/src/templates/admin/journal/manage/accepted_article_archive.html
@@ -1,0 +1,58 @@
+{% extends "admin/core/base.html" %}}
+{% load securitytags %}
+{% load files %}
+{% load static %}
+{% load foundation %}
+
+{% block title %}Accepted Articles{% endblock title %}
+{% block title-section %}Accepted Articles{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li>Accepted Articles</li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+    <div class="large-12 columns">
+        <div class="box">
+            <div class="content">
+                <table class="small article_list scroll">
+                    <thead>
+                    <tr>
+                        <td>ID</td>
+                        <td>Title</td>
+                        <td>Date Accepted</td>
+                        <td>Authors</td>
+                    </tr>
+                    </thead>
+
+                    <tbody>
+                    {% for article in accepted_articles %}
+                        <tr>
+                            <td>{{ article.pk }}</td>
+                            <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a></td>
+                            <td>
+                              {% if article.stage == 'Accepted' %}
+                                {% if article.date_accepted %}
+                                  {{ article.date_accepted|date:"Y-m-d" }}
+                                {% else %}
+                                  No archive date recorded
+                                {% endif %}
+                              {% endif %}
+                            </td>
+                            <td>
+                              {{ article.frozen_authors }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+{% endblock body %}
+
+{% block js %}
+{% include "elements/datatables.html" with target=".article_list" %}
+{% endblock %}

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5132,5 +5132,24 @@
         "value": {
             "default": ""
         }
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "If checked, allow the editor to view information about peer review accepted articles.",
+            "is_translatable": false,
+            "name": "show_accepted_articles_archive",
+            "pretty_name": "Show Accepted Articles Archive",
+            "type": "boolean"
+        },
+        "value": {
+            "default": ""
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
 ]


### PR DESCRIPTION
>[!IMPORTANT]
> This implementation is part of a set of features and fixes developed within the context of a project for the TGDK academic journal, with the goal of customizing Janeway to meet the journal's specific needs, which may also be extended to other contexts.

## Problem / Objective:
In workflows where only the review stage is selected, accepted articles (final state) are not accessible from the interface. Although the articles exist in the system, there is no direct way to view or manage them. This becomes particularly relevant when the editorial workflow is limited to the review stage, as the visibility of accepted articles is crucial for logistical purposes.

## Solution:
A new panel has been added to the "Back Content" section, accessible via the sidebar, to display a table of accepted articles. This panel allows users to view articles that have been accepted during the review process but have not yet been published.

Menu             |  Content
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/a538f91c-501b-495b-89fc-66b40a690a61)  | ![image](https://github.com/user-attachments/assets/fe21e10a-3d3c-44b4-bdb8-4cef2da13008)




This feature enhances usability for journals with simplified workflows, improving accessibility and management of accepted articles.

The panel's visibility and access are configurable through the "Show Accepted Article Archive" setting, located under the "Other" section in Journal Settings. By default, the panel is hidden and must be enabled in the settings.

![image](https://github.com/user-attachments/assets/1f2c22fd-26af-448f-9273-93be9192f049)

