### PR TITLE
Fixes for Uiowa upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ more-itertools==10.1.0
 jsmin==3.0.1
 kitchen==1.2.4
 libsass==0.23.0
-lxml==4.9.4
+lxml==6.0.0
 markdown
 maxminddb==2.5.1
 mock
@@ -46,7 +46,7 @@ orcid==1.0.3
 packaging==23.2
 pdfkit==1.0.0
 pdfminer.six
-psycopg2-binary~=2.9.8
+psycopg2-binary==2.9.10
 pyasn1==0.1.9
 pycparser==2.14
 PyJWT==2.4.0

--- a/src/templates/common/apis/OAI_ListSets.xml
+++ b/src/templates/common/apis/OAI_ListSets.xml
@@ -11,7 +11,7 @@
         {% for issue in all_issues %}
             <set>
                 <setSpec>{{ issue.journal.code }}:{{ issue.issue_type.code }}:{{ issue.pk }}</setSpec>
-                <setName>{{ issue.non_pretty_issue_identifier }}</setName>
+                <setName>{{ issue.non_pretty_issue_identifier|force_escape }}</setName>
             </set>
         {% endfor %}
         {% for section in sections %}


### PR DESCRIPTION
Addresses a couple of problems when upgrading uiowa to v1.8.x:
 - Adds a OAI fix that exists already in their live instance but not on core
 - Updates requirements to be compatible with python 3.12 (Ubuntu LTS 24.04 default python version) 