### PR TITLE
Updates the offset_date tag to take the users preferred timezone into account

### DIFF
--- a/src/core/templatetags/dates.py
+++ b/src/core/templatetags/dates.py
@@ -1,16 +1,21 @@
+from datetime import timedelta
+
+import pytz
 from django import template
 from django.utils import timezone
 
 
+
 register = template.Library()
 
-@register.simple_tag
-def offset_date(days=0, input_type="date"):
+@register.simple_tag(takes_context=True)
+def offset_date(context, days=0, input_type="date"):
     """
     Get a string representing today's date or the now datetime,
     with an offset of X days.
+    :param context: template context, needed to access request.user
     :param days: number of days from now that the date should be set
-    :param date: date or datetime-local
+    :param input_type: 'date' or 'datetime-local'
 
     Usage:
 
@@ -23,7 +28,21 @@ def offset_date(days=0, input_type="date"):
     See admin.core.widgets.soon_date_buttons for a use case.
 
     """
-    due = timezone.now() + timezone.timedelta(days=days)
+    request = context.get("request", None)
+    now = timezone.now()
+
+    if request and hasattr(request, "user"):
+        tz_name = request.user.preferred_timezone
+
+        if tz_name:
+            try:
+                tz = pytz.timezone(tz_name)
+                now = now.astimezone(tz)
+            except pytz.UnknownTimeZoneError:
+                pass
+
+    due = now + timedelta(days=days)
+
     if input_type == "date":
         return due.strftime("%Y-%m-%d")
     elif input_type == "datetime-local":

--- a/src/core/templatetags/dates.py
+++ b/src/core/templatetags/dates.py
@@ -15,7 +15,7 @@ def offset_date(context, days=0, input_type="date"):
     with an offset of X days.
     :param context: template context, needed to access request.user
     :param days: number of days from now that the date should be set
-    :param input_type: 'date' or 'datetime-local'
+    :param input_type: date or datetime-local
 
     Usage:
 

--- a/src/core/templatetags/dates.py
+++ b/src/core/templatetags/dates.py
@@ -26,18 +26,19 @@ def offset_date(context, days=0, input_type="date"):
       value="{% offset_date days=3 input_type=input_type %}">
 
     See admin.core.widgets.soon_date_buttons for a use case.
-
     """
     request = context.get("request", None)
     now = timezone.now()
 
     if request and hasattr(request, "user"):
-        tz_name = request.user.preferred_timezone
-
+        tz_name = request.user.preferred_timezone  # always present, may be ''
         if tz_name:
             try:
                 tz = pytz.timezone(tz_name)
-                now = now.astimezone(tz)
+                if timezone.is_naive(now):
+                    now = timezone.make_aware(now, timezone=tz)
+                else:
+                    now = now.astimezone(tz)
             except pytz.UnknownTimeZoneError:
                 pass
 

--- a/src/core/tests/test_templatetags.py
+++ b/src/core/tests/test_templatetags.py
@@ -1,7 +1,12 @@
+from datetime import timedelta
+
+import pytz
+from django.utils import timezone
+from django.test import TestCase, override_settings
+from freezegun import freeze_time
 
 from utils.testing import helpers
-from django.test import TestCase, override_settings
-from core.templatetags import fqdn
+from core.templatetags import fqdn, dates
 
 class TestFqdn(TestCase):
 
@@ -28,3 +33,76 @@ class TestFqdn(TestCase):
         url_name = 'journal_users' 
         url = fqdn.stateless_site_url(self.journal_two, url_name)
         self.assertEqual(url, f'http://{self.journal_two.press.domain}/{self.journal_two.code}/user/all/')
+
+
+@freeze_time("2025-03-26 12:00:00")
+class TestOffsetDateTag(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_default = helpers.create_user("default@example.com")
+        cls.user_tz = helpers.create_user(
+            "tz@example.com",
+            preferred_timezone="Europe/London",
+        )
+        cls.user_bad_tz = helpers.create_user(
+            "bad@example.com",
+            preferred_timezone="MemoryAlpha/Library",
+        )
+
+        cls.request_default = type("Request", (), {"user": cls.user_default})()
+        cls.request_tz = type("Request", (), {"user": cls.user_tz})()
+        cls.request_bad_tz = type("Request", (), {"user": cls.user_bad_tz})()
+
+    def test_offset_date_with_default_timezone_datetime(self):
+        """
+        Test offset_date tag with default timezone and datetime-local input.
+        """
+        context = {"request": self.request_default}
+        result = dates.offset_date(
+            context,
+            days=2,
+            input_type="datetime-local",
+        )
+        expected = "2025-03-28T12:00"
+        self.assertEqual(result, expected)
+
+    def test_offset_date_with_preferred_timezone_datetime(self):
+        """
+        Test offset_date tag with a valid preferred timezone and datetime-local input.
+        """
+        context = {"request": self.request_tz}
+        # 12:00 UTC is 12:00 GMT in March (not in daylight saving yet)
+        result = dates.offset_date(
+            context,
+            days=1,
+            input_type="datetime-local",
+        )
+        expected = "2025-03-27T12:00"
+        self.assertEqual(result, expected)
+
+    def test_offset_date_with_invalid_timezone_datetime(self):
+        """
+        Test offset_date tag with an invalid preferred timezone and datetime-local input.
+        Should fall back to default timezone.
+        """
+        context = {"request": self.request_bad_tz}
+        result = dates.offset_date(
+            context,
+            days=1,
+            input_type="datetime-local",
+        )
+        expected = "2025-03-27T12:00"
+        self.assertEqual(result, expected)
+
+    def test_offset_date_with_default_timezone_date(self):
+        """
+        Test offset_date tag with default timezone and date input.
+        """
+        context = {"request": self.request_default}
+        result = dates.offset_date(
+            context,
+            days=2,
+            input_type="date",
+        )
+        expected = "2025-03-28"
+        self.assertEqual(result, expected)


### PR DESCRIPTION
- This  closes #4666 however there are browser issues that we cannot fix (such as Chrome's built-in datetime-local widget providing its own Now button that uses the browsers timezone. 