### PR TITLE
bypass for RUSAGE to prevent errors on MacOS

### DIFF
--- a/src/utils/middleware.py
+++ b/src/utils/middleware.py
@@ -75,5 +75,8 @@ class TimeMonitoring(BaseMiddleware):
 
     @staticmethod
     def _get_usage():
-        utime, stime, *_ = resource.getrusage(resource.RUSAGE_THREAD)
+        try:
+            utime, stime, *_ = resource.getrusage(resource.RUSAGE_THREAD)
+        except AttributeError:
+            utime, stime, *_ = resource.getrusage(resource.RUSAGE_SELF)
         return (time.time(), utime, stime)

--- a/src/utils/middleware.py
+++ b/src/utils/middleware.py
@@ -76,7 +76,10 @@ class TimeMonitoring(BaseMiddleware):
     @staticmethod
     def _get_usage():
         try:
-            utime, stime, *_ = resource.getrusage(resource.RUSAGE_THREAD)
-        except AttributeError:
-            utime, stime, *_ = resource.getrusage(resource.RUSAGE_SELF)
-        return (time.time(), utime, stime)
+            try:
+                utime, stime, *_ = resource.getrusage(resource.RUSAGE_THREAD)
+            except AttributeError:
+                utime, stime, *_ = resource.getrusage(resource.RUSAGE_SELF)
+            return (time.time(), utime, stime)
+        except Exception:
+            return (time.time(), 0, 0)


### PR DESCRIPTION
when using dev-settings on mac, we get the following error:
`AttributeError: module 'resource' has no attribute 'RUSAGE_THREAD'`

previously addressed by manually removing`    "utils.middleware.TimeMonitoring",` from these settings each time it was installed on mac. 

This try/catch addresses this directly.
