### PR TITLE
fix: #5348 escape literal % in search SQL before Article.objects.raw()

### DIFF
--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -893,6 +893,14 @@ class ArticleSearchManager(BaseSearchManagerMixin):
         # distinct fields to match order_by fields
         inner_sql = self.stringify_queryset(queryset)
 
+        # stringify_queryset() returns SQL with every parameter already
+        # interpolated via cursor.mogrify(), so any '%' left in the string is a
+        # literal (e.g. from a search term like "50%" or a LIKE pattern). Article
+        # .objects.raw() defaults params to () rather than None, so it re-runs
+        # %-formatting on this SQL and chokes on those literal '%'. Double them so
+        # they survive that pass unchanged. (#5348)
+        inner_sql = inner_sql.replace("%", "%%")
+
         if "relevance" in sort:
             # Relevance is not a field but an annotation
             return Article.objects.raw(

--- a/src/submission/tests/test_article_search.py
+++ b/src/submission/tests/test_article_search.py
@@ -183,3 +183,39 @@ class ArticleSearchTests(TransactionTestCase):
         result = [a for a in queryset]
 
         self.assertEqual(result, [article])
+
+    @override_settings(ENABLE_FULL_TEXT_SEARCH=True)
+    def test_article_search_term_containing_percent(self):
+        """A search term containing '%' must not raise (#5348).
+
+        stringify_queryset() mogrifies the term into the raw SQL, so a literal
+        '%' from the term reaches Article.objects.raw(), which re-runs
+        %-formatting on the string and previously raised. Evaluating the search
+        should now complete instead of erroring.
+        """
+        from django.db import connection
+
+        if connection.vendor == "sqlite":
+            # The bug is in postgres_search()'s raw() query; sqlite falls back to
+            # mysql_search() and never hits the affected code path.
+            return
+
+        models.Article.objects.create(
+            journal=self.journal_one,
+            title="Save 50% on warp-drive systems",
+            date_published=FROZEN_DATETIME_2020,
+            stage=models.STAGE_PUBLISHED,
+        )
+
+        # Mysql can't search at all without FULLTEXT indexes installed
+        call_command("generate_search_indexes")
+
+        search_filters = {"title": True}
+        try:
+            # Forces the RawQuerySet to execute; before the fix this raised
+            # TypeError ("not enough arguments for format string").
+            result = list(models.Article.objects.search("50%", search_filters))
+        except TypeError as exc:
+            self.fail(f"search with a '%' term raised (regression of #5348): {exc}")
+
+        self.assertIsInstance(result, list)


### PR DESCRIPTION
Hey folks,

Thanks to whoever triaged #5348 — the diagnosis in the issue is spot on and saved me the hunt.

`postgres_search()` builds its final ordered query by wrapping `stringify_queryset()` in `Article.objects.raw()`. The catch is that `stringify_queryset()` runs the params through `cursor.mogrify()`, so what comes back is fully-interpolated SQL — every value already baked in as a string literal. When a search term contains a `%` (someone searching for "50%"), that `%` is now sitting in the SQL as a literal. Then `Article.objects.raw()` hands the string to the cursor with `params=()` — Django's default is an empty tuple, not `None` — so psycopg runs `%`-formatting over it again, hits the stray `%`, and raises `TypeError: not enough arguments for format string`. Any search for a term with a `%` in it 500s.

The fix doubles the literal `%` to `%%` in the mogrified SQL before it goes into `raw()`, so they survive that second formatting pass unchanged. Because `stringify_queryset()` has already interpolated everything, there are no real placeholders left to protect — every `%` in that string is literal, so doubling them all is safe.

I added a regression test that searches for a `%`-bearing term and asserts the query executes rather than raising (it guards the Postgres path, since the `raw()` query only runs there). I confirmed the mechanism directly too — a mogrified string with a literal `%` raises under `%`-formatting with empty params, and doubling it clears the error.

One thing I wasn't sure about: I branched this off `master`, but I noticed recent bug fixes going to `r-v1.9.x` — happy to retarget or add a backport if that's the flow you'd prefer.

closes #5348

(full disclosure: AI helped me identify the issue and verify my work)
