### PR TITLE
Removes data migration that causes errors during setup

### DIFF
--- a/src/journal/migrations/0053_display_article_images_settings.py
+++ b/src/journal/migrations/0053_display_article_images_settings.py
@@ -12,23 +12,29 @@ def update_setting_values(apps, schema_editor):
     SettingValue = apps.get_model("core", "SettingValue")
     setting_group, _ = SettingGroup.objects.get_or_create(
         name="article")
-    call_command('load_default_settings')
 
-    thumb_setting, c = Setting.objects.get_or_create(name="disable_article_thumbnails")
-    large_image_setting = Setting.objects.get(name="disable_article_large_image")
-
-    for journal in Journal.objects.filter(disable_article_images=True):
-        SettingValue.objects.get_or_create(
-            setting=thumb_setting,
-            value_en="on",
-            journal=journal,
+    try:
+        thumb_setting, c = Setting.objects.get(
+            name="disable_article_thumbnails"
         )
-        SettingValue.objects.get_or_create(
-            setting=large_image_setting,
-            value_en="on",
-            journal=journal,
+        large_image_setting = Setting.objects.get(
+            name="disable_article_large_image",
         )
 
+        for journal in Journal.objects.filter(disable_article_images=True):
+            SettingValue.objects.get_or_create(
+                setting=thumb_setting,
+                value_en="on",
+                journal=journal,
+            )
+            SettingValue.objects.get_or_create(
+                setting=large_image_setting,
+                value_en="on",
+                journal=journal,
+            )
+    except Setting.DoesNotExist:
+        # There is no setting to update.
+        pass
 
 class Migration(migrations.Migration):
 

--- a/src/journal/migrations/0053_display_article_images_settings.py
+++ b/src/journal/migrations/0053_display_article_images_settings.py
@@ -5,37 +5,6 @@ from django.core.management import call_command
 from django.db import migrations, models
 
 
-def update_setting_values(apps, schema_editor):
-    Journal = apps.get_model("journal", "Journal")
-    Setting = apps.get_model("core", "Setting")
-    SettingGroup = apps.get_model("core", "SettingGroup")
-    SettingValue = apps.get_model("core", "SettingValue")
-    setting_group, _ = SettingGroup.objects.get_or_create(
-        name="article")
-
-    try:
-        thumb_setting, c = Setting.objects.get(
-            name="disable_article_thumbnails"
-        )
-        large_image_setting = Setting.objects.get(
-            name="disable_article_large_image",
-        )
-
-        for journal in Journal.objects.filter(disable_article_images=True):
-            SettingValue.objects.get_or_create(
-                setting=thumb_setting,
-                value_en="on",
-                journal=journal,
-            )
-            SettingValue.objects.get_or_create(
-                setting=large_image_setting,
-                value_en="on",
-                journal=journal,
-            )
-    except Setting.DoesNotExist:
-        # There is no setting to update.
-        pass
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -43,5 +12,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(update_setting_values, reverse_code=migrations.RunPython.noop),
     ]


### PR DESCRIPTION
Originally I tried to fix this migration but realised that there no circumstances under which it will ever work in the future or be useful. The migration was added over two years ago so it has no effect for new installs and anyone still using a version of Janeway that old is very unlikely. The _es setting value will always be missing and it will be skipped or it will error out. We need to decide, for the future, how to handle adding new languages in a safe way or ensure that all migrations will always run. It may be that we need to shift the altering of settings like this _out_ of the migration process all together (although it has proven convenient up until now).

This closes #4632 

Once merged we can create a 1.7.5 release.