### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Thanks for considering contributing to Janeway!
 
 - To report a bug please provide as much information as possible on the action you were undertaking. It would be preferable if we could have the stack trace for the error supplied.
 - To suggest a new feature please describe it as in depth as possible, it will be considered and may be added to a future release of Janeway.
-- To maintain a consistent and readable codebase, we require all Python code to be automatically formatted with Black and linted with [Ruff](https://docs.astral.sh/ruff/formatter/). These tools help ensure code style uniformity and catch potential issues early. Once you have installed the development dependencies, you can run `ruff format .`. We strongly recommend adding our hooks to your repository config (`git config --local core.hooksPath .git-hooks`) to avoid commiting unformatted code.
+- To maintain a consistent and readable codebase, we require all Python code to be automatically formatted with Black and linted with [Ruff](https://docs.astral.sh/ruff/formatter/). These tools help ensure code style uniformity and catch potential issues early. Once you have installed the development dependencies, you can run `ruff format .`. We strongly recommend adding our hooks to your repository config (`git config --local core.hooksPath .git-hooks`) to avoid committing unformatted code.
 - When writing a commit message, we adhere to the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/). We also add a reference in the commit message (e.g `fix: #123 fixed a bug where [...]`)
 - When a PR is expected to resolve an issue you can flag it as `closes #123` and the issue will be closed once the PR is merged into the main branch
 4

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ all: help
 run: janeway
 help:		## Show this help.
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
-janeway:	## Run Janeway web server in attached mode. If NO_DEPS is not set, runs all dependant services detached.
+janeway:	## Run Janeway web server in attached mode. If NO_DEPS is not set, runs all dependent services detached.
 	$(COMPOSE_CMD) run --rm start_dependencies
 	$(COMPOSE_CMD) $(_VERBOSE) run $(NO_DEPS) --rm --service-ports janeway-web $(entrypoint)
 command:	## Run Janeway in a container and pass through a django command passed as the CMD environment variable (e.g make command CMD="migrate -v core 0024")
@@ -102,7 +102,7 @@ db-save-backup: # Archives the current db as a tarball. Returns the output file 
 	@sudo tar -zcf $(DB_VENDOR)-$(DATE)-$(SUFFIX).tar.gz $(DB_VOLUME)
 	@echo "$(DB_VENDOR)-$(DATE)-$(SUFFIX).tar.gz"
 	@sudo chown -R `id -un`:`id -gn` $(DB_VENDOR)-$(DATE)-$(SUFFIX).tar.gz
-db-load-backup: #Loads a previosuly captured backup in the db directory (e.g.: make db-load_backup DB=postgres-21-02-03-3948681d1b6dc2.tar.gz)
+db-load-backup: #Loads a previously captured backup in the db directory (e.g.: make db-load_backup DB=postgres-21-02-03-3948681d1b6dc2.tar.gz)
 	@BACKUP=$(BACKUP);echo "Loading $${BACKUP:?Please set to the name of the backup file}"
 	@tar -zxf $(BACKUP) -C /tmp/
 	@docker kill `docker ps -q --filter 'name=janeway-*'` 2>&1 | true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-We currently only support one major version of Janeway. The master development branch becomes the next major release of Janeway and receieves security support. Security issues that only affect the master branch and not any stable released versions can be reported as Bugs and are fixed in public. Security vulnerabilities that effect a support branch, listed below, should be reported using the details provided under Reporting a Vulnerability.
+We currently only support one major version of Janeway. The master development branch becomes the next major release of Janeway and receives security support. Security issues that only affect the master branch and not any stable released versions can be reported as Bugs and are fixed in public. Security vulnerabilities that effect a support branch, listed below, should be reported using the details provided under Reporting a Vulnerability.
 
 | Version | Supported          |
 | ------- | ------------------ |
@@ -33,7 +33,7 @@ We will follow this process:
 | Activity                              | Days From Initial Report |
 |---------------------------------------|--------------------------|
 | Acknowledge Initial Report            | 1 day                    |
-| Provide Initial Assesment to Reporter | 5 days                   |
+| Provide Initial Assessment to Reporter | 5 days                   |
 | Create and Test Fix                   | 14 days                  |
 | Publish Security Advisory on Github   | 21 days                  |
 

--- a/src/core/homepage_elements/featured/templates/featured_setup.html
+++ b/src/core/homepage_elements/featured/templates/featured_setup.html
@@ -54,7 +54,7 @@
                                 <td>{{ article.date_published }}</td>
                                 <td>{{ article.author_list }}</td>
                                 <td>
-                                    <button class="tiny succes button" type="submit" name="article_id"
+                                    <button class="tiny success button" type="submit" name="article_id"
                                             value="{{ article.pk }}">Add
                                     </button>
                                 </td>

--- a/src/templates/admin/core/flat_base.html
+++ b/src/templates/admin/core/flat_base.html
@@ -3,7 +3,7 @@
 {% comment %}
 A base template that includes some accessibility features:
 - the contextual_title block, which adds the contextual site name for the browser tab
-- supression of toastr modal, so that you can include messages_in_callout where you like
+- suppression of toastr modal, so that you can include messages_in_callout where you like
 {% endcomment %}
 
 {% block title %}

--- a/src/templates/admin/core/manage_access_requests.html
+++ b/src/templates/admin/core/manage_access_requests.html
@@ -9,7 +9,7 @@
 {% block body %}
     <section>
         <div class="box">
-            <p>Active permission requests are listed below. Once approved or rejected they will be removed. Requesters will be notifed of your decision automatically.</p>
+            <p>Active permission requests are listed below. Once approved or rejected they will be removed. Requesters will be notified of your decision automatically.</p>
             <table class="table" id="access_requests">
                 <thead>
                     <tr>

--- a/src/templates/admin/cron/readers.html
+++ b/src/templates/admin/cron/readers.html
@@ -19,7 +19,7 @@
                 <h2>Readers</h2>
             </div>
             <div class="content">
-                <p>Readers recieve notifications when new articles are published in a journal. Note: Only users themselves can add and remove themselves from the Reader role.</p>
+                <p>Readers receive notifications when new articles are published in a journal. Note: Only users themselves can add and remove themselves from the Reader role.</p>
                 <table class="table small" id="readers">
                     <thead>
                         <tr>

--- a/src/templates/admin/elements/account_roles.html
+++ b/src/templates/admin/elements/account_roles.html
@@ -16,7 +16,7 @@
             {% if accountrole.role.slug == 'author' and request.journal %}
               (base role)
               {% comment %}
-                This attempts to gaurd against removing the last role a person has,
+                This attempts to guard against removing the last role a person has,
                 when doing so would remove them from view, preventing the user
                 from undoing their action or adding another role.
               {% endcomment %}

--- a/src/templates/admin/elements/give_me_options_js.html
+++ b/src/templates/admin/elements/give_me_options_js.html
@@ -2,7 +2,7 @@
   Give me options
   This component is CSS and JS only.
   The HTML must be rewritten each time it is used.
-  pid - a unique id that allows the component to be re-used on the same page.
+  pid - a unique id that allows the component to be reused on the same page.
 {% endcomment %}
 
 <script type="module">

--- a/src/templates/admin/elements/issue/new_galley.html
+++ b/src/templates/admin/elements/issue/new_galley.html
@@ -1,4 +1,4 @@
-{# This could be changed to accomodate for elements/production/new_galley.html as well but we need a good galley abstraction first (GH #865#}
+{# This could be changed to accommodate for elements/production/new_galley.html as well but we need a good galley abstraction first (GH #865#}
 <div class="reveal" id="uploadbox" data-reveal data-animation-in="slide-in-up"
      data-animation-out="slide-out-down">
     <div class="card">

--- a/src/templates/admin/repository/author_article.html
+++ b/src/templates/admin/repository/author_article.html
@@ -306,7 +306,7 @@
                     </p>
                     <ol>
                         <li><a href="{% url 'repository_submit_update' preprint.pk 'correction' %}">Correction</a> - This is a small update. You can update the metadata.</li>
-                        <li><a href="{% url 'repository_submit_update' preprint.pk 'version' %}">New Version</a> - A large update. You can update the medadata.</li>
+                        <li><a href="{% url 'repository_submit_update' preprint.pk 'version' %}">New Version</a> - A large update. You can update the metadata.</li>
                         <li><a href="{% url 'repository_submit_update' preprint.pk 'metadata_correction' %}">Metadata Correction</a> - You can only make changes to the metadata.</li>
                     </ol>
                 </div>

--- a/src/templates/admin/repository/review/list_review_recommendations.html
+++ b/src/templates/admin/repository/review/list_review_recommendations.html
@@ -5,7 +5,7 @@
 
 {% block title %}Review Recommendations{% endblock %}
 {% block title-section %}Review Recommendations{% endblock %}
-{% block title-sub %}Manange review recommendations{% endblock %}
+{% block title-sub %}Manage review recommendations{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -22,7 +22,7 @@
             </div>
             <div class="content">
                 <p>You can create, edit and delete review recommendations for your repository using the interface here. </p>
-                <p>Recommendations that are linked to existing reviws cannot be deleted but you can mark them as inactive.</p>
+                <p>Recommendations that are linked to existing reviews cannot be deleted but you can mark them as inactive.</p>
                 <form method="POST">
                     {% csrf_token %}
 

--- a/src/templates/admin/repository/review/manage_review.html
+++ b/src/templates/admin/repository/review/manage_review.html
@@ -53,7 +53,7 @@
             <div class="content">
                 <p>Set your due date, be sure to give the reviewer a decent amount of time to complete their task.</p>
                 {{ form.date_due|foundation }}
-                <p>Once you have selected your reviewer and set the date, use the button below to complate step 1. In step 2 you will be able to compose a message to the reviewer.</p>
+                <p>Once you have selected your reviewer and set the date, use the button below to complete step 1. In step 2 you will be able to compose a message to the reviewer.</p>
                 <div class="row expanded">
                     <div class="large-12 columns">
                         <button class="button" name="submit">Complete Step 1</button>

--- a/src/templates/admin/repository/review/manage_review_recommendation.html
+++ b/src/templates/admin/repository/review/manage_review_recommendation.html
@@ -5,7 +5,7 @@
 
 {% block title %}Review Recommendations{% endblock %}
 {% block title-section %}Review Recommendations{% endblock %}
-{% block title-sub %}Manange review recommendations{% endblock %}
+{% block title-sub %}Manage review recommendations{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -23,7 +23,7 @@
             </div>
             <div class="content">
                 <p>You can create, edit and delete review recommendations for your repository using the interface here. </p>
-                <p>Recommendations that are linked to existing reviws cannot be deleted but you can mark them as inactive.</p>
+                <p>Recommendations that are linked to existing reviews cannot be deleted but you can mark them as inactive.</p>
                 <form method="POST">
                     {% csrf_token %}
                     {{ form|foundation }}

--- a/src/templates/admin/repository/review/review_detail.html
+++ b/src/templates/admin/repository/review/review_detail.html
@@ -195,7 +195,7 @@
                     reviewer.</p>
                 <form method="POST">
                     {% csrf_token %}
-                    <label for="withdraw_reason">Withdrawl Reason:</label>
+                    <label for="withdraw_reason">Withdrawal Reason:</label>
                     <textarea id="withdraw_reason" name="withdraw_reason"></textarea>
                     <button type="submit" class="button warning" name="withdraw">Withdraw
                         Invite

--- a/src/templates/admin/repository/submit/files.html
+++ b/src/templates/admin/repository/submit/files.html
@@ -43,7 +43,7 @@
                     <h2>{% trans 'Supplementary files' %}</h2>
                 </div>
                 <div class="content">
-                    <p>{% trans 'Optional links to externaly hosted supplementary files.' %}</p>
+                    <p>{% trans 'Optional links to externally hosted supplementary files.' %}</p>
                     <a href="#" data-open="newsupplementaryfile" class="button" aria-controls="new-supplementary-file" aria-haspopup="true" tabindex="0">{% trans 'Add New Supplementary File' %}</a>
                 </div>
             </div>

--- a/src/templates/admin/submission/edit/author.html
+++ b/src/templates/admin/submission/edit/author.html
@@ -180,7 +180,7 @@
         {% endif %}
       {% else %}
         <p>{% blocktrans with journal_title=journal.name %}
-          This author has not registerd for a user account with <i>{{ journal_title }}</i>.
+          This author has not registered for a user account with <i>{{ journal_title }}</i>.
         {% endblocktrans %}</p>
       {% endif %}
     </section>

--- a/src/templates/common/metadata/preprint_dc.html
+++ b/src/templates/common/metadata/preprint_dc.html
@@ -8,7 +8,7 @@
     <meta name="DC.Identifier.URI" content="{% site_url 'repository_preprint' preprint.pk %}"/>
     <meta name="DC.Rights" content="{{ preprint.license.name | striptags }}"/>
     <meta name="DC.Publisher" content="{{ request.repository.name }}"/>
-    <meta name="DC.Title" content="{{ preperint.title|striptags }}"/>
+    <meta name="DC.Title" content="{{ preprint.title|striptags }}"/>
     {% for author in preprint.authors %}<meta name="DC.Creator" content="{{ author.full_name }}"/>
     {% endfor %}
 

--- a/src/themes/OLH/assets/foundation-sites/customizer/index.html
+++ b/src/themes/OLH/assets/foundation-sites/customizer/index.html
@@ -29,7 +29,7 @@
               <p><a href="http://zurb.com/university/code-skills">Foundation Code Skills</a><br />These online courses offer you a chance to better understand how Foundation works and how you can master it to create awesome projects.</p>
             </div>
             <div class="large-4 medium-4 columns">
-              <p><a href="http://foundation.zurb.com/forum">Foundation Forum</a><br />Join the Foundation community to ask a question or show off your knowlege.</p>
+              <p><a href="http://foundation.zurb.com/forum">Foundation Forum</a><br />Join the Foundation community to ask a question or show off your knowledge.</p>
             </div>
           </div>
           <div class="row">

--- a/src/themes/clean/README.md
+++ b/src/themes/clean/README.md
@@ -1,6 +1,6 @@
 # clean
 
-The clean theme is based on bootstrap 4 and there are som similarities between it and the default theme.
+The clean theme is based on bootstrap 4 and there are some similarities between it and the default theme.
 
 ## install
 

--- a/src/themes/clean/templates/elements/accounts/edit_profile_body_block.html
+++ b/src/themes/clean/templates/elements/accounts/edit_profile_body_block.html
@@ -13,7 +13,7 @@
                 <p>{% blocktrans %}If you want to change your email address you may do so
                     below, however, you will be logged out and
                     your account will be marked as inactive until you follow the
-                    instructions in the verfication email.{% endblocktrans %}
+                    instructions in the verification email.{% endblocktrans %}
                     <strong>{% trans 'Note' %}: </strong>
                     {% blocktrans %}Changing your email address will also change your username
                     as these are one and the same.{% endblocktrans %}</p>

--- a/src/typesetting/templates/typesetting/elements/production_files.html
+++ b/src/typesetting/templates/typesetting/elements/production_files.html
@@ -9,7 +9,7 @@ Deprecated. Use file_list.html instead.
     </div>
     <div class="content">
         <p>
-            <small>Listed below are all the manuscripts, copyedited files and corrections for this paper. Typesetters will also get access to all figure files uploaded by the author. If you need to manage these files use the <a targer="_blank" href="{% url 'document_management' article.pk %}">Document Management</a> page. If you need to upload a newer version use the Upload File button in the top right of this box.</small>
+            <small>Listed below are all the manuscripts, copyedited files and corrections for this paper. Typesetters will also get access to all figure files uploaded by the author. If you need to manage these files use the <a target="_blank" href="{% url 'document_management' article.pk %}">Document Management</a> page. If you need to upload a newer version use the Upload File button in the top right of this box.</small>
         </p>
         <table class="scroll small">
             <tr style="text-align: left">

--- a/src/typesetting/templates/typesetting/index.html
+++ b/src/typesetting/templates/typesetting/index.html
@@ -16,7 +16,7 @@
     journal's <a href="{% url 'core_journal_workflow' %}">configured workflow</a>
 </p>
 <p>
-    This plugin is inteded to replace the original production and proofing workflow elements
+    This plugin is intended to replace the original production and proofing workflow elements
 </p>
 </div>
 {% endblock body %}

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -537,7 +537,7 @@
             "description": "Email sent to reviewers when a review request is withdrawn.",
             "is_translatable": true,
             "name": "review_withdrawl",
-            "pretty_name": "Review Withdrawl",
+            "pretty_name": "Review Withdrawal",
             "type": "rich-text"
         },
         "value": {
@@ -3233,7 +3233,7 @@
         },
         "setting": {
             "type": "char",
-            "pretty_name": "Review Withdrawl",
+            "pretty_name": "Review Withdrawal",
             "is_translatable": true,
             "description": "Subject for Email sent to reviewers when a review request is withdrawn.",
             "name": "subject_review_withdrawl"


### PR DESCRIPTION
```bash
codespell --skip="*css,*.ent,*.js,*.map,*.po,*.py,*.rst,*.xml,*.xsd,*.xsl" \
     --ignore-words-list=notin --write-changes
```