### PR TITLE
Don't look for an attribute on None object

### DIFF
--- a/src/security/decorators.py
+++ b/src/security/decorators.py
@@ -728,7 +728,7 @@ def article_stage_accepted_or_later_or_staff_required(func):
             deny_access(request)
         elif article_object is not None and (request.user.is_editor(request) or request.user.is_staff):
             return func(request, *args, **kwargs)
-        elif request.user in article_object.section_editors():
+        elif article_object is not None and request.user in article_object.section_editors():
             return func(request, *args, **kwargs)
         else:
             deny_access(request)


### PR DESCRIPTION
Not particularly important, but I thought I'd report :slightly_smiling_face: 

In the decorator `article_stage_accepted_or_later_or_staff_required`, there is an `if` clause that might try to access an attribute of a None object.

To replicate, one should log-in to a journal and manually enter the URL of a non existing article in order to trigger the view "article_file_download" (`views.serve_article_file`).

E.g. https://olh.openlibhums.org/article/id/20000/file/1234/  (ATM article 20000 does not exist).

HTH
