### PR TITLE
Fixes a bug that caused clean theme collections to be in a single column

### DIFF
--- a/src/themes/clean/templates/journal/collections.html
+++ b/src/themes/clean/templates/journal/collections.html
@@ -29,7 +29,6 @@
                         <p class="card-text">{{ collection.issue_description|safe }}</p>
                         {% endif %}
                     </div>
-                    </div>
                 </div>
             </div>
         {% empty %}


### PR DESCRIPTION
Closes #4674 

Before:
![image](https://github.com/user-attachments/assets/0bae06cd-03f2-4e01-806b-736b7c752327)

After:
![image](https://github.com/user-attachments/assets/b2d5a0e2-4eda-4856-9500-53c86075a946)
