### PR TITLE
Fixed a display bug where the article title was not displayed due to numerous authors

### DIFF
--- a/src/static/common/css/common.css
+++ b/src/static/common/css/common.css
@@ -327,3 +327,11 @@ a.twitter-x{
   font-weight: bold;
   line-height: 1.25;
 }
+
+/* Hotfix for creating a scrollbar when
+ * there are numerous authors, due to limited
+ * display space on OLH and clean themes */
+:not(.show-for-small-only) .article-authors-br {
+  overflow-y: scroll;
+  max-height: 6rem;
+}

--- a/src/templates/common/elements/journal/article_authors_br.html
+++ b/src/templates/common/elements/journal/article_authors_br.html
@@ -1,8 +1,10 @@
-<p>
-  {% for author in article.frozen_authors.all %}
-    {% if forloop.first == False %}
-      <br>
-    {% endif %}
-    {% include "common/elements/journal/article_author_display.html" %}
-  {% endfor %}
-</p>
+<div class="article-authors-br">
+  <p>
+    {% for author in article.frozen_authors.all %}
+      {% if forloop.first == False %}
+        <br>
+      {% endif %}
+      {% include "common/elements/journal/article_author_display.html" %}
+    {% endfor %}
+  </p>
+</div>


### PR DESCRIPTION
Fixes #4952.

I've decided on a minimal intervention here, which is to make the author list scrollable when it is taller than 6 rem.

Moving the authors out of the box as I suggested earlier would entail much more work on this theme and does not fit our strategy for upgrading the themes.

I've opted against hiding the email address behind an icon, because I want users to be able to read it, or select and copy it, without having to hover. Even if we did hide the email address, what if an article has 20 authors? We need a solution for displaying this content that does not depend on knowing the maximum length of the author list.

Another possibility, if people don't like the scrolling solution: when there are more than 3 authors, display a compact, comma-separated list of their names (truncated at about 70 words), with a button below that can expand this out into a line-broken list of full author details, potentially in a popover. This would just take more styling work, again, than we now want to spend on the current themes.