### PR TITLE
feat: #3755 make the submitted file version 1 automatically

### DIFF
--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -1043,6 +1043,12 @@ class Preprint(models.Model):
         self.current_step = 5
         self.save()
 
+        # The most recently uploaded submission file automatically becomes
+        # version 1, so managers do not have to select it manually before
+        # starting their review.
+        if self.submission_file and not self.has_version():
+            self.make_new_version(self.submission_file)
+
     def subject_editors(self):
         editors = []
         for subject in self.subject.all():

--- a/src/repository/tests/test_models.py
+++ b/src/repository/tests/test_models.py
@@ -135,6 +135,23 @@ class TestModels(TestCase):
                 article_two,
             )
 
+    def test_submit_preprint_creates_first_version(self):
+        self.preprint_one.submit_preprint()
+        self.assertEqual(self.preprint_one.preprintversion_set.count(), 1)
+        version = self.preprint_one.current_version
+        self.assertEqual(version.version, 1)
+        self.assertEqual(version.file, self.preprint_one.submission_file)
+
+    def test_submit_preprint_does_not_duplicate_existing_version(self):
+        self.preprint_one.make_new_version(self.preprint_one.submission_file)
+        self.preprint_one.submit_preprint()
+        self.assertEqual(self.preprint_one.preprintversion_set.count(), 1)
+
+    def test_submit_preprint_without_file_creates_no_version(self):
+        self.preprint_one.submission_file = None
+        self.preprint_one.submit_preprint()
+        self.assertEqual(self.preprint_one.preprintversion_set.count(), 0)
+
 
 class TestRepositoryOrganisationUnit(TestCase):
     """Tests for the RepositoryOrganisationUnit model introduced in iowa-and-isolinear."""


### PR DESCRIPTION
Closes #3755

## What this does

When an author completes preprint submission (`Preprint.submit_preprint()`), the submission file now automatically becomes **PreprintVersion 1**. Repository managers no longer have to select the one pending file as a "version" in the manager view before they can start reviewing.

## Design notes

- The version is created from `preprint.submission_file`, which the submission file-upload view overwrites on every upload — so it always points at the author's **most recent** file. That covers the accidental multiple-upload case discussed in the issue (ref BirkbeckCTP/janeway#2810): the latest file is the one flagged as version 1.
- Guarded by `has_version()`: if a version already exists nothing is created, so the change is idempotent and cannot duplicate versions.
- If there is no submission file (edge case — the files step normally blocks completion without one), behavior is unchanged: no version is created.
- The manager's existing "make version" control is untouched and still works for subsequent versions.

## Tests

Three new tests in `repository/tests/test_models.py`:
- submitting creates version 1 pointing at the submission file
- submitting when a version already exists does not create a duplicate
- submitting without a submission file creates no version

`DB_VENDOR=sqlite python src/manage.py test repository` — 47/47 pass locally. `ruff format --check` clean on both changed files.