### PR TITLE
[TGDK][Feature] Add Configurable Option to Enable or Disable 'Skip Email Notification' Button

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -324,10 +324,6 @@ def get_settings_to_edit(display_group, journal, user):
                     'general',
                     'hide_editors_from_authors', journal
                 ),
-            },
-            {
-                'name': 'enable_skip_send_email',
-                'object': setting_handler.get_setting('general', 'enable_skip_send_email', journal),
             }
         ]
         setting_group = 'general'
@@ -428,6 +424,10 @@ def get_settings_to_edit(display_group, journal, user):
                 'name': 'display_completed_reviews_in_additional_rounds_text',
                 'object': setting_handler.get_setting('general', 'display_completed_reviews_in_additional_rounds_text', journal),
             },
+            {
+                'name': 'enable_skip_send_email',
+                'object': setting_handler.get_setting('general', 'enable_skip_send_email', journal),
+            }
         ]
         setting_group = 'general'
 

--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -324,6 +324,10 @@ def get_settings_to_edit(display_group, journal, user):
                     'general',
                     'hide_editors_from_authors', journal
                 ),
+            },
+            {
+                'name': 'enable_skip_send_email',
+                'object': setting_handler.get_setting('general', 'enable_skip_send_email', journal),
             }
         ]
         setting_group = 'general'

--- a/src/templates/admin/elements/email_form.html
+++ b/src/templates/admin/elements/email_form.html
@@ -7,7 +7,7 @@
     <div class="card-divider">
         <div class="button-group">
             <button type="submit" class="button success" name="send"><i class="fa fa-envelope-o">&nbsp;</i>Send</button>
-            {% if skip %}
+            {% if skip and journal_settings.general.enable_skip_send_email %}
             <button type="submit" class="button warning" name="skip" value="skip"><i class="fa fa-step-forward">&nbsp;</i>Skip & continue</button>
             {% endif %}
             {% if cancel_url %}

--- a/src/templates/admin/elements/forms/group_review.html
+++ b/src/templates/admin/elements/forms/group_review.html
@@ -10,6 +10,7 @@
     {% include "admin/elements/forms/field.html" with field=edit_form.enable_one_click_access %}
     {% include "admin/elements/forms/field.html" with field=edit_form.draft_decisions %}
     {% include "admin/elements/forms/field.html" with field=edit_form.enable_suggested_reviewers %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.enable_skip_send_email %}
 </div>
 
 <div class="title-area">

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5132,5 +5132,24 @@
         "value": {
             "default": ""
         }
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "If enabled, Editors can skip sending notification emails.",
+            "is_translatable": false,
+            "name": "enable_skip_send_email",
+            "pretty_name": "Enable Skip Send Email",
+            "type": "boolean"
+        },
+        "value": {
+            "default": "on"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
 ]


### PR DESCRIPTION
>[!IMPORTANT]
> This implementation is part of a set of features and fixes developed within the context of a project for the TGDK academic journal, with the goal of customizing Janeway to meet the journal's specific needs, which may also be extended to other contexts.

## Problem / Objective
By default, many interactions between users on the platform (such as editor assignments, reviewer assignments, etc.) include the option to skip sending an email notification to the other party involved. This is implemented via a button on the respective notification page.

![image](https://github.com/user-attachments/assets/174ca9ce-0852-4c33-a9d7-f0fca76176e3)

While this flexibility is valuable for some workflows, many journals require administrators to enforce the sending of these notifications as part of their editorial policies. The current setup does not allow journals to disable the skip option, which can lead to inconsistencies in communication practices.

## Solution
This feature introduces a configurable option, "Enable Skip Send Email", to allow journals to enable or disable the "Skip Email Notification" button

![image](https://github.com/user-attachments/assets/b9872455-147c-4ad4-9cb7-aa367230dd1d)

The option is added to the Review Settings and is activated by default to align with the platform's current behavior.

> Journals can disable this setting to enforce mandatory email notifications for all user interactions.
Impact on User Interface

When disabled, the "Skip Email Notification" button is no longer displayed on relevant notification pages, ensuring that all interactions automatically trigger email notifications.

