### PR TITLE
Fixes a bug that was stopping all CREDIT roles from displaying

### DIFF
--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -510,7 +510,6 @@ class CreditRecordForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.frozen_author = kwargs.pop("frozen_author", None)
         super().__init__(*args, **kwargs)
-        self.fields["role"].choices = self.fields["role"].choices[1:]
 
         if self.frozen_author:
             self._remove_choices_when_roles_already_exist(


### PR DESCRIPTION
RadioSelect does not add a blank entry to the choices list so we don't need to slice the list.