### PR TITLE
Fix: Add success and error messages for user search and Typesetting Guideline updates

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -994,6 +994,7 @@ def edit_setting(request, setting_group, setting_name):
                     messages.add_message(request, messages.ERROR, error)
                 else:
                     cache.clear()
+                    messages.success(request, _('Setting updated successfully.'))  
 
                 return language_override_redirect(
                     request,

--- a/src/templates/admin/core/manager/users/enrol_users.html
+++ b/src/templates/admin/core/manager/users/enrol_users.html
@@ -45,9 +45,17 @@
                     </form>
                 </div>
 
-                     {% for user in user_search %}
-                        {% include "admin/elements/core/user_search_list.html" %}
-                     {% endfor %}
+                    {% if first_name or last_name or email %}
+                        {% if user_search %}
+                            {% for user in user_search %}
+                                {% include "admin/elements/core/user_search_list.html" %}
+                            {% endfor %}
+                        {% else %}
+                            <div class="callout warning">
+                                <strong>No matching user accounts found.</strong>
+                            </div>
+                        {% endif %}
+                    {% endif %}
 
             </div>
         </div>


### PR DESCRIPTION
### Summary

This PR resolves two issues related to missing user feedback messages in the admin interface:

1. **User Search:**
   - When searching for a user that does not exist, the result was previously blank with no message.
   - A new message has been added to inform the user that the searched user does not exist.

2. **Typesetting Guideline Update:**
   - When updating the "Typesetting Guidelines" setting, the update was successful but no success message was shown.
   - A success message is now displayed after updating the setting.

### Changes Made

1. **User Search:**
    - janeway/src/templates/admin/core/manager/users/enrol_users.html (Line no 48 to 58)

2 **Typesetting Guideline Update:**
    - janeway/src/core/views.py (Line 997)