### PR TITLE
feat: add hook for editor actions menu on in_review page

### DIFF
--- a/src/templates/admin/review/in_review.html
+++ b/src/templates/admin/review/in_review.html
@@ -1,5 +1,6 @@
 {% extends "admin/core/base.html" %}
 {% load static itertools roles securitytags %}
+{% load hooks %}
 
 {% block title %}Review {{ article.title }}{% endblock %}
 {% block title-section %}Peer Review{% endblock %}
@@ -301,6 +302,7 @@
                             <a href="{% url 'upload_reviewers_from_csv' article.id %}" class="expanded"><span class="fa fa-file-text"></span> Create Review Assignments from CSV</a>
                         </li>
                     {% endif %}
+                    {% hook 'in_review_editor_actions' %}
                     </ul>
                 </div>
             </div>

--- a/src/templates/admin/review/in_review.html
+++ b/src/templates/admin/review/in_review.html
@@ -302,7 +302,7 @@
                             <a href="{% url 'upload_reviewers_from_csv' article.id %}" class="expanded"><span class="fa fa-file-text"></span> Create Review Assignments from CSV</a>
                         </li>
                     {% endif %}
-                    {% hook 'in_review_editor_actions' %}
+                        {% hook 'in_review_editor_actions' %}
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Adds a template hook to the in_review.html page, inside the editor's action menu block.

This allows plugins to inject additional action items during the review stage,
enabling better extensibility.

This hook is added to support the development of the RQC Adapter Plugin (https://reviewqualitycollector.org/) for Janeway, which needs to inject additional editor actions during the review stage.