### PR TITLE
Fix editor_or_manager decorator and add additional_nav hook

### DIFF
--- a/src/security/decorators.py
+++ b/src/security/decorators.py
@@ -145,7 +145,10 @@ def editor_or_manager(func):
         if request.user.is_staff:
             return func(request, *args, **kwargs)
 
-        if request.journal and request.user in request.journal.editor_list():
+        if request.journal and (
+            request.user.is_editor(request)
+            or request.user.is_journal_manager(request.journal)
+        ):
             return func(request, *args, **kwargs)
 
         if request.repository and request.user in request.repository.managers.all():

--- a/src/templates/admin/core/nav.html
+++ b/src/templates/admin/core/nav.html
@@ -140,6 +140,7 @@
             </li>
             {% hook 'journal_admin_nav_block' %}
         {% endif %}
+        {% hook 'additional_nav' %}
         <li class="subtitle">
             <a href="#">Version: {{ version }}</a>
         </li>


### PR DESCRIPTION
`editor_or_manager` referenced `Journal.editor_list()` which does not exist. Replace with is_editor/is_journal_manager matching editor_user_required.

Add additional_nav hook call to core nav so plugins can inject nav links for any user type by checking context in their own templates.

Closes https://github.com/openlibhums/janeway/issues/4308 with https://github.com/openlibhums/reporting/pull/49