### PR TITLE
fix: save tinymce edits to proofing task

### DIFF
--- a/src/templates/admin/typesetting/typesetting_manage_proofing_assignment.html
+++ b/src/templates/admin/typesetting/typesetting_manage_proofing_assignment.html
@@ -177,7 +177,3 @@
         </div>
     </div>
 {% endblock body %}
-
-{% block js %}
-{% include "elements/jqte.html" %}
-{% endblock js %}


### PR DESCRIPTION
fixes bug reported in ticket 12047. 

edits to the tinymce when managing a proofing task were not saving.  The date changes were saving.