### PR TITLE
Removes the subtitle field from the submission configurator as this h…

### DIFF
--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -445,7 +445,10 @@ class ConfiguratorForm(forms.ModelForm):
 
     class Meta:
         model = models.SubmissionConfiguration
-        exclude = ("journal", "subtitle",)
+        exclude = (
+            "journal",
+            "subtitle",
+        )
 
 
 class ProjectedIssueForm(forms.ModelForm):

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -445,7 +445,7 @@ class ConfiguratorForm(forms.ModelForm):
 
     class Meta:
         model = models.SubmissionConfiguration
-        exclude = ("journal",)
+        exclude = ("journal", "subtitle",)
 
 
 class ProjectedIssueForm(forms.ModelForm):

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -3284,6 +3284,7 @@ class SubmissionConfiguration(models.Model):
     competing_interests = models.BooleanField(default=True)
     comments_to_the_editor = models.BooleanField(default=True)
 
+    subtitle = models.BooleanField(default=False)
     abstract = models.BooleanField(default=True)
     language = models.BooleanField(default=True)
     license = models.BooleanField(default=True)

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -3284,7 +3284,6 @@ class SubmissionConfiguration(models.Model):
     competing_interests = models.BooleanField(default=True)
     comments_to_the_editor = models.BooleanField(default=True)
 
-    subtitle = models.BooleanField(default=False)
     abstract = models.BooleanField(default=True)
     language = models.BooleanField(default=True)
     license = models.BooleanField(default=True)


### PR DESCRIPTION
Removes the subtitle field from the submission configurator as this has been deprecated. En/disabling it does not have any impact on the submission fields as is. This was a phantom tick box.

Closes #4888 

This hides it from view and makes the subtitle setting accessible only from admin.