### PR TITLE
Fixes issue with repository log view

### DIFF
--- a/src/templates/admin/elements/core/addressee_display.html
+++ b/src/templates/admin/elements/core/addressee_display.html
@@ -3,7 +3,11 @@
 {% for field, addressees in email_fields %}
     {% if field %}<strong>{{ field }}: </strong>{% endif %}
     {% for addressee in addressees %}
-        {{ addressee.email|se_can_see_pii:article }}{% if not forloop.last %}, {% endif %}
+        {% if article %}
+            {{ addressee.email|se_can_see_pii:article }}{% if not forloop.last %}, {% endif %}
+        {% else %}
+           {{ addressee.email }}{% if not forloop.last %}, {% endif %}
+       {% endif %}
     {% endfor %}
     {% if not forloop.last %}<br>{% endif %}
 {% endfor %}


### PR DESCRIPTION
The addressee display template was updated to include a check for PII, but the implementation assumes that the item being managed is an article in a journal, but that template fragment is also used by the repository log.

Adds some logic to check if the article variable is defined before applying PII checks. This means that PII checks are not appliedd to repository email addresses in this list, but as none of the rest of the PII functionality is built out for repository side, this seems reasonble.

Fixes #4637