### PR TITLE
[TGDK][Feature] Add Configurable Default Table Pagination Sizeg

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -502,6 +502,12 @@ def get_settings_to_edit(display_group, journal, user):
                                                       'display_journal_title',
                                                       journal),
             },
+            {
+                'name': 'table_default_page_length',
+                'object': setting_handler.get_setting('styling',
+                                                      'table_default_page_length',
+                                                      journal),
+            },
         ]
         setting_group = 'styling'
     elif display_group == 'editorial':

--- a/src/templates/admin/elements/datatables.html
+++ b/src/templates/admin/elements/datatables.html
@@ -13,7 +13,9 @@ $(document).ready(function() {
       {% if sort and order %}"order": [[ {{ sort }}, "{{ order }}" ]],{% endif %}
       {% if sort_list %}"order": [{{ sort_list }}],{% endif %}
       {% if disable_ordering %}"ordering": false,{% endif %}
-      {% if page_length %}"pageLength": {{ page_length }},{% endif %}
+      {% if journal_settings.styling.table_default_page_length %}"pageLength": {{ journal_settings.styling.table_default_page_length }},
+      {% else %}{% if page_length %}"pageLength": {{ page_length }},{% endif %}
+      {% endif %}
     });
   });
 });

--- a/src/templates/admin/elements/forms/group_styling.html
+++ b/src/templates/admin/elements/forms/group_styling.html
@@ -3,4 +3,5 @@
     <p class="help-text">{% trans 'Full Width Navbar only applies to the Material theme' %}.</p>
     {% include "admin/elements/forms/field.html" with field=edit_form.multi_page_editorial %}
     {% include "admin/elements/forms/field.html" with field=edit_form.display_journal_title %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.table_default_page_length %}
 </div>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5132,5 +5132,24 @@
         "value": {
             "default": ""
         }
+    },
+    {
+        "group": {
+            "name": "styling"
+        },
+        "setting": {
+            "description": "Default page length for tables in the platform. If the value is 0, each table will have a custom length. To show all elements in all tables, use -1.",
+            "is_translatable": false,
+            "name": "table_default_page_length",
+            "pretty_name": "Table Default Page Length",
+            "type": "number"
+        },
+        "value": {
+            "default": "0"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
 ]


### PR DESCRIPTION
>[!IMPORTANT]
> This implementation is part of a set of features and fixes developed within the context of a project for the TGDK academic journal, with the goal of customizing Janeway to meet the journal's specific needs, which may also be extended to other contexts.

## Problem / Objective
In many scenarios, the current default pagination size of the tables greatly limits their operation and visibility, so it is expected that it can be a configurable value at the journal level. This decision is also based on the fact that the volume of information and current technology allow without problems to load greater volumes of information.

## Solution
The `Table Default Page Length` configuration is created to allow you to select the default paging size for tables on the platform. There are some considerations for this numerical value:
- Entering `0` allows you to use the usual platform configuration, customized for each type of table
- Entering `-1` allows you to not limit the pagination of the tables, that is, it allows you to view all the records.
- Entering any other positive value allows you to limit the maximum pagination of the tables to that value.

This option is in Styling Settings

![image](https://github.com/user-attachments/assets/49c4a108-0255-49bf-a734-bef4ca4c720c)
