### PR TITLE
The options block will now show for editors in Typesetting, allowing them to do conversions

### DIFF
--- a/src/typesetting/templates/typesetting/elements/file_list.html
+++ b/src/typesetting/templates/typesetting/elements/file_list.html
@@ -1,4 +1,5 @@
-{% load files %}
+{% load files roles %}
+{% user_has_role request 'editor' as user_is_editor %}
 
 <fieldset>
     {% if checkboxes  %}


### PR DESCRIPTION
file_list.html currently checks for the editor role but it is not defined in the template meaning it will never display for editors.