### PR TITLE
[TGDK][Feature] Add configurable Custom Editor Assignment tool for enhanced editor management

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -424,6 +424,10 @@ def get_settings_to_edit(display_group, journal, user):
                 'name': 'display_completed_reviews_in_additional_rounds_text',
                 'object': setting_handler.get_setting('general', 'display_completed_reviews_in_additional_rounds_text', journal),
             },
+            {
+                'name': 'enable_custom_editor_assignment',
+                'object': setting_handler.get_setting('general', 'enable_custom_editor_assignment', journal),
+            },
         ]
         setting_group = 'general'
 

--- a/src/review/urls.py
+++ b/src/review/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     re_path(r'^unassigned/article/(?P<article_id>\d+)/notify/(?P<editor_id>\d+)/$', views.assignment_notification,
         name='review_assignment_notification'),
     re_path(r'^unassigned/article/(?P<article_id>\d+)/move/review/$', views.move_to_review, name='review_move_to_review'),
+    re_path(r'^article/(?P<article_id>\d+)/editor/add/$', views.add_editor_assignment, name='add_editor_assignment'),
     re_path(r'^article/(?P<article_id>\d+)/crosscheck/$', views.view_ithenticate_report, name='review_crosscheck'),
     re_path(r'^article/(?P<article_id>\d+)/move/(?P<decision>accept|decline|undecline)/$', views.review_decision,
         name='review_decision'),

--- a/src/templates/admin/elements/forms/group_review.html
+++ b/src/templates/admin/elements/forms/group_review.html
@@ -9,6 +9,7 @@
     {% include "admin/elements/forms/field.html" with field=edit_form.default_review_visibility %}
     {% include "admin/elements/forms/field.html" with field=edit_form.enable_one_click_access %}
     {% include "admin/elements/forms/field.html" with field=edit_form.draft_decisions %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.enable_custom_editor_assignment %}
     {% include "admin/elements/forms/field.html" with field=edit_form.enable_suggested_reviewers %}
 </div>
 

--- a/src/templates/admin/elements/review/add_editor_table_custom_row.html
+++ b/src/templates/admin/elements/review/add_editor_table_custom_row.html
@@ -1,0 +1,15 @@
+<tr>
+    <td>
+        <input type="radio" name="editor" value="{{ editor.id }}"
+            {% if editor.id == form.cleaned_data.editor.pk %}checked=True{% endif %}
+            {% if journal_settings.general.enable_competing_interest_selections and editor.has_conflict %}disabled{% endif %}
+        >
+    </td>
+    <td>{{ editor.full_name }}</td>
+    <td>{{ editor.email }}</td>
+    <td>{{ editor_type_label }}</td>
+    <td>{{ editor.active_assignments_count|default_if_none:0 }}</td>
+    <td class="list-interests">
+        {% for interest in editor.interest.all %}{{ interest.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
+    </td>
+</tr>

--- a/src/templates/admin/review/add_editor_assignment.html
+++ b/src/templates/admin/review/add_editor_assignment.html
@@ -119,4 +119,34 @@
         {% include "admin/elements/open_modal.html" with target=form.modal.id %}
     {% endif %}
     {% include "elements/datatables.html" with target="#enrolluser" %}
+
+    <script lang="javascript">
+    function getQueryStrings()
+    {
+        let vars = [], hash;
+        let hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+        for(let i = 0; i < hashes.length; i++)
+        {
+            hash = hashes[i].split('=');
+            vars.push(hash[0]);
+            vars[hash[0]] = hash[1].split('#')[0];
+        }
+        return vars;
+    }
+
+    // populate the query box when ready
+    $( document ).ready(function() {
+        let urls = getQueryStrings();
+        let user = urls["user"];
+        let user_id = urls["id"];
+
+        if (user !== '') {
+            $('#editors').DataTable().search(decodeURIComponent(user)).draw();
+
+            if (user_id !== '') {
+                $("input[value=" + decodeURIComponent(user_id) + "]").attr('checked', 'checked');
+            }
+        }
+    });
+    </script>
 {% endblock js %}

--- a/src/templates/admin/review/add_editor_assignment.html
+++ b/src/templates/admin/review/add_editor_assignment.html
@@ -1,0 +1,122 @@
+{% extends "admin/core/base.html" %}
+{% load foundation %}
+{% block title %}Add Editor Assignment{% endblock title %}
+{% block title-section %}Add Editor Assignment{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% include "elements/breadcrumbs/unassigned_base.html" %}
+    {% if article %}<li><a href="{% url 'review_unassigned_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
+    <li>Add Editor Assignment</li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+    <div class="large-12 columns">
+        <form id="editor_assignment_form" method="POST">
+            {% include "elements/forms/errors.html" with form=form %}
+            {% csrf_token %}
+            <div class="box">
+                <div class="title-area">
+                    <h2>Select Editor</h2>
+                        <a href="{% if journal_settings.general.enable_one_click_access %}#{% else %}{% url 'core_add_user' %}?role=section-editor&return={{ request.path }}{% endif %}" class="button" data-open="editor"><i class="fa fa-plus">&nbsp;</i>Add New Editor</a>
+                        <a href="{% url 'core_manager_enrol_users' %}" class="button" target="_blank"><i class="fa fa-users">&nbsp;</i>Enroll Existing User</a>
+                </div>
+                <div class="content">
+                    <div class="callout primary">
+                        <p><span class="fa fa-info-circle"></span>&nbsp;
+                            {% blocktrans %}
+                                You can select an editor using the radio 
+                                buttons in the first column.
+                            {% endblocktrans %}
+                            {% blocktrans %}
+                                If you cannot find the editor you want in 
+                                this list you can use <b>Enroll Existing User</b> to 
+                                search the database and give users the Editor 
+                                role, or <b>Add New Editor</b> to create a new 
+                                account for an editor (this process is silent, 
+                                they will not receive an account creation 
+                                email).
+                            {% endblocktrans %}
+                        </p>
+                    </div>
+
+                    <table class="small scroll" id="editors">
+                        <thead>
+                        <tr>
+                            <th>Select</th>
+                            <th>Name</th>
+                            <th>Email Address</th>
+                            <th>Type</th>
+                            <th>Active Assignments</th>
+                            <th>Interests</th>
+                        </tr>
+                        </thead>
+
+                        <tbody>
+                        {% for editor in editors %}
+                            {% include "admin/elements/review/add_editor_table_custom_row.html" with editor_type_label='Editor' %}
+                        {% endfor %}
+                        {% for editor in section_editors %}
+                            {% include "admin/elements/review/add_editor_table_custom_row.html" with editor_type_label='Section Editor' %}
+                        {% endfor %}
+                        {% if not editors and not section_editors %}
+                            <tr>
+                                <td>No suitable editors.</td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                        {% endif %}
+                        </tbody>
+                    </table>
+                </div>
+                <div class="row expanded">
+                    <div class="large-12 columns">
+                        <button type="submit" class="button success" name="add" id="add">Add Editor</button>
+                        &nbsp;
+                    </div>
+                </div>
+            </div>
+            </div>        &nbsp;&nbsp;
+        </form>
+    </div>
+
+    {% if journal_settings.general.enable_one_click_access %}
+    <div class="reveal large" id="editor" data-reveal data-animation-in="slide-in-up"
+     data-animation-out="slide-out-down">
+        <div class="card">
+            <div class="card-divider">
+                <h4><i class="fa fa-plus">&nbsp;</i>Add New Editor</h4>
+            </div>
+            <div class="card-section">
+                <button class="close-button" data-close aria-label="Close reveal" type="button">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <div class="content">
+                    <p>This form allows you to quickly create a new editor without having to input a full user's data.</p>
+                    <form method="POST">
+                        {% include "elements/forms/errors.html" with form=new_editor_form %}
+                        {% csrf_token %}
+                        {{ new_editor_form|foundation }}
+                        <button type="submit" class="button success" name="assign" id="assign">Add Editor</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if form.modal %}
+        {% include "admin/elements/confirm_modal.html" with modal=form.modal form_id="editor_assignment_form" %}
+    {% endif %}
+
+{% endblock body %}
+
+{% block js %}
+    {% include "elements/datatables.html" with target="#editors" %}
+    {% if form.modal %}
+        {% include "admin/elements/open_modal.html" with target=form.modal.id %}
+    {% endif %}
+    {% include "elements/datatables.html" with target="#enrolluser" %}
+{% endblock js %}

--- a/src/templates/admin/review/unassigned_article.html
+++ b/src/templates/admin/review/unassigned_article.html
@@ -210,6 +210,9 @@
         <div class="box">
             <div class="title-area">
                 <h2>Editors</h2>
+                {% if journal_settings.general.enable_custom_editor_assignment %}
+                    <a href="{% url 'add_editor_assignment' article.id %}" class="button">Add Editor</a>
+                {% endif %}
             </div>
             <div class="content">
                 <table class="scroll small" id="unassigned">

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5132,5 +5132,24 @@
         "value": {
             "default": ""
         }
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "If enabled, Editors can be assigned to an article in a custom way.",
+            "is_translatable": false,
+            "name": "enable_custom_editor_assignment",
+            "pretty_name": "Enable Custom Editor Assignment",
+            "type": "boolean"
+        },
+        "value": {
+            "default": ""
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
 ]


### PR DESCRIPTION
>[!IMPORTANT]
> This implementation is part of a set of features and fixes developed within the context of a project for the TGDK academic journal, with the goal of customizing Janeway to meet the journal's specific needs, which may also be extended to other contexts.

## Problem / Objective
The current editor assignment system in Janeway has significant limitations in terms of customization and process optimization. Due to its layout, structure, and element arrangement, it does not provide a seamless experience or advanced tools for managing complex assignments.

![image](https://github.com/user-attachments/assets/71dae6f7-ba8d-466b-95ea-6071f9763ee9)

This can make the organization and efficient management of editors challenging, especially in more dynamic editorial workflows.

## Solution:
A new custom editor assignment tool has been developed, inspired by the reviewer assignment system, with advanced features to enhance the user experience and optimize the process. This tool:

- Offers an intuitive design, allowing users to easily view and select editors from a table displaying relevant information (active assignments count, interests, editor type).
- Provides an additional pathway for assigning editors, while keeping the original editor assignment method active and unchanged. Users can choose which method to use, based on their preferences and workflow needs.
- Integrates a more robust flow that supports additional functionalities, such as adding new editors or quick assignments directly from the interface.

![image](https://github.com/user-attachments/assets/9a9f0d9d-641e-4190-b57d-82da42a2c863)

This tool is configurable through the "**Enable Custom Editor Assignment**" option available in Review Settings (General section). This option is disabled by default and can be activated based on the journal's needs.

![image](https://github.com/user-attachments/assets/133de423-9489-452d-bc95-7579f168b759)

The custom editor assignment tool includes:

- A new form, `EditorAssignmentForm`, dedicated to managing the editor assignment process.
- Functions to sort and prioritize the list of editors based on specific parameters, such as interests, number of active assignments, and roles.
