### PR TITLE
Fix build From header using formataddr instead of sanitize_address

### DIFF
--- a/src/utils/notify_plugins/notify_email.py
+++ b/src/utils/notify_plugins/notify_email.py
@@ -1,12 +1,10 @@
 import re
 
 from collections.abc import Iterable
-from email.utils import parseaddr
+from email.utils import formataddr
 
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
-from django.core.mail.message import sanitize_address
-from django.utils.encoding import force_str
 from django.utils.html import strip_tags
 
 from utils import setting_handler
@@ -50,7 +48,7 @@ def send_email(
         else:
             to = [to]
     elif isinstance(to, Iterable):
-        to = [email for email in to if not settings.DUMMY_EMAIL_DOMAIN in email]
+        to = [email for email in to if settings.DUMMY_EMAIL_DOMAIN not in email]
 
     if (
         request
@@ -59,27 +57,15 @@ def send_email(
         and request.user.email not in to
     ):
         reply_to = [request.user.email]
-        full_from_string = '"{0}" <{1}>'.format(
-            sanitize_from(request.user.full_name()),
-            from_email,
-        )
+        from_name = request.user.full_name()
     else:
         reply_to = []
-        if request:
-            full_from_string = '"{0}" <{1}>'.format(
-                sanitize_from(request.site_type.name), from_email
-            )
-        else:
-            full_from_string = from_email
+        from_name = request.site_type.name if request else None
 
-    # handle django 3.2 raising an exception when invalid characters are found
-    # during sanitization (call ported from Django 1.11)
-    full_from_string = parseaddr(force_str(full_from_string))
-    # As per #3545, not all backends sanitize from string before .send()
-    full_from_string = sanitize_address(
-        full_from_string,
-        settings.DEFAULT_CHARSET,
-    )
+    if from_name:
+        full_from_string = formataddr((sanitize_from(from_name), from_email))
+    else:
+        full_from_string = from_email
 
     # if a replyto is passed to this function, use that.
     if replyto:
@@ -186,7 +172,7 @@ def notify_hook(**kwargs):
 
     log_dict = kwargs.get("log_dict", None)
 
-    if not type(to) in [list, tuple, set]:
+    if type(to) not in [list, tuple, set]:
         to = [to]
 
     if log_dict:

--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -51,7 +51,6 @@ from utils.testing import helpers
 from utils.testing.context_managers import janeway_setting_override
 from utils.shared import clear_cache
 from utils.notify_plugins import notify_email
-from utils.management.commands import check_mailgun_stat
 
 from journal import (
     models as journal_models,
@@ -926,6 +925,54 @@ class NotifyEmail(TestCase):
         ) as msg:
             notify_email.send_email(*args, **kwargs)
             self.assertIn(kwargs["replyto"], msg.call_args.kwargs["reply_to"])
+
+    def test_from_header_robust_to_weird_display_names(self):
+        """
+        Tests that long, non-ASCII and otherwise awkward display ames must produce
+        a valid, single-line, ASCII-safe From header.
+        """
+        long_name = (
+            "Some Very Long Journal Name That Easily Exceeds Seventy "
+            "Eight Characters Per Line Indeed"
+        )
+        weird_names = [
+            "Journal of Things",
+            long_name,
+            "A" * 120,
+            "Jöurnal of Ünicøde",
+            "Ö" + long_name,
+            "人文学期刊",
+            "Journal \U0001f600 of Fun",
+            "Real Name\r\nBcc: attacker@example.com",
+            "Real Name\nX-Evil: 1",
+            'He said "<hello>" today',
+            "Smith, John, Editor in Chief",
+            "Tabbed\tName",
+            "Re: Important: Journal",
+            "    ",
+            "é" * 120,
+        ]
+
+        for name in weird_names:
+            with self.subTest(name=name):
+                mail.outbox = []
+                request = mock.Mock()
+                request.FILES = None
+                request.site_type.name = name
+
+                notify_email.send_email(
+                    "subject",
+                    "to@example.com",
+                    "html_body",
+                    self.journal_one,
+                    request,
+                )
+
+                self.assertEqual(len(mail.outbox), 1)
+                from_header = mail.outbox[0].message()["From"]
+                self.assertNotIn("\n", from_header)
+                self.assertNotIn("\r", from_header)
+                from_header.encode("ascii")
 
 
 class TestOIDC(TestCase):


### PR DESCRIPTION
Closes #5320 

As discussed with Mauro I opted for a simple solution here and will open a new issue for a Janeway 2.0 change.