### PR TITLE
Fix a server error that happened when deleting an author copyediting review

### DIFF
--- a/src/copyediting/views.py
+++ b/src/copyediting/views.py
@@ -697,7 +697,7 @@ def delete_author_review(request, article_id, copyedit_id, author_review_id):
         pk=author_review_id,
         assignment__article__journal=request.journal,
     )
-    article = (author_review.assignment.article,)
+    article = author_review.assignment.article
     copyedit = author_review.assignment
 
     email_context = logic.get_author_copyedit_message_context(


### PR DESCRIPTION
Fixes #4939.

The extra comma is from 056b29151b86ec3ece82d2ea4a3bbe47100bad52. Ruff formatting made the tuple look intentional but it was just a typo.