### PR TITLE
feat: make on revisions requested event fire

### DIFF
--- a/src/events/logic.py
+++ b/src/events/logic.py
@@ -77,7 +77,7 @@ class Events:
     # raised when an editor accepts or accepts an article
     ON_ARTICLE_ACCEPTED = "on_article_accepted"
 
-    # kwargs: article, revision, request, user_message_content, skip (boolean)
+    # kwargs: article, revision, request
     # raised when a revision request is created
     ON_REVISIONS_REQUESTED = "on_revisions_requested"
 

--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -582,6 +582,15 @@ def handle_decision_action(article, draft, request):
         article.stage = submission_models.STAGE_UNDER_REVISION
         article.save()
 
+        event_logic.Events.raise_event(
+            event_logic.Events.ON_REVISIONS_REQUESTED,
+            **{
+                "article": article,
+                "revision": revision,
+                "request": request,
+            },
+        )
+
         kwargs["user_message_content"] = revision_rendered_template
         kwargs["revision"] = revision
         event_logic.Events.raise_event(

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -2034,6 +2034,16 @@ def request_revisions(request, article_id):
             article.stage = submission_models.STAGE_UNDER_REVISION
             article.save()
 
+            kwargs = {
+                "article": article,
+                "revision": revision_request,
+                "request": request,
+            }
+            event_logic.Events.raise_event(
+                event_logic.Events.ON_REVISIONS_REQUESTED,
+                **kwargs,
+            )
+
             return redirect(
                 reverse(
                     "request_revisions_notification",


### PR DESCRIPTION
This PR adds functionality for firing the ON_REVISIONS_REQUESTED event.

Previously, the event was declared in events/logic.py but never actually triggered anywhere in the codebase. With this change, the event is now raised whenever a revision request is created (e.g. from the request_revisions view or via handle_decision_action).

### Event kwargs

The docstring in events/logic.py currently lists the kwargs as:

`article`, `revision`, `request`, `user_message_content`, `skip`

In this implementation I removed two of the arguments:
`skip`: the Request Revisions form does not provide a "skip" option, so this argument would always be empty/false and potentially misleading.
`user_message_content`: the editor’s note is already stored in the revision object. Also in the case of other events e.g. "ON_REQUEST_REVISIONS_NOTIFY" this argument is used to transmit email contents but in the case of "ON_REVIEWS_REQUESTED" there is no email-content yet.

### Reasons for the change:
All other major article stage changes also trigger an event, making ON_REVISIONS_REQUESTED behave consistent with the workflow.
Also added to support the development of the Review Quality Collector Adapter Plugin (https://reviewqualitycollector.org/) for Janeway since the RQC-API requires transmitting changes in the editorial decision for an article.