### PR TITLE
Fix an inaccurate help message when adding an author

### DIFF
--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -2944,6 +2944,7 @@ class FrozenAuthor(AbstractLastModifiedModel):
                     orcid__contains=orcid,
                 )
                 author = account.snapshot_as_author(article)
+                created = True
             except core_models.Account.DoesNotExist:
                 author = None
 


### PR DESCRIPTION
Fixes #5498 