### PR TITLE
Upgrade django-simple-history

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-modeltranslation==0.18.11
 django-settings-export==1.2.1
 django-recaptcha==3.0.0
 django-simple-math-captcha==2.0.1
-django-simple-history==3.3.0
+django-simple-history==3.10.1
 django-summernote==0.8.20.0
 django-tinymce==3.7.1
 djangorestframework==3.15.2


### PR DESCRIPTION
Closes #4859.

I have read the changelog and do not believe there are any breaking changes.

The new pinned version (3.10.1) still supports Python 3.9+.