### PR TITLE
Removes share links from the article page and replaces them with a share link and copy button

### DIFF
--- a/src/static/common/js/clipboard.js
+++ b/src/static/common/js/clipboard.js
@@ -1,0 +1,12 @@
+function copyToClipboard() {
+    var linkField = document.getElementById("share-link");
+
+    if (!linkField) {
+        console.error("No input field found with ID 'share-link'");
+        return;
+    }
+
+    navigator.clipboard.writeText(linkField.value).catch(function(err) {
+        console.error("Failed to copy: ", err);
+    });
+}

--- a/src/themes/OLH/templates/elements/journal/share.html
+++ b/src/themes/OLH/templates/elements/journal/share.html
@@ -1,0 +1,25 @@
+{% with article.get_doi_url|default:article.url as share_url %}
+  <div class="section">
+    <h3>{% trans "Share" %}</h3>
+    <div class="input-group">
+      <input
+              id="share-link"
+              class="input-group-field"
+              type="text"
+              aria-label="{% trans "Article's sharing URL" %}"
+              value="{{ share_url }}"
+              readonly
+      >
+      <div class="input-group-button">
+        <button
+                class="button"
+                type="button"
+                onclick="copyToClipboard()"
+                aria-label="{% trans 'Copy Share Link' %}"
+        >
+          <span class="fa fa-copy"></span>&nbsp;{% trans "Copy" %}
+        </button>
+      </div>
+    </div>
+  </div>
+{% endwith %}

--- a/src/themes/OLH/templates/elements/journal/share.html
+++ b/src/themes/OLH/templates/elements/journal/share.html
@@ -17,7 +17,7 @@
                 onclick="copyToClipboard()"
                 aria-label="{% trans 'Copy Share Link' %}"
         >
-          <span class="fa fa-copy"></span>&nbsp;{% trans "Copy" %}
+          <i aria-hidden="true" class="fa fa-copy"></i>&nbsp;{% trans "Copy" %}
         </button>
       </div>
     </div>

--- a/src/themes/OLH/templates/elements/journal/share.html
+++ b/src/themes/OLH/templates/elements/journal/share.html
@@ -2,11 +2,11 @@
   <div class="section">
     <h3>{% trans "Share" %}</h3>
     <div class="input-group">
+      <label for="share-link" class="sr-only">{% trans "Article URL" %}</label>
       <input
               id="share-link"
               class="input-group-field"
               type="text"
-              aria-label="{% trans "Article's sharing URL" %}"
               value="{{ share_url }}"
               readonly
       >

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -108,19 +108,7 @@
                         <div class="title-bar-title">{% trans 'Options' %}</div>
                     </div>
                     <div id="options-menu">
-                        <div class="small-4 medium-3 large-2 columns">
-                            <ul class="menu vertical medium-horizontal pad-left-15"
-                                data-responsive-menu="drilldown medium-dropdown">
-                              {% with article.get_doi_url as doi_url %}
-                                <li>{% trans "Share" %}:</li>
-                                <li><a href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="{% trans 'Share on Facebook' %}"><i class="fa fa-facebook"></i></a></li>
-                                <li><a class= "twitter-x"
-                                    href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="{% trans 'Share on X' %}">&#120143;</a></li>
-                                <li><a href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="{% trans 'Share on LinkedIn' %}"><i class="fa fa-linkedin"></i></a></li>
-                              {% endwith %}
-                            </ul>
-                        </div>
-                        <div class="small-8 medium-9 large-10 columns">
+                        <div class="small-12s medium-9 medium-offset-3 large-10 large-offset-2 columns">
                             <div class = "float-right">
                                 <ul class="menu vertical medium-horizontal"
                                     data-responsive-menu="dropdown">
@@ -332,6 +320,8 @@
                                     </ul>
                                 </div>
                             {% endif %}
+
+                            {% include "elements/journal/share.html" %}
                             <div class="section">
                                 {% if article.is_published or proofing %}
                                     <h3>{% trans "Downloads" %}</h3>
@@ -518,4 +508,5 @@
     });
     </script>
     <script src="{% static "common/lightbox/js/lightbox.js" %}"></script>
+    <script src="{% static "common/js/clipboard.js" %}"></script>
 {% endblock js %}

--- a/src/themes/clean/templates/elements/journal/share.html
+++ b/src/themes/clean/templates/elements/journal/share.html
@@ -16,7 +16,7 @@
               onclick="copyToClipboard()"
               aria-label="{% trans 'Copy Share Link' %}"
       >
-        <span class="fa fa-copy"></span>&nbsp;{% trans "Copy" %}
+        <i aria-hidden="true" class="fa fa-copy"></i>&nbsp;{% trans "Copy" %}
       </button>
     </div>
   </div>

--- a/src/themes/clean/templates/elements/journal/share.html
+++ b/src/themes/clean/templates/elements/journal/share.html
@@ -1,0 +1,23 @@
+{% with article.get_doi_url|default:article.url as share_url %}
+  <h2>{% trans "Share" %}</h2>
+  <div class="input-group mb-3">
+    <input
+            id="share-link"
+            class="input-group-field"
+            type="text"
+            aria-label="{% trans "Article's sharing URL" %}"
+            value="{{ share_url }}"
+            readonly
+    >
+    <div class="input-group-append">
+      <button
+              class="btn btn-primary"
+              type="button"
+              onclick="copyToClipboard()"
+              aria-label="{% trans 'Copy Share Link' %}"
+      >
+        <span class="fa fa-copy"></span>&nbsp;{% trans "Copy" %}
+      </button>
+    </div>
+  </div>
+{% endwith %}

--- a/src/themes/clean/templates/elements/journal/share.html
+++ b/src/themes/clean/templates/elements/journal/share.html
@@ -1,11 +1,11 @@
 {% with article.get_doi_url|default:article.url as share_url %}
   <h2>{% trans "Share" %}</h2>
   <div class="input-group mb-3">
+    <label for="share-link" class="sr-only">{% trans "Article URL" %}</label>
     <input
             id="share-link"
             class="input-group-field"
             type="text"
-            aria-label="{% trans "Article's sharing URL" %}"
             value="{{ share_url }}"
             readonly
     >

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -169,18 +169,7 @@
                 {% endif %}
 
                 {% if article.is_published or proofing %}
-                    <h2>{% trans "Share" %}</h2>
-                    {% with article.get_doi_url as doi_url%}
-                        <a class="waves-effect waves-light btn btn-small social-share-btn facebook-bg"
-                            href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" 
-                            target="_blank" aria-label="{% trans 'Share on Facebook' %}"><i class="fa fa-facebook"></i></a>
-                        <a class="waves-effect waves-light btn btn-small social-share-btn twitter-x" 
-                            href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
-                            target="_blank" aria-label="{% trans 'Share on X' %}">&#120143;</a>
-                        <a class="waves-effect waves-light btn btn-small social-share-btn linkedin-bg"
-                            href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
-                            target="_blank" aria-label="{% trans 'Share on LinkedIn' %}"><i class="fa fa-linkedin"></i></a></button>
-                    {% endwith %}
+                    {% include "elements/journal/share.html" %}
                     <h2>{% trans "Downloads" %}</h2>
                     {% if galleys %}
                         <ul>
@@ -369,4 +358,5 @@
     });
     </script>
     <script src="{% static "common/lightbox/js/lightbox.js" %}"></script>
+    <script src="{% static "common/js/clipboard.js" %}"></script>
 {% endblock js %}

--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -739,3 +739,9 @@ main {
 .decade-list-item:hover {
     text-decoration: underline;
 }
+
+.share-container {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}

--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -745,3 +745,12 @@ main {
     align-items: center;
     gap: 5px;
 }
+
+.share-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 40px;
+    padding: 0 10px;
+    min-width: 40px;
+}

--- a/src/themes/material/templates/elements/journal/share.html
+++ b/src/themes/material/templates/elements/journal/share.html
@@ -13,7 +13,7 @@
             onclick="copyToClipboard()"
             aria-label="{% trans 'Copy Share Link' %}"
     >
-      <i class="fa fa-copy"></i>&nbsp;Copy
+      <i aria-hidden="true" class="fa fa-copy"></i>&nbsp;Copy
     </button>
   </div>
 {% endwith %}

--- a/src/themes/material/templates/elements/journal/share.html
+++ b/src/themes/material/templates/elements/journal/share.html
@@ -1,10 +1,10 @@
 <h4>{% trans "Share" %}</h4>
 {% with article.get_doi_url|default:article.url as share_url %}
   <div class="share-container">
+    <label for="share-link" class="sr-only">{% trans "Article URL" %}</label>
     <input
             id="share-link"
             type="text"
-            aria-label="{% trans "Article's sharing URL" %}"
             value="{{ share_url }}"
             readonly
     >

--- a/src/themes/material/templates/elements/journal/share.html
+++ b/src/themes/material/templates/elements/journal/share.html
@@ -1,0 +1,19 @@
+<h4>{% trans "Share" %}</h4>
+{% with article.get_doi_url|default:article.url as share_url %}
+  <div class="share-container">
+    <input
+            id="share-link"
+            type="text"
+            aria-label="{% trans "Article's sharing URL" %}"
+            value="{{ share_url }}"
+            readonly
+    >
+    <button class="btn btn-small waves-effect waves-light teal darken-1 share-button"
+            type="button"
+            onclick="copyToClipboard()"
+            aria-label="{% trans 'Copy Share Link' %}"
+    >
+      <i class="fa fa-copy"></i>&nbsp;Copy
+    </button>
+  </div>
+{% endwith %}

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -229,21 +229,7 @@
             <div class="card">
                 <div class="card-content">
                     {% include "common/elements/altmetric_badges.html" with article=article %}
-                    <h4>
-                        {% trans "Share" %}
-                    </h4>
-                      {% with article.get_doi_url as doi_url%}
-                        <a class="waves-effect waves-light btn btn-small facebook-bg"
-                            href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" 
-                            target="_blank" aria-label="{% trans 'Share on Facebook' %}"><i class="fa fa-facebook"></i></a>
-                        <a class="waves-effect waves-light btn btn-small twitter-bg twitter-x" 
-                            href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
-                            target="_blank" aria-label="{% trans 'Share on X' %}">&#120143;</a>
-                        <a class="waves-effect waves-light btn btn-small linkedin-bg"
-                            href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
-                            target="_blank" aria-label="{% trans 'Share on LinkedIn' %}"><i class="fa fa-linkedin"></i></a></button>
-                      {% endwith %}
-
+                    {% include "elements/journal/share.html" %}
                     {% if article.frozen_authors.count > 0 %}
                     <div class="spacer">
                         <div class="divider"></div>
@@ -536,4 +522,5 @@
     </script>
     <script src="{% static "common/lightbox/js/lightbox.js" %}"></script>
     <script type='text/javascript' src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js'></script>
+    <script src="{% static "common/js/clipboard.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
- Drops all share links on all themes
- Adds a field with either the DOI or canonical URL
- Adds copy to clipboard common JS script
- Closes #4390 


<img width="441" alt="Screenshot 2025-02-12 at 16 53 21" src="https://github.com/user-attachments/assets/49790430-e459-4f17-8ca5-7eed58138d1e" />
<img width="397" alt="Screenshot 2025-02-12 at 16 53 26" src="https://github.com/user-attachments/assets/0a8fff04-9afe-4619-bf05-b38d7480a4b1" />
<img width="426" alt="Screenshot 2025-02-12 at 16 53 30" src="https://github.com/user-attachments/assets/a0d099ec-b4d8-4903-9ff8-096ad45a9d07" />
