### PR TITLE
Fixes a bug with Full Text search some results were not being matched when combining full-text with search with other fields

### DIFF
--- a/src/core/model_utils.py
+++ b/src/core/model_utils.py
@@ -615,7 +615,7 @@ class SearchVector(DjangoSearchVector):
 
     # Override template to ignore function
     function = None
-    template = "%(expressions)s"
+    template = "COALESCE(%(expressions)s, '')"
 
 
 def search_model_admin(request, model, q=None, queryset=None):

--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -773,9 +773,9 @@ class PreprintSearchManager(model_utils.BaseSearchManagerMixin):
             for v in vectors[1:]:
                 vector += v
             query = SearchQuery(search_term)
-            relevance = SearchRank(vector, query)
-            annotations["relevance"] = relevance
-            lookups["relevance__gte"] = 0.01
+            annotations["search_vector"] = vector
+            annotations["relevance"] = SearchRank(vector, query)
+            lookups["search_vector"] = query
 
         if search_filters.get("ORCID"):
             lookups["preprintauthor__account__orcid"] = search_term

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -965,11 +965,9 @@ class ArticleSearchManager(BaseSearchManagerMixin):
             for v in vectors[1:]:
                 vector += v
             query = SearchQuery(search_term)
-            relevance = SearchRank(vector, query)
-            annotations["relevance"] = relevance
-            # Since we weight file contents as 'D', the returned relevance
-            # values can range between .01 and .1
-            lookups["relevance__gte"] = 0.01
+            annotations["search_vector"] = vector
+            annotations["relevance"] = SearchRank(vector, query)
+            lookups["search_vector"] = query
 
         if search_filters.get("ORCID"):
             lookups["frozenauthor__author__orcid"] = search_term

--- a/src/submission/tests/test_article_search.py
+++ b/src/submission/tests/test_article_search.py
@@ -126,6 +126,86 @@ class ArticleSearchTests(TransactionTestCase):
         self.assertEqual(result, [article])
 
     @override_settings(ENABLE_FULL_TEXT_SEARCH=True)
+    def test_full_text_search_preserves_matches_without_file_text(self):
+        """Articles with no indexed file text must still match other filters"""
+
+        from django.db import connection
+
+        if connection.vendor == "sqlite":
+            # No native support for full text search in sqlite
+            return
+        needle = "diagnostic"
+
+        article_matching_title = models.Article.objects.create(
+            journal=self.journal_one,
+            title="A diagnostic run on warp-drive systems",
+            date_published=FROZEN_DATETIME_2020,
+            stage=models.STAGE_PUBLISHED,
+        )
+        article_matching_text = models.Article.objects.create(
+            journal=self.journal_one,
+            title="Testing the search of articles",
+            date_published=FROZEN_DATETIME_2020,
+            stage=models.STAGE_PUBLISHED,
+        )
+        file_obj = File.objects.create(article_id=article_matching_text.pk)
+        create_galley(article_matching_text, file_obj)
+        FileText = swapper.load_model("core", "FileText")
+        text = FileText.objects.create(
+            contents=FileText.preprocess_contents(
+                "Computer, run a level-two diagnostic.",
+            ),
+        )
+        file_obj.text = text
+        file_obj.save()
+
+        call_command("generate_search_indexes")
+
+        search_filters = {"title": True, "full_text": True}
+        queryset = models.Article.objects.search(needle, search_filters)
+        result = [a for a in queryset]
+
+        self.assertCountEqual(
+            result,
+            [article_matching_title, article_matching_text],
+        )
+
+    @override_settings(ENABLE_FULL_TEXT_SEARCH=True)
+    def test_full_text_search_multiword_distant_terms(self):
+        """Test that terms separate from each other still match"""
+        from django.db import connection
+
+        if connection.vendor == "sqlite":
+            # No native support for full text search in sqlite
+            return
+        filler = " ".join("filler%d" % i for i in range(200))
+        text_to_search = "jeffreis %s tube" % filler
+        needle = "jeffreis tube"
+
+        article = models.Article.objects.create(
+            journal=self.journal_one,
+            title="Testing the search of articles",
+            date_published=FROZEN_DATETIME_2020,
+            stage=models.STAGE_PUBLISHED,
+        )
+        file_obj = File.objects.create(article_id=article.pk)
+        create_galley(article, file_obj)
+        FileText = swapper.load_model("core", "FileText")
+        text = FileText.objects.create(
+            contents=FileText.preprocess_contents(text_to_search),
+        )
+        file_obj.text = text
+        file_obj.save()
+
+        call_command("generate_search_indexes")
+
+        search_filters = {"full_text": True}
+        queryset = models.Article.objects.search(needle, search_filters)
+        result = [a for a in queryset]
+
+        self.assertEqual(result, [article])
+
+    @override_settings(ENABLE_FULL_TEXT_SEARCH=True)
     def test_article_search_abstract(self):
         text_to_search = """
             Exceeding reaction chamber thermal limit.


### PR DESCRIPTION
 - All columns are now being coallesced on the resulting query to avoid OR logic on NULL values
 - We use `ts_rank` rather than a relevance cutoff to avoid results being accidentally dropped