### PR TITLE
Fix #4636 - pre-ticked repo submit agreement

### DIFF
--- a/src/repository/forms.py
+++ b/src/repository/forms.py
@@ -59,7 +59,7 @@ class PreprintInfo(utils_forms.KeywordModelForm):
 
         # If using this form and there is an instance then this has
         # previously been checked as it is required.
-        if self.instance and 'submission_agreement' in self._meta.fields:
+        if self.instance.id and 'submission_agreement' in self._meta.fields:
             self.fields['submission_agreement'].initial = True
 
         self.fields['subject'].queryset = models.Subject.objects.filter(


### PR DESCRIPTION
When a user starts the process for a new repository submission, the box is always pre-ticked. The current code checks if the form model is False, but it is actually an instance of `<class 'repository.models.Preprint'>`. This updates the logic to check if the instance has an id, which it won't if not yest saved to the database, but it will have an id if it has been saved.

Fixes #4636