### PR TITLE
[TGDK][Feature] Add Dashboard Panel for Pending Draft Decisions

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -605,6 +605,7 @@ def dashboard(request):
     section_editor_articles = review_models.EditorAssignment.objects.filter(editor=request.user,
                                                                             editor_type='section-editor',
                                                                             article__journal=request.journal)
+    editor_draft_decisions = review_models.DecisionDraft.objects.filter(editor=request.user, editor_decision__isnull=True)
 
     # TODO: Move most of this to model logic.
     context = {
@@ -633,6 +634,7 @@ def dashboard(request):
         'is_author': request.user.is_author(request),
         'is_reviewer': request.user.is_reviewer(request),
         'section_editor_articles': section_editor_articles,
+        'editor_draft_decisions': editor_draft_decisions,
         'active_submission_count': submission_models.Article.objects.filter(
             owner=request.user,
             journal=request.journal).exclude(

--- a/src/templates/admin/core/dashboard.html
+++ b/src/templates/admin/core/dashboard.html
@@ -167,6 +167,48 @@
             {% endif %}
         {% endfor %}
 
+        {% if journal_settings.general.draft_decisions and is_editor %}
+            <div class="large-12 columns end">
+                <div class="box">
+                    <div class="title-area">
+                        <h2>Draft Decisions Pending</h2>
+                    </div>
+                    <div class="content">
+                        <table class="scroll">
+                            <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Article</th>
+                                <th>Section Editor</th>
+                                <th>Drafted Date</th>
+                                <th>Draft Decision</th>
+                                <th>Actions</th>
+                            </tr>
+                            </thead>
+                            {% for draft in editor_draft_decisions %}
+                                <tr>
+                                    <td>{{ draft.article.pk }}</td>
+                                    <td>
+                                        <a href="{{ draft.article.current_workflow_element_url }}">{{ draft.article.safe_title }}</a>
+                                    </td>
+                                    <td>{{ draft.section_editor }}</td>
+                                    <td>{{ draft.drafted }}</td>
+                                    <td>{{ draft.decision|capfirst }}</td>
+                                    <td>
+                                        <a class="small button" href="{% url 'review_edit_draft_decision' draft.article.pk draft.id %}">Draft Decisions</a>
+                                    </td>
+
+                                </tr>
+                                {% empty %}
+                                <tr>
+                                    <td colspan="4">No Draft Decision Requested</td>
+                                </tr>
+                            {% endfor %}
+                        </table>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
 
         {% user_has_role request 'section-editor' as sectioneditor %}
         {% if sectioneditor %}


### PR DESCRIPTION
>[!IMPORTANT]
> This implementation is part of a set of features and fixes developed within the context of a project for the TGDK academic journal, with the goal of customizing Janeway to meet the journal's specific needs, which may also be extended to other contexts.

## Problem / Objective
When the draft_decisions configuration is enabled, section editors can submit draft decisions on articles—such as acceptance, rejection, or requesting revisions—that require approval from the journal’s editor-in-chief. However, the lack of a dedicated interface for managing these pending approvals made it challenging for editors-in-chief to quickly and efficiently review their pending draft decisions. This gap in functionality increased the complexity of the editorial workflow, particularly in journals with a high volume of submissions.

## Solution
This feature introduces a new dashboard panel specifically for pending draft decisions. The panel provides a centralized and easily accessible interface where editors-in-chief can view and manage all their draft decision requests awaiting approval.

![image](https://github.com/user-attachments/assets/b62e5cb6-b07c-4886-b442-3d6baf7ba848)
