### PR TITLE
a11y #4228 prevent non-telephone numbers becoming call links

### DIFF
--- a/src/themes/OLH/templates/core/base.html
+++ b/src/themes/OLH/templates/core/base.html
@@ -12,6 +12,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="format-detection" content="telephone=no"/>
     <title>{% block title %}{{ request.journal.name }}{% endblock title %}</title>
     {% block head %}{% endblock head %}
     <link rel="sitemap" type="application/xml" title="Sitemap" href="{% url 'website_sitemap' %}">

--- a/src/themes/clean/templates/core/base.html
+++ b/src/themes/clean/templates/core/base.html
@@ -6,6 +6,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="format-detection" content="telephone=no"/>
     {% if request.journal %}
         <meta name="description" content="{{ request.journal.description }}">{% endif %}
     <title>{% block title %}{% if request.journal %}{{ request.journal.name }}{% else %}{{ request.press.name }}

--- a/src/themes/material/templates/core/base.html
+++ b/src/themes/material/templates/core/base.html
@@ -10,6 +10,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="format-detection" content="telephone=no"/>
     <title>{% block title %}{% if request.journal %}{{ request.journal.name }}{% elif request.repository %}{{ request.repository.name }}{% else %}{{ request.press.name }}{% endif %}{% endblock title %}</title>
     {% block head %}{% endblock head %}
     <link rel="sitemap" type="application/xml" title="Sitemap" href="{% url 'website_sitemap' %}">


### PR DESCRIPTION
Updated `base.html` for the three themes.

before:
<img width="328" alt="image" src="https://github.com/user-attachments/assets/aa1d4dd8-3e13-471d-a640-6dc8b8ef654a" />


after:
<img width="323" alt="image" src="https://github.com/user-attachments/assets/09cbb276-bbd1-4895-b056-a4325ec27a31" />


Closes #4228 