### PR TITLE
Raise 404 error for non-existing issue sitemaps

### DIFF
--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -2199,7 +2199,8 @@ def sitemap(request, issue_id=None):
     :return: HttpResponse object
     """
     if issue_id:
-        issue = models.Issue.objects.get(
+        issue = get_object_or_404(
+            Issue,
             pk=issue_id,
             journal=request.journal,
         )


### PR DESCRIPTION
We had this issue when a bot picked up the URL of the sitemap for an Issue that was then deleted.

Roughly every two days the bot GETs the old URL and we get a 500 :slightly_smiling_face: 
