### PR TITLE
fix: #5486 give MultiWidget fields a working label association

### DIFF
--- a/src/templates/admin/elements/forms/field.html
+++ b/src/templates/admin/elements/forms/field.html
@@ -2,7 +2,10 @@
 {% get_language_info_list for LANGUAGES as languages %}
 
 <div>
-  <label for="{{ field.id_for_label }}">
+  {# A MultiWidget has no single control, so id_for_label is the empty #}
+  {# string. Fall back to its first subwidget, which Django ids as #}
+  {# <auto_id>_0, or the label is associated with nothing. See #5486. #}
+  <label for="{% if field.id_for_label %}{{ field.id_for_label }}{% else %}{{ field.auto_id }}_0{% endif %}">
     <strong>
       {{ field.label }}
       {% if field.field.required %}


### PR DESCRIPTION
closes #5486

### The bug

`templates/admin/elements/forms/field.html` renders `<label for="{{ field.id_for_label }}">`. Django returns the **empty string** from `BoundField.id_for_label` whenever the widget is a `MultiWidget`, because there is no single control to point at — so the partial emits `<label for="">`, associated with nothing, and the field has **no accessible name**.

Not cosmetic on the registration form: with the default `CAPTCHA_TYPE = "simple_math"`, `django-simple-math-captcha`'s `MathCaptchaField` is a MultiWidget, so the *required* captcha input is announced as nothing. A screen-reader user cannot complete registration.

The partial is included from ~20 templates, so any other MultiWidget field (`SplitDateTimeWidget`, etc.) is affected wherever it renders.

### The change

One line: fall back to the first subwidget, which Django ids as `<auto_id>_0`.

```django
<label for="{% if field.id_for_label %}{{ field.id_for_label }}{% else %}{{ field.auto_id }}_0{% endif %}">
```

### Why it is safe for the other ~20 include sites

Any field that already has an `id_for_label` takes the existing branch, so its output is byte-identical. Verified by rendering the patched line against both a plain field and a MultiWidget:

```
email    -> for="id_email"      (unchanged)
captcha  -> for="id_captcha_0"  (was for="")
```

The reproduction in #5486 is standalone — plain Django, no Janeway needed — if you want to confirm before and after yourself.

### Deliberately not included

For the captcha specifically the *question* (`<span class="captcha-question">`) sits outside the label, so even with a correct `for` the accessible name is just "Answer this question:" — the user is told to answer a question they are never read. Fixing that by wrapping `{{ field }}` in the label would be wrong here, because a MultiWidget that renders several real inputs (e.g. `SplitDateTimeWidget`) would end up with two controls under one label. It likely belongs in the captcha field's own rendering rather than this shared partial. Happy to follow up separately if you'd like it addressed.
