### PR TITLE
feat: add hook for the guidelines section of the review_form template

### DIFF
--- a/src/templates/admin/review/review_form.html
+++ b/src/templates/admin/review/review_form.html
@@ -1,5 +1,6 @@
 {% extends "admin/core/base.html" %}
 {% load foundation %}
+{% load hooks %}
 
 {% block title %}Review Request{% endblock title %}
 {% block title-section %}Review Request{% endblock %}
@@ -79,6 +80,7 @@
                         </div>
                     {% endif %}
                 {% endif %}
+                {% hook 'review_form_guidelines' %}
 
             </div>
             <div class="box">


### PR DESCRIPTION
This PR adds a template hook to the review form guidelines section, allowing 
plugins to inject additional content into the reviewer acceptance flow.

Although the guideline text is customizable, in the context of Review Quality Collector we would like to include a form that allows reviewers to indicate whether they wish to participate in RQC, as it collects data about their reviews.

The hook is positioned at the end of the guidelines content, allowing plugins 
to add forms or additional information without disrupting the core review 
workflow.