### PR TITLE
fix: #5329 repair unit tests after v1.8.0 merge

### DIFF
--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -4,6 +4,7 @@ __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
 import os
+import re
 import uuid
 import json
 from dateutil import parser as dateparser
@@ -604,6 +605,36 @@ class PreprintSearchManager(model_utils.BaseSearchManagerMixin):
                 date_published__isnull=False,
             )
         return queryset
+
+    def _search(self, search_term, search_filters, sort=None, site=None, queryset=None):
+        """SQLite-compatible search across preprint fields.
+
+        The base implementation targets Article's ``frozenauthor`` relation,
+        which Preprint does not have, so we mirror the Postgres/MySQL author
+        lookups against the ``preprintauthor`` relation here.
+        """
+        preprints = queryset or self.get_queryset()
+        if search_term:
+            escaped = re.escape(search_term)
+            split_term = [re.escape(word) for word in search_term.split(" ")]
+            split_term.append(escaped)
+            search_regex = "^({})$".format("|".join({name for name in split_term}))
+            q_object = Q()
+            if search_filters.get("title"):
+                q_object = q_object | Q(title__icontains=search_term)
+            if search_filters.get("abstract"):
+                q_object = q_object | Q(abstract__icontains=search_term)
+            if search_filters.get("keywords"):
+                q_object = q_object | Q(keywords__word=search_term)
+            if search_filters.get("authors"):
+                q_object = q_object | (
+                    Q(preprintauthor__account__first_name__iregex=search_regex)
+                    | Q(preprintauthor__account__last_name__iregex=search_regex)
+                )
+            preprints = preprints.filter(q_object)
+            if site:
+                preprints = preprints.filter(repository=site)
+        return preprints.distinct()
 
     def mysql_search(
         self, search_term, search_filters, sort=None, site=None, queryset=None

--- a/src/review/tests/test_views.py
+++ b/src/review/tests/test_views.py
@@ -641,6 +641,7 @@ class ReviewTests(TestCase):
             "editoruser@martineve.com", ["editor"], journal=self.journal_one
         )
         self.editor.is_active = True
+        self.editor.save()
         self.reviewer = self.create_user(
             "revieweruser@email.com", ["reviewer"], journal=self.journal_one
         )

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -431,7 +431,7 @@ def assignment_notification(request, article_id, editor_id):
 
     template = "review/assignment_notification.html"
     context = {
-        "article": article_id,
+        "article": article,
         "editor": editor,
         "assignment": assignment,
         "form": form,

--- a/src/templates/admin/elements/contacts_box_person.html
+++ b/src/templates/admin/elements/contacts_box_person.html
@@ -1,8 +1,9 @@
+{% load securitytags %}
 <p>
-    <strong>{{ person.full_name }}</strong>
+    <strong>{{ person.full_name|se_can_see_pii:article }}</strong>
     <a onclick="return popitup('{% url 'send_user_email_article' person.pk article.pk %}')">
         <i class="fa fa-envelope-o" aria-hidden="true"></i>
     </a><br>
-    <small>{{ person.real_email }}</small><br>
+    <small>{{ person.real_email|se_can_see_pii:article }}</small><br>
     <small>{{ role }}</small>
 </p>

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -152,39 +152,7 @@
                                         <li>
                                             <a target="_blank" href="{% url 'article_view_galley' article.id galley.id %}">{% trans "View" %} {{ galley.label }}</a>
                                     {% endif %}
-                                {% endfor %}
-                            </ul>
-                            {% if proofing %}
-                                <p id="note_to_proofreader_2">
-                                    <i aria-hidden="true" class="fa fa-info"></i>
-                                    Note to proofreader: Download links on this page begin to work when the article is published.
-                                </p>
-                            {% endif %}
-                        {% else %}
-                            <p> {% trans 'Downloads are not available for this article.' %}</p>
-                        {% endif %}
-                    {% endif %}
-                    {% include "elements/journal/share.html" %}
-                    <h2>{% trans "Files" %}</h2>
-                    {% if galleys %}
-                        <ul>
-                            {% for galley in galleys %}
-                                {% if not galley.label == 'HTML' or not galley.file.mime_type == 'text/html' %}
-                                        {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
-                                            &nbsp;
-                                            <li>
-                                                <a target="_blank" href="{% url 'article_view_galley' article.id galley.id %}">
-                                                    {% trans "View" %} {{ galley.label }}
-                                                    {% include "elements/icons/link_new_tab.html" %}
-                                                </a>
-                                            </li>
-                                        {% endif %}
-                                        <li>
-                                            <a href="{% url 'article_download_galley' article.id galley.id %}">
-                                                {{ galley.label }}
-                                                {% include "elements/icons/link_download.html" %}
-                                            </a>
-                                        </li>
+                                </li>
                                 {% endif %}
                             {% endfor %}
                         </ul>
@@ -197,6 +165,7 @@
                     {% else %}
                         <p> {% trans 'Downloads are not available for this article.' %}</p>
                     {% endif %}
+                    {% include "elements/journal/share.html" %}
                 {% endif %}
                 {% if article.supplementary_files.all %}
                     <h3>{% trans "Supplementary Files" %}</h3>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -284,48 +284,9 @@
                                         {% endif %}
                                     </li>
                                 {% endfor %}
-                            </ul>    
+                            </ul>
                         {% endif %}
-
-                        <div class="spacer">
-                            <div class="divider"></div>
-                        </div>
-                        {% if article.is_published or proofing %}
-                            <h2>
-                                {% trans "Files" %}
-                            </h2>
-                            {% if galleys %}
-                                <ul>
-                                    {% for galley in galleys %}
-                                        {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
-                                            <li>
-                                                <a target="_blank" href="{% url 'article_view_galley' article.id galley.id %}">
-                                                    {% trans "View" %} {{ galley.label }}
-                                                    {% include "elements/icons/link_new_tab.html" %} 
-                                                </a>
-                                            </li>
-                                        {% endif %}
-                                        <li>
-                                            <a href="{% url 'article_download_galley' article.id galley.id %}">
-                                                {{ galley.label }}
-                                                {% include "elements/icons/link_download.html" %} 
-                                            </a>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                                {% if proofing %}
-                                    <p id="note_to_proofreader_2">
-                                        <i aria-hidden="true" class="fa fa-info-circle" ></i>
-                                        Note to proofreader: Download links on this page begin to work when the article is published.
-                                    </p>
-                                {% endif %}
-                                <div class="spacer">
-                                    <div class="divider"></div>
-                                </div>
-                            {% else %}
-                                <p> {% trans 'Downloads are not available for this article.' %}</p>
-                            {% endif %}
-                        {% endif %}
+                    {% endif %}
 
                         {% include "elements/journal/article_issue_list.html" %}
                         <div class="spacer">

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5319,19 +5319,6 @@
     }
   },
   {
-    "value": {"default": "Production Complete"},
-    "setting": {
-        "type": "char",
-        "pretty_name": "Production Complete",
-        "is_translatable": true,
-        "description": "Subject for Email sent to Editors when Production is Complete.",
-        "name": "subject_production_complete"
-    },
-    "group": {
-        "name": "email_subject"
-    }
-  },
-  {
     "group": {
         "name": "email"
     },
@@ -5663,6 +5650,18 @@
             "is_translatable": false,
             "name": "author_affiliation_dates",
             "pretty_name": "Author Affiliation Dates",
+            "type": "boolean"
+        },
+        "value": {
+            "default": "on"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "group": {
             "name": "general"
         },
         "setting": {

--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -3,12 +3,15 @@ __author__ = "Martin Paul Eve & Andy Byers"
 __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
+import codecs
 import io
+import json
 import os
 
 from bs4 import BeautifulSoup
 
 from django.apps import apps
+from django.conf import settings
 from django.http import QueryDict
 from django.test import TestCase, override_settings
 from django.utils import timezone, translation
@@ -1603,3 +1606,71 @@ class CheckMailgunStatCommandTests(TestCase):
         call_command("check_mailgun_stat")
         self.log_entry.refresh_from_db()
         self.assertEqual(self.log_entry.message_status, "accepted")
+
+
+class DefaultSettingsIntegrityTests(TestCase):
+    """Guards against malformed entries in journal_defaults.json.
+
+    A botched merge once fused two setting entries together, producing
+    duplicate JSON keys. The file still parsed, but the duplicated keys
+    silently dropped a setting, which only surfaced as DoesNotExist errors
+    deep in unrelated tests. These checks fail fast and point at the file.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.file_path = os.path.join(
+            settings.BASE_DIR,
+            "utils/install/journal_defaults.json",
+        )
+        with codecs.open(cls.file_path, encoding="utf-8") as json_data:
+            cls.raw = json_data.read()
+
+    def reject_duplicate_keys(self, pairs):
+        keys = [key for key, value in pairs]
+        duplicates = [key for key in set(keys) if keys.count(key) > 1]
+        if duplicates:
+            raise AssertionError(
+                "Duplicate keys {} in journal_defaults.json object {}".format(
+                    duplicates, dict(pairs)
+                )
+            )
+        return dict(pairs)
+
+    def test_no_duplicate_keys(self):
+        # object_pairs_hook runs for every object, so a duplicate key
+        # anywhere in the file raises rather than silently winning.
+        json.loads(self.raw, object_pairs_hook=self.reject_duplicate_keys)
+
+    def test_every_setting_is_well_formed(self):
+        default_data = json.loads(self.raw)
+        for item in default_data:
+            self.assertIn("group", item)
+            self.assertIn("setting", item)
+            self.assertIn("value", item)
+            self.assertTrue(item["group"].get("name"))
+            self.assertTrue(item["setting"].get("name"))
+            self.assertTrue(item["setting"].get("type"))
+
+    def test_setting_names_are_unique_within_group(self):
+        default_data = json.loads(self.raw)
+        seen = set()
+        for item in default_data:
+            key = (item["group"]["name"], item["setting"]["name"])
+            self.assertNotIn(
+                key,
+                seen,
+                msg="Duplicate setting {} in journal_defaults.json".format(key),
+            )
+            seen.add(key)
+
+    def test_author_affiliation_dates_setting_present(self):
+        # Regression check for the specific setting dropped by the merge.
+        default_data = json.loads(self.raw)
+        matches = [
+            item
+            for item in default_data
+            if item["group"]["name"] == "metadata"
+            and item["setting"]["name"] == "author_affiliation_dates"
+        ]
+        self.assertEqual(len(matches), 1)


### PR DESCRIPTION
Repairs failures introduced by the v1.8.0 merge:

- journal_defaults.json: split the fused author_affiliation_dates / a11y_public_info entry (duplicate keys silently dropped the setting, causing Setting.DoesNotExist) and remove a duplicate subject_production_complete entry.
- clean and material article templates: close unclosed {% if %} blocks and remove duplicated galley download blocks (also fixes a duplicate note_to_proofreader_2 id).
- review notify tests: save the active editor so editor_user_required does not redirect to login; assignment_notification view now passes the article object (not its pk) to the template so se_can_see_pii works.
- repository: add a SQLite _search override on PreprintSearchManager using preprintauthor (the base hardcodes Article's frozenauthor).
- contacts_box_person.html: anonymise author name/email with se_can_see_pii so section editors cannot see PII.
- add DefaultSettingsIntegrityTests to guard journal_defaults.json.