### PR TITLE
allow able or disable to select the send emails

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -340,6 +340,10 @@ def get_settings_to_edit(display_group, journal, user):
                 'choices': review_models.review_visibilty()
             },
             {
+                'name': 'select_review_visibility',
+                'object': setting_handler.get_setting('general', 'select_review_visibility', journal),
+            },
+            {
                 'name': 'review_file_help',
                 'object': setting_handler.get_setting('general', 'review_file_help', journal),
             },

--- a/src/review/forms.py
+++ b/src/review/forms.py
@@ -82,6 +82,10 @@ class ReviewAssignmentForm(forms.ModelForm, core_forms.ConfirmableIfErrorsForm):
             create=True,
         ).processed_value
 
+        select_review_visibility = self.journal.get_setting(
+            'general','select_review_visibility'
+        )
+
         if self.journal:
             self.fields['form'].queryset = models.ReviewForm.objects.filter(journal=self.journal, deleted=False)
 
@@ -105,6 +109,9 @@ class ReviewAssignmentForm(forms.ModelForm, core_forms.ConfirmableIfErrorsForm):
             # Form should not be changed after request has been accepted
             self.fields['form'].initial = self.instance.form
             self.fields['form'].disabled = True
+        
+        if not select_review_visibility:
+            self.fields['visibility'].disabled = True
 
     def save(self, commit=True):
         review_assignment = super().save(commit=False)

--- a/src/templates/admin/elements/forms/group_review.html
+++ b/src/templates/admin/elements/forms/group_review.html
@@ -6,6 +6,7 @@
     {% include "admin/elements/forms/field.html" with field=edit_form.review_file_help %}
     {% include "admin/elements/forms/field.html" with field=edit_form.default_review_form %}
     {% include "admin/elements/forms/field.html" with field=edit_form.default_review_days %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.select_review_visibility %}
     {% include "admin/elements/forms/field.html" with field=edit_form.default_review_visibility %}
     {% include "admin/elements/forms/field.html" with field=edit_form.enable_one_click_access %}
     {% include "admin/elements/forms/field.html" with field=edit_form.draft_decisions %}

--- a/src/templates/admin/review/add_review_assignment.html
+++ b/src/templates/admin/review/add_review_assignment.html
@@ -79,7 +79,9 @@
                 <div class="content">
                     <div class="row expanded">
                         <div class="large-4 columns">{{ form.form|foundation }}</div>
-                        <div class="large-4 columns">{{ form.visibility|foundation }}</div>
+                        {% if journal_settings.general.select_review_visibility %}
+                            <div class="large-4 columns">{{ form.visibility|foundation }}</div>
+                        {% endif %}
                         <div class="large-4 columns">{{ form.date_due|foundation }}</div>
                     <div class="row expanded">
                         <div class="large-12 columns">

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5132,5 +5132,24 @@
         "value": {
             "default": ""
         }
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "If enabled, allow choosing anonymity visibility for a new review assignment.",
+            "is_translatable": false,
+            "name": "select_review_visibility",
+            "pretty_name": "Select Review Visibility",
+            "type": "boolean"
+        },
+        "value": {
+            "default": "on"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
 ]


### PR DESCRIPTION
>[!IMPORTANT]
> This implementation is part of a set of features and fixes developed within the context of a project for the TGDK academic journal, with the goal of customizing Janeway to meet the journal's specific needs, which may also be extended to other contexts.

## Problem / Objective
The level of anonymity in the peer review process is often a critical component of a journal’s editorial policies. While Janeway currently allows users to customize the anonymity setting for each review via a toggle in the reviewer assignment form, this flexibility may conflict with journals that require a consistent anonymity policy across all reviews. Ensuring compliance with such policies is essential for maintaining editorial standards and uniformity.

![image](https://github.com/user-attachments/assets/a4f80fe0-e5df-4ddd-b70a-d9e7a3cbe6fc)

## Solution
A new configuration, "Select Review Visibility", has been introduced in the Review Settings to address this need. By default, this option is enabled, allowing customization of review anonymity on a per-review basis via a toggle in the reviewer assignment form.

![image](https://github.com/user-attachments/assets/60139a91-2a24-4e66-bfce-e182e6b34719)

When this setting is disabled, the toggle is removed, and all reviews automatically follow the journal’s default anonymity policy. This ensures that the level of anonymity remains consistent across all reviews, supporting journals that prioritize compliance with their editorial guidelines.

This solution provides both flexibility and standardization, adapting to the diverse needs of different journals.