### PR TITLE
ENH: Expose issue sections in issue page context

### DIFF
--- a/src/journal/tests/test_journal_frontend.py
+++ b/src/journal/tests/test_journal_frontend.py
@@ -118,6 +118,69 @@ class TestJournalSite(TestCase):
         self.assertContains(response, "Volume 4")
         self.assertContains(response, self.article_title)
 
+    def test_issue_sections_context_is_not_paginated(self):
+        first_section = self.published_article.section
+        second_section = helpers.create_section(
+            self.journal,
+            name="Review",
+            plural="Reviews",
+            sequence=999,
+        )
+        unpublished_section = helpers.create_section(
+            self.journal,
+            name="Draft",
+            plural="Drafts",
+            sequence=1000,
+        )
+
+        for num in range(50):
+            article = helpers.create_article(
+                journal=self.journal,
+                title=f"Extra issue article {num}",
+                stage="Published",
+                section=first_section,
+                date_published=timezone.now(),
+            )
+            self.issue.articles.add(article)
+
+        second_section_article = helpers.create_article(
+            journal=self.journal,
+            title="Second section article",
+            stage="Published",
+            section=second_section,
+            date_published=timezone.now(),
+        )
+        self.issue.articles.add(second_section_article)
+
+        unpublished_article = helpers.create_article(
+            journal=self.journal,
+            title="Unpublished section article",
+            stage="Unassigned",
+            section=unpublished_section,
+        )
+        self.issue.articles.add(unpublished_article)
+
+        response = self.client.get(
+            reverse(
+                "journal_issue",
+                kwargs={
+                    "issue_id": self.issue.pk,
+                },
+            ),
+            SERVER_NAME=self.journal_domain,
+        )
+
+        article_page_sections = {
+            article.section for article in response.context["articles"]
+        }
+        self.assertIn(first_section, article_page_sections)
+        self.assertNotIn(second_section, article_page_sections)
+
+        self.assertEqual(
+            response.context["issue_sections"],
+            [first_section, second_section],
+        )
+
     def test_become_reviewer_page(self):
         self.client.force_login(
             self.new_user,

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -344,8 +344,17 @@ def issue(request, issue_id, show_sidebar=True):
         date__lte=timezone.now(),
     )
 
+    sorted_articles = issue_object.get_sorted_articles()
+    issue_sections = []
+    seen_section_ids = set()
+
+    for article in sorted_articles:
+        if article.section_id not in seen_section_ids:
+            issue_sections.append(article.section)
+            seen_section_ids.add(article.section_id)
+
     page = request.GET.get("page", 1)
-    paginator = Paginator(issue_object.get_sorted_articles(), 50)
+    paginator = Paginator(sorted_articles, 50)
 
     try:
         articles = paginator.page(page)
@@ -373,6 +382,7 @@ def issue(request, issue_id, show_sidebar=True):
         "issues": issue_objects,
         "structure": issue_object.structure,  # for backwards compatibility
         "articles": articles,
+        "issue_sections": issue_sections,
         "editors": editors,
         "show_sidebar": show_sidebar,
     }


### PR DESCRIPTION
## Summary

This adds an `issue_sections` context variable to the journal issue view.

`issue_sections` is built from the issue’s unpaginated, sorted, published articles and preserves the section order while removing duplicate sections.

## Rationale

Issue templates may need a section-level table of contents or navigation. The existing `articles` context is paginated, so grouping `articles` by section can miss sections that only appear on later pages.

Providing `issue_sections` gives themes a stable section list independent of article pagination, while keeping the existing paginated `articles` context unchanged.

## Implementation

- Reuses `issue_object.get_sorted_articles()` once in the issue view.
- Builds `issue_sections` before pagination.
- Keeps `articles` paginated as before.
- Exposes `issue_sections` alongside the existing issue context.

## Tests

Added a regression test that verifies:

- `issue_sections` includes a section whose article falls beyond the first paginated page.
- `issue_sections` excludes sections that only contain unpublished articles.
- The existing paginated `articles` context remains paginated.

Test run:

```bash
lando python manage.py test journal.tests.test_journal_frontend.TestJournalSite.test_issue_sections_context_is_not_paginated