### PR TITLE
Add Submissions and Publications to User History

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -1445,23 +1445,12 @@ def user_history(request, user_id):
     template = 'core/manager/users/history.html'
     context = {
         'user': user,
-        'review_assignments': review_models.ReviewAssignment.objects.filter(
-            reviewer=user,
-            article__journal=request.journal,
-        ),
         'copyedit_assignments':
             copyedit_models.CopyeditAssignment.objects.filter(
                 copyeditor=user,
                 article__journal=request.journal,
             ),
         'log_entries': log_entries,
-        'submissions':
-            submission_models.Article.objects.filter(
-                authors=user,
-                journal=request.journal,
-            ).exclude(
-                stage=submission_models.STAGE_PUBLISHED,
-            ).order_by('-date_started'),
         'publications':
             submission_models.Article.objects.filter(
                 authors=user,
@@ -1469,9 +1458,20 @@ def user_history(request, user_id):
                 stage=submission_models.STAGE_PUBLISHED,
                 date_published__isnull=False,
             ).order_by('-date_published'),
+        'review_assignments': review_models.ReviewAssignment.objects.filter(
+            reviewer=user,
+            article__journal=request.journal,
+        ),
         'stages': {
             'STAGE_UNSUBMITTED': submission_models.STAGE_UNSUBMITTED,
         },
+        'submissions':
+            submission_models.Article.objects.filter(
+                authors=user,
+                journal=request.journal,
+            ).exclude(
+                stage=submission_models.STAGE_PUBLISHED,
+            ).order_by('-date_started'),
     }
 
     return render(request, template, context)

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -1455,6 +1455,23 @@ def user_history(request, user_id):
                 article__journal=request.journal,
             ),
         'log_entries': log_entries,
+        'submissions':
+            submission_models.Article.objects.filter(
+                authors=user,
+                journal=request.journal,
+            ).exclude(
+                stage=submission_models.STAGE_PUBLISHED,
+            ).order_by('-date_started'),
+        'publications':
+            submission_models.Article.objects.filter(
+                authors=user,
+                journal=request.journal,
+                stage=submission_models.STAGE_PUBLISHED,
+                date_published__isnull=False,
+            ).order_by('-date_published'),
+        'stages': {
+            'STAGE_UNSUBMITTED': submission_models.STAGE_UNSUBMITTED,
+        },
     }
 
     return render(request, template, context)

--- a/src/templates/admin/core/manager/users/history.html
+++ b/src/templates/admin/core/manager/users/history.html
@@ -17,6 +17,68 @@
         <div class="row expanded">
             <div class="large-6 columns">
                 <div class="title-area">
+                    <h2>Submissions</h2>
+                </div>
+                <div class="content">
+                    <table class="scroll small">
+                        <tr>
+                            <th>ID</th>
+                            <th>Article</th>
+                            <th>Stage</th>
+                            <th>Date Started</th>
+                            <th>Last Update</th>
+                        </tr>
+                        {% for submission in submissions %}
+                            <tr>
+                                <td>{{ submission.pk }}</td>
+                                {% if submission.stage == stages.STAGE_UNSUBMITTED %}
+                                    <td>{{ submission.safe_title }}</td>
+                                {% else %}
+                                    <td><a href="{% url 'manage_archive_article' submission.pk %}">{{ submission.safe_title }}</a></td>
+                                {% endif %}
+                                <td>{{ submission.stage }}</td>
+                                <td>{{ submission.date_started }}</td>
+                                <td>{{ submission.date_updated }}</td>
+                            </tr>
+                        {% empty %}
+                            <tr>
+                                <td colspan="4">No submissions</td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
+            </div>
+            <div class="large-6 columns">
+                <div class="title-area">
+                    <h2>Publications</h2>
+                </div>
+                <div class="content">
+                    <table class="scroll small">
+                        <tr>
+                            <th>ID</th>
+                            <th>Article</th>
+                            <th>Date Started</th>
+                            <th>Date Published</th>
+                        </tr>
+                        {% for publication in publications %}
+                            <tr>
+                                <td>{{ publication.pk }}</td>
+                                <td><a href="{% url 'manage_archive_article' publication.pk %}">{{ publication.safe_title }}</a></td>
+                                <td>{{ publication.date_started }}</td>
+                                <td>{{ publication.date_published }}</td>
+                            </tr>
+                        {% empty %}
+                            <tr>
+                                <td colspan="4">No publications</td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="row expanded">
+            <div class="large-6 columns">
+                <div class="title-area">
                     <h2>Editorial Assignments</h2>
                 </div>
                 <div class="content">

--- a/src/templates/admin/core/manager/users/history.html
+++ b/src/templates/admin/core/manager/users/history.html
@@ -37,12 +37,12 @@
                                     <td><a href="{% url 'manage_archive_article' submission.pk %}">{{ submission.safe_title }}</a></td>
                                 {% endif %}
                                 <td>{{ submission.stage }}</td>
-                                <td>{{ submission.date_started }}</td>
-                                <td>{{ submission.date_updated }}</td>
+                                <td>{{ submission.date_started|date:"Y-m-d" }}</td>
+                                <td>{{ submission.date_updated|date:"Y-m-d" }}</td>
                             </tr>
                         {% empty %}
                             <tr>
-                                <td colspan="4">No submissions</td>
+                                <td colspan="5">No submissions</td>
                             </tr>
                         {% endfor %}
                     </table>
@@ -64,8 +64,8 @@
                             <tr>
                                 <td>{{ publication.pk }}</td>
                                 <td><a href="{% url 'manage_archive_article' publication.pk %}">{{ publication.safe_title }}</a></td>
-                                <td>{{ publication.date_started }}</td>
-                                <td>{{ publication.date_published }}</td>
+                                <td>{{ publication.date_started|date:"Y-m-d" }}</td>
+                                <td>{{ publication.date_published|date:"Y-m-d" }}</td>
                             </tr>
                         {% empty %}
                             <tr>
@@ -84,6 +84,7 @@
                 <div class="content">
                 <table class="scroll small">
                         <tr>
+                            <th>ID</th>
                             <th>Article</th>
                             <th>Assigned</th>
                             <th>Notified</th>
@@ -91,14 +92,15 @@
                         </tr>
                         {% for assignment in user.editorassignment_set.all %}
                             <tr>
-                                <td>{{ assignment.article.safe_title }}</td>
+                                <td>{{ assignment.article.pk }}</td>
+                                <td><a href="{% url 'manage_archive_article' assignment.article.pk %}">{{ assignment.article.safe_title }}</a></td>
                                 <td>{{ assignment.assigned }}</td>
                                 <td>{{ assignment.notified }}</td>
                                 <td>{{ assignment.editor_type|capfirst }}</td>
                             </tr>
                         {% empty %}
                             <tr>
-                                <td colspan="4">No review assignments</td>
+                                <td colspan="5">No editorial assignments</td>
                             </tr>
                         {% endfor %}
                     </table>
@@ -111,6 +113,7 @@
                 <div class="content">
                     <table class="scroll small">
                         <tr>
+                            <th>ID</th>
                             <th>Article</th>
                             <th>Assigned</th>
                             <th>Due</th>
@@ -118,7 +121,8 @@
                         </tr>
                         {% for assignment in review_assignments %}
                             <tr>
-                                <td>{{ assignment.article.safe_title }}</td>
+                                <td>{{ assignment.article.pk }}</td>
+                                <td><a href="{% url 'manage_archive_article' assignment.article.pk %}">{{ assignment.article.safe_title }}</a></td>
                                 <td>{{ assignment.date_requested }}</td>
                                 <td>{{ assignment.date_due|date:"Y-m-d" }}</td>
                                 <td>
@@ -127,7 +131,7 @@
                             </tr>
                         {% empty %}
                             <tr>
-                                <td colspan="4">No review assignments</td>
+                                <td colspan="5">No review assignments</td>
                             </tr>
                         {% endfor %}
                     </table>
@@ -142,6 +146,7 @@
                 <div class="content">
                     <table class="scroll small">
                         <tr>
+                            <th>ID</th>
                             <th>Article</th>
                             <th>Assigned</th>
                             <th>Due</th>
@@ -149,14 +154,15 @@
                         </tr>
                         {% for assignment in copyedit_assignments %}
                             <tr>
-                                <td>{{ assignment.article.safe_title }}</td>
+                                <td>{{ assignment.article.pk }}</td>
+                                <td><a href="{% url 'manage_archive_article' assignment.article.pk %}">{{ assignment.article.safe_title }}</a></td>
                                 <td>{{ assignment.assigned }}</td>
                                 <td>{{ assignment.due }}</td>
                                 <td>{{ assignment.copyeditor_completed }}</td>
                             </tr>
                         {% empty %}
                             <tr>
-                                <td colspan="4">No review assignments</td>
+                                <td colspan="5">No copyediting assignments</td>
                             </tr>
                         {% endfor %}
                     </table>
@@ -169,6 +175,7 @@
                 <div class="content">
                     <table class="scroll small">
                         <tr>
+                            <th>ID</th>
                             <th>Article</th>
                             <th>Assigned</th>
                             <th>Accepted</th>
@@ -176,14 +183,15 @@
                         </tr>
                         {% for assignment in user.typesettask_set.all %}
                             <tr>
-                                <td>{{ assignment.assignment.article.safe_title }}</td>
+                                <td>{{ assignment.assignment.article.pk }}</td>
+                                <td><a href="{% url 'manage_archive_article' assignment.assignment.article.pk %}">{{ assignment.assignment.article.safe_title }}</a></td>
                                 <td>{{ assignment.assigned }}</td>
                                 <td>{{ assignment.accepted }}</td>
                                 <td>{{ assignment.completed }}</td>
                             </tr>
                         {% empty %}
                             <tr>
-                                <td colspan="4">No review assignments</td>
+                                <td colspan="5">No typesetting assignments</td>
                             </tr>
                         {% endfor %}
                     </table>
@@ -198,6 +206,7 @@
                 <div class="content">
                     <table class="scroll small">
                         <tr>
+                            <th>ID</th>
                             <th>Article</th>
                             <th>Assigned</th>
                             <th>Notified</th>
@@ -205,14 +214,15 @@
                         </tr>
                         {% for assignment in user.productionassignment_set.all %}
                             <tr>
-                                <td>{{ assignment.article.safe_title }}</td>
+                                <td>{{ assignment.article.pk }}</td>
+                                <td><a href="{% url 'manage_archive_article' assignment.article.pk %}">{{ assignment.article.safe_title }}</a></td>
                                 <td>{{ assignment.assigned }}</td>
                                 <td>{{ assignment.notified }}</td>
                                 <td>{{ assignment.closed }}</td>
                             </tr>
                         {% empty %}
                             <tr>
-                                <td colspan="4">No review assignments</td>
+                                <td colspan="5">No production manager assignments</td>
                             </tr>
                         {% endfor %}
                     </table>
@@ -225,6 +235,7 @@
                 <div class="content">
                     <table class="scroll small">
                         <tr>
+                            <th>ID</th>
                             <th>Article</th>
                             <th>Assigned</th>
                             <th>Due</th>
@@ -232,14 +243,15 @@
                         </tr>
                         {% for assignment in user.proofingtask_set.all %}
                             <tr>
-                                <td>{{ assignment.round.assignment.article.safe_title }}</td>
+                                <td>{{ assignment.round.assignment.article.pk }}</td>
+                                <td><a href="{% url 'manage_archive_article' assignment.round.assignment.article.pk %}">{{ assignment.round.assignment.article.safe_title }}</a></td>
                                 <td>{{ assignment.assigned }}</td>
                                 <td>{{ assignment.due }}</td>
                                 <td>{{ assignment.completed }}</td>
                             </tr>
                         {% empty %}
                             <tr>
-                                <td colspan="4">No review assignments</td>
+                                <td colspan="5">No proofing assignments</td>
                             </tr>
                         {% endfor %}
                     </table>


### PR DESCRIPTION
This adds both publication and submission history of a user to the history section. A link to the archive page of the article is also provided if the article isn't in the "UNSUBMITTED" stage. 

Preview: 
<img width="1463" alt="Screenshot 2025-04-11 at 1 09 48 PM" src="https://github.com/user-attachments/assets/9db7d12c-a232-410f-917c-ef6360fe0d60" />