### PR TITLE
Updated dev docker base image file to python 3.12

### DIFF
--- a/dockerfiles/Dockerfile.base
+++ b/dockerfiles/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.12
 ADD ./dockerfiles/janeway.sqlite3 /db/janeway.sqlite3
 RUN curl https://raw.githubusercontent.com/BirkbeckCTP/janeway/master/requirements.txt > /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt


### PR DESCRIPTION
I've tested `make rebuild` unit tests.
Django added support for py3.12 on 4.2.8 so it is compatible with the version we've pinned