### PR TITLE
Auto-record Janeway version bumps using signals

### DIFF
--- a/src/core/apps.py
+++ b/src/core/apps.py
@@ -12,6 +12,7 @@ class CoreConfig(AppConfig):
     name = 'core'
 
     def ready(self):
+        from core import upgrade # register upgrade signals
         from core.model_utils import SearchLookup
         models.CharField.register_lookup(SearchLookup)
         models.TextField.register_lookup(SearchLookup)

--- a/src/core/upgrade.py
+++ b/src/core/upgrade.py
@@ -1,0 +1,24 @@
+"""
+Routines for handling Janeway version upgrades.
+"""
+__copyright__ = "Copyright 2025 Open Library of Humanties"
+__author__ = "Open Library of Humanities"
+__license__ = "AGPL v3"
+__maintainer__ = "Open Library of Humanities"
+
+from django.apps import apps
+from django.db.models.signals import post_migrate
+from django.dispatch import receiver
+
+from utils.logic import get_janeway_version
+
+
+@receiver(post_migrate)
+def version_change_signal(sender, **kwargs):
+    """ Signal handler that commits Janeway version changes
+    """
+    if sender.name == "utils":
+        # Ensure we only log the version change once after any migrations
+        # affecting the model have run
+        Version = apps.get_model('utils', 'Version')
+        Version.objects.log_version_change(get_janeway_version())

--- a/src/janeway/__init__.py
+++ b/src/janeway/__init__.py
@@ -1,2 +1,2 @@
 from packaging import version
-__version__ = version.parse("1.7.5")
+__version__ = version.parse("1.8.0")

--- a/src/utils/migrations/0011_upgrade_1_3_5.py
+++ b/src/utils/migrations/0011_upgrade_1_3_5.py
@@ -22,5 +22,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0013_upgrade_1_3_6.py
+++ b/src/utils/migrations/0013_upgrade_1_3_6.py
@@ -23,5 +23,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0014_upgrade_1_3_7.py
+++ b/src/utils/migrations/0014_upgrade_1_3_7.py
@@ -23,5 +23,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0015_upgrade_1_3_8.py
+++ b/src/utils/migrations/0015_upgrade_1_3_8.py
@@ -23,5 +23,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0019_upgrade_1_3_9.py
+++ b/src/utils/migrations/0019_upgrade_1_3_9.py
@@ -23,5 +23,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0020_upgrade_1_3_10.py
+++ b/src/utils/migrations/0020_upgrade_1_3_10.py
@@ -29,5 +29,6 @@ class Migration(migrations.Migration):
             name='number',
             field=models.CharField(max_length=10),
         ),
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0023_upgrade_1_4_0.py
+++ b/src/utils/migrations/0023_upgrade_1_4_0.py
@@ -29,5 +29,6 @@ class Migration(migrations.Migration):
             name='number',
             field=models.CharField(max_length=10),
         ),
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0025_upgrade_1_4_1.py
+++ b/src/utils/migrations/0025_upgrade_1_4_1.py
@@ -24,5 +24,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0026_upgrade_1_4_2.py
+++ b/src/utils/migrations/0026_upgrade_1_4_2.py
@@ -24,5 +24,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0027_upgrade_1_4_3.py
+++ b/src/utils/migrations/0027_upgrade_1_4_3.py
@@ -24,5 +24,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0028_upgrade_1_4_4.py
+++ b/src/utils/migrations/0028_upgrade_1_4_4.py
@@ -24,5 +24,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0030_upgrade_1_5_0.py
+++ b/src/utils/migrations/0030_upgrade_1_5_0.py
@@ -24,5 +24,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0031_upgrade_1_5_1.py
+++ b/src/utils/migrations/0031_upgrade_1_5_1.py
@@ -25,5 +25,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0032_upgrade_1_5_2.py
+++ b/src/utils/migrations/0032_upgrade_1_5_2.py
@@ -25,5 +25,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0033_upgrade_1_6_0.py
+++ b/src/utils/migrations/0033_upgrade_1_6_0.py
@@ -25,5 +25,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0035_upgrade_1_7_0.py
+++ b/src/utils/migrations/0035_upgrade_1_7_0.py
@@ -25,5 +25,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0037_upgrade_1_7_1.py
+++ b/src/utils/migrations/0037_upgrade_1_7_1.py
@@ -26,5 +26,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0038_upgrade_1_7_2.py
+++ b/src/utils/migrations/0038_upgrade_1_7_2.py
@@ -26,5 +26,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]

--- a/src/utils/migrations/0039_upgrade_1_7_4.py
+++ b/src/utils/migrations/0039_upgrade_1_7_4.py
@@ -26,5 +26,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(upgrade, reverse_code=rollback),
+        # Version data migrations are handled via signals now
+        # migrations.RunPython(upgrade, reverse_code=rollback),
     ]


### PR DESCRIPTION
Removes the need for adding migration bumps manually.

Closes #4826 