### PR TITLE
Update to fix issues with building plugins and Mac OS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,4 @@ src/files/issues
 src/files/press
 src/files/temp
 src/files/xsl
-src/plugins/*
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get install -y pylint
 RUN apt-get install -y gettext
 RUN pip3 install -r requirements.txt --src /tmp/src
 RUN pip3 install -r dev-requirements.txt --src /tmp/src
+RUN find "/vol/janeway/src/plugins/" -print -iname "*requirements.txt" -exec pip3 install -r {} --src /tmp/src \;
 RUN pip3 install mysqlclient
 RUN if [ -n "$(ls -A ./lib)" ]; then pip3 install -e lib/*; fi
 RUN cp src/core/janeway_global_settings.py src/core/settings.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ Pillow==10.2.0
 python-crontab==2.2.3
 python-dateutil==2.8.1
 python-docx==0.8.11
-python-magic==0.4.13
+python-magic==0.4.27
 pytz==2024.1
 requests==2.32.4
 six==1.16.0


### PR DESCRIPTION
This update fixes an issue with various MacOS builds by updating the python-magic to a newer version as well as fixes an issue with building plugins using the `make` file. 