### PR TITLE
Fixes an error when adding frozen authors with email that match existing accounts

### DIFF
--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -391,7 +391,7 @@ class EditFrozenAuthor(forms.ModelForm):
                 account = core_models.Account.objects.get(
                     username=obj.frozen_email.lower())
                 obj.author = account
-                obj.frozen_email = None
+                obj.frozen_email = ""  # linked account, don't store this value
             except core_models.Account.DoesNotExist:
                 pass
             obj.save()


### PR DESCRIPTION
Updated the `save` method in `EditFrozenAuthor` to set `frozen_email` to an empty string (`""`) instead of `None` after linking an existing account.

Closes #4572 