### PR TITLE
fix copy citation button not working on clean

### DIFF
--- a/src/themes/clean/templates/elements/journal/citation_modals.html
+++ b/src/themes/clean/templates/elements/journal/citation_modals.html
@@ -10,14 +10,12 @@
                 </div>
                 <div class="modal-body">
                     <p>
-                        <span id="harvard-cite">
-                            <ul class="list-inline comma-ampersand-sep">
-                                {% for author in article.frozenauthor_set.all %}
-                                    <li>{{ author.last_name }}, {{ author.first_name|slice:"1" }}</li>
-                                {% endfor %}
-                            </ul>
-                            ({{ article.date_published.year }}) '{{ article.title|safe }}',
-                            <em>{% if journal.name %}{{ journal.name }}{% else %}{{ request.press.name }} Preprints{% endif %}</em>. {% if article.issue %}{{ article.issue.volume }}({{ article.issue.issue }}){% endif %}{% if article.page_range %}:{{ article.page_range }}.{% endif %}
+                        <span id="harvard-cite">{% for author in article.frozenauthor_set.all %}
+                            {% if not forloop.first and not forloop.last %},
+                            {% elif forloop.last and not forloop.first %}& {% endif %}{{ author.last_name }},
+                                {{ author.first_name|slice:"1" }}{% if forloop.last %}.{% endif %} {% endfor %}
+                                ({{ article.date_published.year }}) '{{ article.title|safe }}',
+                                <em>{% if journal.name %}{{ journal.name }}{% else %}{{ request.press.name }} Preprints{% endif %}</em>. {% if article.issue %}{{ article.issue.volume }}({{ article.issue.issue }}){% endif %}{% if article.page_range %}:{{ article.page_range }}.{% endif %}
                             {% if article.identifier.id_type == 'doi' %}
                                 {% include "elements/doi_display.html" with doi=article.identifier.identifier title=article.title %}
                             {% endif %}
@@ -43,15 +41,12 @@
                 </div>
                 <div class="modal-body">
                     <p>
-                        <span id="vancouver-cite">
-                            <ul class="list-inline comma-ampersand-sep">
-                                {% for author in article.frozenauthor_set.all %}
-                                    <li>{{ author.last_name }}, {{ author.first_name|slice:"1" }}</li>
-                                {% endfor %}
-                            </ul>
-                            {{ article.title|safe }}. {% if journal.name %}{{ journal.name }}{% else %}{{ request.press.name }} Preprints{% endif %}. {{ article.date_published.year }} {{ article.date_published.month }};{% if article.issue %} {{ article.issue.volume }}({{ article.issue.issue }}){% endif %}{% if article.page_range %}:{{ article.page_range }}.{% endif %}
-                            {% if article.identifier.id_type == 'doi' %}
-                                {% include "elements/doi_display.html" with doi=article.identifier.identifier title=article.title %}
+                        <span id="vancouver-cite">{% for author in article.frozenauthor_set.all %}{% if not forloop.first and not forloop.last %},
+                            {% elif forloop.last and not forloop.first %}& {% endif %}{{ author.last_name }},
+                                {{ author.first_name|slice:"1" }}{% if forloop.last %}.{% endif %} {% endfor %}
+                                {{ article.title|safe }}. {% if journal.name %}{{ journal.name }}{% else %}{{ request.press.name }} Preprints{% endif %}. {{ article.date_published.year }} {{ article.date_published.month }};{% if article.issue %} {{ article.issue.volume }}({{ article.issue.issue }}){% endif %}{% if article.page_range %}:{{ article.page_range }}.{% endif %}
+                                {% if article.identifier.id_type == 'doi' %}
+                                    {% include "elements/doi_display.html" with doi=article.identifier.identifier title=article.title %}
                             {% endif %}
                         </span>
                         {% include "admin/elements/button_copy_element.html" with element_id="vancouver-cite" %}
@@ -75,12 +70,9 @@
                 </div>
                 <div class="modal-body">
                     <p>
-                        <span id="apa-cite">
-                            <ul class="list-inline comma-ampersand-sep">
-                                {% for author in article.frozenauthor_set.all %}
-                                    <li>{{ author.last_name }}, {{ author.first_name|slice:"1" }}</li>
-                                {% endfor %}
-                            </ul>
+                        <span id="apa-cite">{% for author in article.frozenauthor_set.all %}{% if forloop.last %}{% if not forloop.first %}
+                            &amp; {% endif %}{% endif %}{{ author.last_name }},
+                            {{ author.first_name|slice:"1" }}{% if forloop.last %}.{% endif %} {% endfor %}
                             ({{ article.date_published.year }}, {{ article.date_published.month }} {{ article.date_published.day }}). {{ article.title|safe }}.
                             <em>{% if journal.name %}{{ journal.name }}{% else %}{{ request.press.name }} {% trans 'Preprints' %}{% endif %}</em> {% if article.issue %}{{ article.issue.volume }}({{ article.issue.issue }}){% endif %}{% if article.page_range %}:{{ article.page_range }}.{% endif %}
                             {% if article.identifier.id_type == 'doi' %}


### PR DESCRIPTION
In [b-4890-loop-a11y-syntax](https://github.com/openlibhums/janeway/tree/b-4890-loop-a11y-syntax) while updating list syntax for loops across the theme, I updated the citation modals too. But on testing Clarity I found this breaks the copy citation function in two ways. First it places lists inside a span, which is invalid HTML and so they end up with an empty span and the lists afterwards. But the copy button is aiming at the span element, so effectively, it copies nothing. Changing out the span for a div doesn't work either, as having a list inside when copy/pasting ends up with bullets being added in when pasting into word. 

So the best solution seems to be to revert the original change.  I have also made the same change to Clarity in #5000.

This PR reverts 55fa11f52 a11y: #4890 update non-visible list syntax on clean
