### PR TITLE
Fixed a bug where rendering URL from journal A to journal B would lead to both journal codes being appended

### DIFF
--- a/src/core/templatetags/fqdn.py
+++ b/src/core/templatetags/fqdn.py
@@ -1,5 +1,7 @@
 from django import template
+from django.conf import settings
 from django.urls import reverse, NoReverseMatch
+from django.urls.resolvers import get_resolver
 
 register = template.Library()
 
@@ -47,7 +49,7 @@ def site_url(context, url_name=None, *args):
 
 
 @register.simple_tag
-def stateless_site_url(site, url_name=None, query=None, *args):
+def stateless_site_url(site, url_name=None, query=None, *args, **kwargs):
     """A tag for constructing a url for a site without global request state
     This should eventually become the canonical site builder for all other
     tags in this file
@@ -60,7 +62,9 @@ def stateless_site_url(site, url_name=None, query=None, *args):
     :param *args: additional arguments for reversing the url by name
     """
     if url_name is not None:
-        path = reverse(url_name, args=args)
+        # avoid leaking script_prefix across sites
+        resolver = get_resolver()
+        path = resolver._reverse_with_prefix(url_name, "/", *args, **kwargs)
     else:
         path = None
 


### PR DESCRIPTION
Our `stateless_site_url` is not stateless because django's `reverse` checks the `script_prefix` set for the context of the request. I've changed this to invoke the resolver directly with a script prefix override and allow the site-implemented `site_url` to control if a prefix should be inserted to the URL or not.

