### PR TITLE
Fixes a bug that stopped ORCID login from succeeding when OIDC is also enabled

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -442,7 +442,11 @@ def register(request, orcid_token=None):
                 if new_user.email == initial.get("email"):
                     new_user.is_active = True
                     new_user.save()
-                    login(request, new_user)
+                    login(
+                        request,
+                        new_user,
+                        backend='django.contrib.auth.backends.ModelBackend',
+                    )
                     return redirect(
                         request.site_type.auth_success_url(next_url=next_url)
                     )

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -244,7 +244,11 @@ def user_login_orcid(request):
                 if candidates.exists():
                     # Store ORCID for future authentication requests
                     candidates.update(orcid=orcid_id)
-                    login(request, candidates.first())
+                    login(
+                        request,
+                        candidates.first(),
+                        backend='django.contrib.auth.backends.ModelBackend',
+                    )
                     return redirect(
                         request.site_type.auth_success_url(next_url=next_url)
                     )


### PR DESCRIPTION
If OIDC is enabled and we don't call `authenticate()` we need to be explicit with which backend to use when calling `login()`