### PR TITLE
Remove circular import

### DIFF
--- a/src/journal/forms.py
+++ b/src/journal/forms.py
@@ -13,7 +13,7 @@ from tinymce.widgets import TinyMCE
 
 from core import models as core_models
 from core.forms import FullSettingEmailForm
-from journal import models as journal_models, logic
+from journal import models as journal_models
 from utils.forms import CaptchaForm
 
 SEARCH_SORT_OPTIONS = [

--- a/src/review/tests.py
+++ b/src/review/tests.py
@@ -296,7 +296,7 @@ class ReviewTests(TestCase):
             article=article1,
             is_complete=False,
             review_round=round,
-            reviewer=self.regular_user,
+            reviewer=self.third_reviewer,
         )
         assignment.decision = None
         assignment.save()
@@ -358,7 +358,7 @@ class ReviewTests(TestCase):
             article=article_with_completed_reviews,
             is_complete=False,
             review_round=round_two,
-            reviewer=self.regular_user,
+            reviewer=self.third_reviewer,
         )
 
         # turn setting on
@@ -710,6 +710,12 @@ class ReviewTests(TestCase):
         self.second_reviewer.is_active = True
         self.second_reviewer.save()
 
+        self.third_reviewer = self.create_user(
+            "third_reviewer@invalid.com", ["reviewer"], journal=self.journal_one
+        )
+        self.third_reviewer.is_active = True
+        self.third_reviewer.save()
+
         self.public_file = core_models.File(
             mime_type="A/FILE",
             original_filename="blah.txt",
@@ -845,7 +851,7 @@ class ReviewTests(TestCase):
         self.review_assignment_complete = review_models.ReviewAssignment(
             article=self.article_review_completed,
             review_round=self.round_one,
-            reviewer=self.regular_user,
+            reviewer=self.third_reviewer,
             editor=self.editor,
             date_due=timezone.now(),
             form=self.review_form,
@@ -905,7 +911,7 @@ class ReviewTests(TestCase):
 
         self.review_assignment_not_in_scope = review_models.ReviewAssignment(
             article=self.article_in_production,
-            reviewer=self.regular_user,
+            reviewer=self.third_reviewer,
             editor=self.editor,
             date_due=timezone.now(),
             form=self.review_form,


### PR DESCRIPTION
`journal.forms` imports `journal.logic` which in turn imports `journal.forms`.

`logic` is not used in `journal.forms` code, so it's a redundant import in any case.

This has not triggered any error just due to a lucky combination of factors, but changes in WJS project triggers this error 🙂

(thanks @yakky for noticing)
