### PR TITLE
Removes correspondence author's name from the article page

### DIFF
--- a/src/templates/common/elements/journal/article_title.html
+++ b/src/templates/common/elements/journal/article_title.html
@@ -1,0 +1,2 @@
+{{ article.title|striptags }} |
+{{ journal_settings.general.journal_name|striptags }}

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -5,8 +5,10 @@
 
 {% block page_title %}{% if article.preprint %}{% trans "Preprint" %} {% endif %}{% trans "Article" %}{% endblock %}
 
-{% block title %}{{ article.frozen_authors.0.last_name | striptags }} | {{ article.title | striptags }} |
-    {{ journal_settings.general.journal_name | striptags }} {% endblock %}
+{% block title %}
+  {{ article.title|striptags }} |
+  {{ journal_settings.general.journal_name|striptags }}
+{% endblock %}
 
 {% block head %}
     <link href="{% static "common/lightbox/css/lightbox.css" %}" rel="stylesheet" />

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -6,8 +6,7 @@
 {% block page_title %}{% if article.preprint %}{% trans "Preprint" %} {% endif %}{% trans "Article" %}{% endblock %}
 
 {% block title %}
-  {{ article.title|striptags }} |
-  {{ journal_settings.general.journal_name|striptags }}
+  {% include "common/elements/journal/article_title.html" %}
 {% endblock %}
 
 {% block head %}

--- a/src/themes/OLH/templates/journal/print.html
+++ b/src/themes/OLH/templates/journal/print.html
@@ -2,11 +2,12 @@
 {% load hooks %}
 {% load i18n %}
 <html>
-<title>{{ article.authors.all.0.last_name | striptags }} | {{ article.title | striptags }}
-    |{{ journal_settings.general.journal_name | striptags }} </title>
 
 <head>
-    {% include "elements/article_meta_tags.html" %}
+  <title>
+    {% include "common/elements/journal/article_title.html" %}
+  </title>
+  {% include "elements/article_meta_tags.html" %}
 </head>
 <body>
 <p class="uppercase">{{ article.section.name }}</p>

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -4,8 +4,7 @@
 {% load i18n %}
 
 {% block title %}
-  {{ article.title | striptags }} |
-  {{ journal_settings.general.journal_name | striptags }}
+  {% include "common/elements/journal/article_title.html" %}
 {% endblock %}
 
 {% block head %}

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -3,8 +3,10 @@
 {% load hooks %}
 {% load i18n %}
 
-{% block title %}{{ article.frozen_authors.all.0.last_name | striptags }} | {{ article.title | striptags }} |
-    {{ journal_settings.general.journal_name | striptags }} {% endblock %}
+{% block title %}
+  {{ article.title | striptags }} |
+  {{ journal_settings.general.journal_name | striptags }}
+{% endblock %}
 
 {% block head %}
     <link href="{% static "common/lightbox/css/lightbox.css" %}" rel="stylesheet" />

--- a/src/themes/clean/templates/journal/print.html
+++ b/src/themes/clean/templates/journal/print.html
@@ -2,10 +2,10 @@
 {% load hooks %}
 {% load i18n %}
 <html>
-<title>{{ article.authors.all.0.last_name | striptags }} | {{ article.title | striptags }}
-    |{{ journal_settings.general.journal_name | striptags }} </title>
-
 <head>
+  <title>
+    {% include "common/elements/journal/article_title.html" %}
+  </title>
     {% include "elements/article_meta_tags.html" %}
 </head>
 <body>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -7,8 +7,7 @@
 {% block page_title %}{% if article.preprint %}{% trans "Preprint" %} {% endif %}{% trans "Article" %}{% endblock %}
 
 {% block title %}
-  {{ article.title|striptags }} |
-  {{ journal_settings.general.journal_name|striptags }}
+  {% include "common/elements/journal/article_title.html" %}
 {% endblock %}
 
 {% block head %}

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -6,8 +6,10 @@
 
 {% block page_title %}{% if article.preprint %}{% trans "Preprint" %} {% endif %}{% trans "Article" %}{% endblock %}
 
-{% block title %}{{ article.frozen_authors.0.last_name | striptags }} | {{ article.title | striptags }} |
-    {{ journal_settings.general.journal_name | striptags }} {% endblock %}
+{% block title %}
+  {{ article.title|striptags }} |
+  {{ journal_settings.general.journal_name|striptags }}
+{% endblock %}
 
 {% block head %}
     <link href="{% static "common/lightbox/css/lightbox.css" %}" rel="stylesheet" />


### PR DESCRIPTION
- Adds a new common template for rendering article page titles (for use on article.html and print.html)
- Removes corresp authors surname from title
- Fixes print template struct
- Closes #4679