### PR TITLE
Refactor get_ip_address to avoid 500 errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ geoip2==4.8.0
 html2text==2017.10.4
 idna==2.7
 ipaddress==1.0.16
+django-ipware==7.0.1
 more-itertools==10.1.0
 jsmin==3.0.1
 kitchen==1.2.4

--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -854,7 +854,8 @@ def get_ua_and_ip(request):
 def add_failed_login_attempt(request):
     user_agent, ip_address = get_ua_and_ip(request)
 
-    models.LoginAttempt.objects.create(user_agent=user_agent, ip_address=ip_address)
+    if ip_address:
+        models.LoginAttempt.objects.create(user_agent=user_agent, ip_address=ip_address)
 
 
 def clear_bad_login_attempts(request):

--- a/src/core/migrations/0100_contact_ip_address_null.py
+++ b/src/core/migrations/0100_contact_ip_address_null.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0019_auto_20240328_1743'),
+        ('cms', '0099_alter_accountrole_options'),
     ]
 
     operations = [

--- a/src/core/migrations/0100_contact_ip_address_null.py
+++ b/src/core/migrations/0100_contact_ip_address_null.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0019_auto_20240328_1743'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contact',
+            name='client_ip',
+            field=models.GenericIPAddressField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='loginattempt',
+            name='ip_address',
+            field=models.GenericIPAddressField(blank=True, null=True),
+        ),
+    ]

--- a/src/core/migrations/0100_contact_ip_address_null.py
+++ b/src/core/migrations/0100_contact_ip_address_null.py
@@ -13,9 +13,4 @@ class Migration(migrations.Migration):
             name='client_ip',
             field=models.GenericIPAddressField(blank=True, null=True),
         ),
-        migrations.AlterField(
-            model_name='loginattempt',
-            name='ip_address',
-            field=models.GenericIPAddressField(blank=True, null=True),
-        ),
     ]

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1595,7 +1595,7 @@ class Contact(models.Model):
     sender = models.EmailField(max_length=200, verbose_name=_('Your contact email address'))
     subject = models.CharField(max_length=300, verbose_name=_('Subject'))
     body = JanewayBleachField(verbose_name=_('Your message'))
-    client_ip = models.GenericIPAddressField()
+    client_ip = models.GenericIPAddressField(blank=True, null=True)
     date_sent = models.DateField(auto_now_add=True)
 
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE, related_name='contact_c_t',
@@ -1793,7 +1793,7 @@ class HomepageElement(models.Model):
 
 
 class LoginAttempt(models.Model):
-    ip_address = models.GenericIPAddressField()
+    ip_address = models.GenericIPAddressField(blank=True, null=True)
     user_agent = models.TextField()
     timestamp = models.DateTimeField(default=timezone.now)
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1793,7 +1793,7 @@ class HomepageElement(models.Model):
 
 
 class LoginAttempt(models.Model):
-    ip_address = models.GenericIPAddressField(blank=True, null=True)
+    ip_address = models.GenericIPAddressField()
     user_agent = models.TextField()
     timestamp = models.DateTimeField(default=timezone.now)
 

--- a/src/metrics/logic.py
+++ b/src/metrics/logic.py
@@ -311,3 +311,5 @@ def get_iso_country_code(ip):
         if ip == '127.0.0.1':
             return "GB"
         return 'OTHER'
+    except TypeError:
+        return None

--- a/src/utils/shared.py
+++ b/src/utils/shared.py
@@ -6,6 +6,7 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 import random
 import mimetypes
 from datetime import datetime
+from ipware import get_client_ip
 from urllib.parse import urlencode, quote_plus
 
 from django.core.cache import cache
@@ -32,13 +33,12 @@ def get_ip_address(request):
     if request is None:
         return None
 
-    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
-    if x_forwarded_for:
-        ip = x_forwarded_for.split(',')[0]
-    else:
-        ip = request.META.get('REMOTE_ADDR')  # Real IP address of client Machine
-    return ip
+    client_ip, is_routable = get_client_ip(request)
 
+    if client_ip is None:
+        return None
+
+    return client_ip
 
 def clear_cache():
     cache.clear()


### PR DESCRIPTION
This refactoring aims to prevent 500 errors when the `HTTP_X_FORWARDED_FOR` and `REMOTE_ADDR` headers are manipulated by potentially malicious users and do not contain a valid IP address.

For example, the following request could cause such an issue:
`wget "http://<domain>/article/pubid/<pubid>/" -O /dev/null --header="X-Forwarded-For: some-random-text,1.2.3.4"`

## Models changes
The `LoginAttempt.ip_address` field needs to be updated to allow `None` values. This is necessary because if the `get_ip_address` method returns `None`, we need to be able to save `None` when there are failed login attempts with invalid or manipulated headers.

The same applies to the `Contact.client_ip` field, which is set in `journal.views.contact` using `new_contact.client_ip = shared.get_ip_address(request)`. Without this change, an error will occur if the IP address is None.

Although it's highly unlikely that ipware will ever return `None`, actually Its `get_client_ip` method can return `None` values.

## Code changes
We also need to handle TypeError in the `get_iso_country_code` method, as `geoip2.database.Reader().country` will fail if the IP address is `None`. It seems appropriate to modify this method to return `None`, as its output is used by `iso_to_country_object`, which already returns `None` if the corresponding Country object is not found among the registered Countries.