### PR TITLE
B 5342 olh licence overflow r1.9x

### DIFF
--- a/src/themes/OLH/assets/scss/app.scss
+++ b/src/themes/OLH/assets/scss/app.scss
@@ -757,6 +757,16 @@ div.caption span.label {
   .bottom {
     background: var(--primary-light-color);
   }
+
+
+  #license {
+    max-width: 100%;
+
+    p {
+      white-space: normal;
+      overflow-wrap: break-word;
+    }
+  }
 }
 
 footer {


### PR DESCRIPTION
cherry-picking #5345 which fixed  #5342 on master as this is important for  colour contrast improvements in 1.9.