### PR TITLE
Fix bug that kept filter from working on some search views

### DIFF
--- a/src/core/forms/forms.py
+++ b/src/core/forms/forms.py
@@ -698,9 +698,9 @@ class CBVFacetForm(forms.Form):
                     count = values_list.count(value)
                     label_with_count = f'{label} ({count})'
                     choices.append((value, label_with_count))
-
                 choices = sorted(choices, key=lambda x: x[1])
-                self.fields[facet_key] = forms.ChoiceField(
+
+                self.fields[facet_key] = forms.MultipleChoiceField(
                     widget=forms.widgets.CheckboxSelectMultiple,
                     choices=choices,
                     required=False,


### PR DESCRIPTION
Fixes #4607.

Note that this is hot-fixed on OLH as well, so that the Supporters Manager country field works.

The bug does not directly affect most Janeway users because only the Supporters plugin uses this field, to my knowledge.